### PR TITLE
feat(atelier-guild-rank): TASK-0027 リザルト画面実装完了

### DIFF
--- a/atelier-guild-rank/src/presentation/scenes/GameClearScene.spec.ts
+++ b/atelier-guild-rank/src/presentation/scenes/GameClearScene.spec.ts
@@ -1,0 +1,197 @@
+/**
+ * GameClearScene.spec.ts - GameClearSceneのテスト
+ * TASK-0027: リザルト画面（GameOver/GameClear）
+ *
+ * テストケース:
+ * T-0027-02: ゲームクリア遷移 - 画面表示
+ * T-0027-03: 統計表示 - 正しい値
+ * T-0027-04: タイトルへボタン - TitleSceneへ遷移
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GameEndStats } from '../../shared/types';
+import { GameClearScene } from './GameClearScene';
+
+describe('GameClearScene', () => {
+  let scene: GameClearScene;
+  let mockRexUI: any;
+
+  beforeEach(() => {
+    scene = new GameClearScene();
+
+    // rexUIプラグインのモック
+    mockRexUI = {
+      add: {
+        roundRectangle: vi.fn(() => ({
+          setFillStyle: vi.fn().mockReturnThis(),
+        })),
+        label: vi.fn(() => ({
+          setInteractive: vi.fn().mockReturnThis(),
+          on: vi.fn().mockReturnThis(),
+          layout: vi.fn().mockReturnThis(),
+          destroy: vi.fn(),
+        })),
+      },
+    };
+
+    (scene as any).rexUI = mockRexUI;
+
+    // Phaserシーンのモック
+    (scene as any).cameras = {
+      main: {
+        centerX: 640,
+        centerY: 360,
+      },
+    };
+
+    (scene as any).scale = {
+      width: 1280,
+      height: 720,
+    };
+
+    (scene as any).add = {
+      rectangle: vi.fn().mockReturnThis(),
+      text: vi.fn(() => ({
+        setOrigin: vi.fn().mockReturnThis(),
+      })),
+    };
+
+    (scene as any).scene = {
+      start: vi.fn(),
+    };
+  });
+
+  describe('T-0027-02: ゲームクリア遷移 - 画面表示', () => {
+    it('GameClearSceneが正しく初期化される', () => {
+      const stats: GameEndStats = {
+        finalRank: 'S',
+        totalDays: 25,
+        totalDeliveries: 58,
+        totalGold: 4120,
+      };
+
+      scene.init({ stats });
+      expect((scene as any).stats).toEqual(stats);
+    });
+
+    it('GameClearSceneのcreate()が正しく実行される', () => {
+      const stats: GameEndStats = {
+        finalRank: 'S',
+        totalDays: 25,
+        totalDeliveries: 58,
+        totalGold: 4120,
+      };
+
+      scene.init({ stats });
+      scene.create();
+
+      // 背景が作成される
+      expect((scene as any).add.rectangle).toHaveBeenCalled();
+      // テキストが作成される（タイトル、メッセージ、統計情報3行、ボタンテキスト2つ）
+      expect((scene as any).add.text).toHaveBeenCalled();
+      // ボタンが作成される（タイトルへ、NEW GAME+）
+      expect(mockRexUI.add.label).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('T-0027-03: 統計表示 - 正しい値', () => {
+    it('統計情報が正しく表示される', () => {
+      const stats: GameEndStats = {
+        finalRank: 'S',
+        totalDays: 25,
+        totalDeliveries: 58,
+        totalGold: 4120,
+      };
+
+      scene.init({ stats });
+      scene.create();
+
+      const textCalls = (scene as any).add.text.mock.calls;
+
+      // 統計情報のテキストを確認
+      const statsTexts = textCalls.slice(2); // タイトルとメッセージをスキップ
+
+      expect(statsTexts.some((call: any) => call[2].includes('クリア日数: 25日'))).toBe(true);
+      expect(statsTexts.some((call: any) => call[2].includes('総納品数: 58'))).toBe(true);
+      expect(statsTexts.some((call: any) => call[2].includes('獲得ゴールド: 4,120G'))).toBe(true);
+    });
+  });
+
+  describe('T-0027-04: タイトルへボタン - TitleSceneへ遷移', () => {
+    it('タイトルへボタンをクリックするとTitleSceneへ遷移する', () => {
+      const stats: GameEndStats = {
+        finalRank: 'S',
+        totalDays: 25,
+        totalDeliveries: 58,
+        totalGold: 4120,
+      };
+
+      scene.init({ stats });
+      scene.create();
+
+      // ボタンのonイベントを確認
+      const buttonElement = mockRexUI.add.label.mock.results[0].value;
+      const onHandler = buttonElement.on.mock.calls.find((call: any) => call[0] === 'pointerdown');
+
+      expect(onHandler).toBeDefined();
+
+      // ボタンをクリック
+      onHandler[1]();
+
+      // TitleSceneへ遷移することを確認
+      expect((scene as any).scene.start).toHaveBeenCalledWith('TitleScene');
+    });
+
+    it('NEW GAME+ボタンをクリックするとMainSceneへ遷移する', () => {
+      const stats: GameEndStats = {
+        finalRank: 'S',
+        totalDays: 25,
+        totalDeliveries: 58,
+        totalGold: 4120,
+      };
+
+      scene.init({ stats });
+      scene.create();
+
+      // NEW GAME+ボタンのクリックハンドラーを取得
+      const buttonElement = mockRexUI.add.label.mock.results[1].value;
+      const onHandler = buttonElement.on.mock.calls.find((call: any) => call[0] === 'pointerdown');
+
+      expect(onHandler).toBeDefined();
+
+      // ボタンをクリック
+      onHandler[1]();
+
+      // MainSceneへ遷移することを確認（将来実装でNEW GAME+の処理を追加予定）
+      expect((scene as any).scene.start).toHaveBeenCalledWith('MainScene');
+    });
+  });
+
+  describe('シーンのライフサイクル', () => {
+    it('shutdown()でリソースが解放される', () => {
+      const stats: GameEndStats = {
+        finalRank: 'S',
+        totalDays: 25,
+        totalDeliveries: 58,
+        totalGold: 4120,
+      };
+
+      scene.init({ stats });
+      scene.create();
+
+      // ボタンを取得
+      const buttons = [
+        mockRexUI.add.label.mock.results[0].value,
+        mockRexUI.add.label.mock.results[1].value,
+      ];
+
+      // shutdown実行
+      scene.shutdown();
+
+      // 各ボタンのdestroyが呼ばれることを確認
+      for (const button of buttons) {
+        expect(button.destroy).toHaveBeenCalled();
+      }
+    });
+  });
+});

--- a/atelier-guild-rank/src/presentation/scenes/GameClearScene.ts
+++ b/atelier-guild-rank/src/presentation/scenes/GameClearScene.ts
@@ -1,0 +1,362 @@
+/**
+ * GameClearScene.ts - ゲームクリアシーン
+ * TASK-0027: リザルト画面（GameOver/GameClear）
+ *
+ * 【機能概要】
+ * ゲームクリア時のリザルト画面を表示するシーン。
+ * プレイ統計（クリア日数、総納品数、獲得ゴールド）を表示し、
+ * タイトルへ戻る・NEW GAME+のボタンを提供する。
+ *
+ * 【実装方針】
+ * 設計文書（TASK-0027.md）に基づいてゲームクリア画面を実装。
+ * GameOverSceneのスタイルを参考にしながら、お祝いの雰囲気を演出。
+ *
+ * @信頼性レベル 🔵 設計文書準拠
+ * @see docs/tasks/atelier-guild-rank/phase-3/TASK-0027.md
+ */
+
+import Phaser from 'phaser';
+import type { GameEndStats } from '../../shared/types';
+import { THEME } from '../ui/theme';
+
+// =============================================================================
+// 定数定義
+// =============================================================================
+
+/**
+ * ゲームクリアシーンのレイアウト定数
+ * @信頼性レベル 🟡 実装者が決定
+ */
+const LAYOUT = {
+  /** タイトルのY座標 */
+  TITLE_Y: 120,
+  /** メッセージのY座標 */
+  MESSAGE_Y: 220,
+  /** 統計情報の開始Y座標 */
+  STATS_START_Y: 320,
+  /** 統計情報の行間 */
+  STATS_LINE_SPACING: 35,
+  /** ボタンの開始Y座標 */
+  BUTTON_START_Y: 550,
+  /** ボタン間のスペーシング */
+  BUTTON_SPACING: 150,
+} as const;
+
+/**
+ * スタイル定数
+ * @信頼性レベル 🟡 実装者が決定
+ */
+const STYLES = {
+  /** タイトルのフォントサイズ */
+  TITLE_FONT_SIZE: '42px',
+  /** タイトルの色（ゴールド） */
+  TITLE_COLOR: '#DAA520',
+  /** メッセージのフォントサイズ */
+  MESSAGE_FONT_SIZE: '20px',
+  /** メッセージの色 */
+  MESSAGE_COLOR: '#666666',
+  /** 統計情報のフォントサイズ */
+  STATS_FONT_SIZE: '18px',
+  /** 統計情報の色 */
+  STATS_COLOR: '#333333',
+  /** ボタンのフォントサイズ */
+  BUTTON_FONT_SIZE: '16px',
+} as const;
+
+/**
+ * ボタンのサイズ定数
+ * @信頼性レベル 🟡 実装者が決定
+ */
+const SIZES = {
+  /** ボタンの幅 */
+  BUTTON_WIDTH: 180,
+  /** ボタンの高さ */
+  BUTTON_HEIGHT: 50,
+  /** ボタンの角丸半径 */
+  BUTTON_RADIUS: 8,
+} as const;
+
+/**
+ * テキスト定数
+ * @信頼性レベル 🔵 設計文書に基づく
+ */
+const TEXT = {
+  TITLE: '🎉 CONGRATULATIONS! 🎉',
+  MESSAGE_LINE1: 'Sランク錬金術師に',
+  MESSAGE_LINE2: '昇格しました!',
+  TO_TITLE: 'タイトルへ',
+  NEW_GAME_PLUS: 'NEW GAME+',
+} as const;
+
+// =============================================================================
+// GameClearSceneクラス
+// =============================================================================
+
+/**
+ * GameClearScene - ゲームクリア画面シーン
+ *
+ * 【責務】
+ * - ゲームクリアタイトルの表示
+ * - 成功メッセージの表示
+ * - プレイ統計情報の表示
+ * - タイトルへ戻る・NEW GAME+ボタンの提供
+ *
+ * @信頼性レベル 🔵 設計文書（TASK-0027.md）に基づく
+ */
+export class GameClearScene extends Phaser.Scene {
+  // ===========================================================================
+  // プロパティ
+  // ===========================================================================
+
+  /**
+   * rexUIプラグイン参照（テストでモックされる）
+   * @remarks rexUIプラグインの型は複雑なため、anyを使用
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: rexUIプラグインの型は複雑なため
+  protected rexUI: any;
+
+  /**
+   * ゲーム終了時の統計情報
+   */
+  private stats!: GameEndStats;
+
+  /**
+   * ボタン参照（破棄時に使用）
+   * @remarks rexUI Labelコンポーネントの型は複雑なため、anyを使用
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: rexUI Labelコンポーネントの型は複雑なため
+  private buttons: any[] = [];
+
+  // ===========================================================================
+  // コンストラクタ
+  // ===========================================================================
+
+  /**
+   * GameClearSceneのコンストラクタ
+   */
+  constructor() {
+    super({ key: 'GameClearScene' });
+  }
+
+  // ===========================================================================
+  // ライフサイクルメソッド
+  // ===========================================================================
+
+  /**
+   * init() - シーン初期化
+   *
+   * 【機能概要】
+   * 前のシーンから受け取った統計情報を保存する。
+   *
+   * @param data シーン初期化データ
+   */
+  init(data: { stats: GameEndStats }): void {
+    this.stats = data.stats;
+  }
+
+  /**
+   * create() - ゲームクリア画面の生成
+   *
+   * 【機能概要】
+   * ゲームクリア画面を構築し、統計情報とボタンを表示する。
+   *
+   * @信頼性レベル 🔵 設計文書に準拠
+   */
+  create(): void {
+    const centerX = this.cameras.main.centerX;
+
+    // 背景
+    this.createBackground();
+
+    // タイトル表示
+    this.createTitle(centerX);
+
+    // メッセージ表示
+    this.createMessage(centerX);
+
+    // 統計情報表示
+    this.createStats(centerX);
+
+    // ボタン表示
+    this.createButtons(centerX);
+
+    // クリア演出（将来実装）
+    // this.playClearAnimation();
+
+    // クリア音楽再生（将来実装）
+    // this.playClearMusic();
+  }
+
+  /**
+   * シャットダウン処理
+   * シーン破棄時にリソースを解放する。
+   */
+  shutdown(): void {
+    for (const button of this.buttons) {
+      if (button) {
+        button.destroy();
+      }
+    }
+    this.buttons = [];
+  }
+
+  // ===========================================================================
+  // UI生成メソッド（プライベート）
+  // ===========================================================================
+
+  /**
+   * 背景を生成する
+   */
+  private createBackground(): void {
+    const sceneWidth = this.scale?.width || 1280;
+    const sceneHeight = this.scale?.height || 720;
+
+    this.add.rectangle(
+      sceneWidth / 2,
+      sceneHeight / 2,
+      sceneWidth,
+      sceneHeight,
+      THEME.colors.background,
+    );
+  }
+
+  /**
+   * タイトルを生成する
+   * @param centerX 画面中央X座標
+   */
+  private createTitle(centerX: number): void {
+    this.add
+      .text(centerX, LAYOUT.TITLE_Y, TEXT.TITLE, {
+        fontSize: STYLES.TITLE_FONT_SIZE,
+        color: STYLES.TITLE_COLOR,
+      })
+      .setOrigin(0.5);
+  }
+
+  /**
+   * メッセージを生成する
+   * @param centerX 画面中央X座標
+   */
+  private createMessage(centerX: number): void {
+    const message = `${TEXT.MESSAGE_LINE1}\n${TEXT.MESSAGE_LINE2}`;
+    this.add
+      .text(centerX, LAYOUT.MESSAGE_Y, message, {
+        fontSize: STYLES.MESSAGE_FONT_SIZE,
+        color: STYLES.MESSAGE_COLOR,
+        align: 'center',
+      })
+      .setOrigin(0.5);
+  }
+
+  /**
+   * 統計情報を生成する
+   * @param centerX 画面中央X座標
+   */
+  private createStats(centerX: number): void {
+    const statsLines = [
+      `クリア日数: ${this.stats.totalDays}日`,
+      `総納品数: ${this.stats.totalDeliveries}`,
+      `獲得ゴールド: ${this.stats.totalGold.toLocaleString()}G`,
+    ];
+
+    statsLines.forEach((line, index) => {
+      this.add
+        .text(centerX, LAYOUT.STATS_START_Y + index * LAYOUT.STATS_LINE_SPACING, line, {
+          fontSize: STYLES.STATS_FONT_SIZE,
+          color: STYLES.STATS_COLOR,
+        })
+        .setOrigin(0.5);
+    });
+  }
+
+  /**
+   * ボタンを生成する
+   * @param centerX 画面中央X座標
+   */
+  private createButtons(centerX: number): void {
+    // タイトルへボタン
+    const toTitleButton = this.createButton(
+      centerX - LAYOUT.BUTTON_SPACING / 2,
+      LAYOUT.BUTTON_START_Y,
+      TEXT.TO_TITLE,
+      THEME.colors.secondary,
+      () => this.onToTitleClick(),
+    );
+    this.buttons.push(toTitleButton);
+
+    // NEW GAME+ボタン（将来実装のためスタブ）
+    const newGamePlusButton = this.createButton(
+      centerX + LAYOUT.BUTTON_SPACING / 2,
+      LAYOUT.BUTTON_START_Y,
+      TEXT.NEW_GAME_PLUS,
+      THEME.colors.primary,
+      () => this.onNewGamePlusClick(),
+    );
+    this.buttons.push(newGamePlusButton);
+  }
+
+  /**
+   * ボタンを生成する共通メソッド
+   * @param x X座標
+   * @param y Y座標
+   * @param text ボタンテキスト
+   * @param backgroundColor 背景色
+   * @param onClick クリック時のコールバック
+   * @returns 生成されたボタン（rexUI Labelコンポーネント）
+   */
+  private createButton(
+    x: number,
+    y: number,
+    text: string,
+    backgroundColor: number,
+    onClick: () => void,
+    // biome-ignore lint/suspicious/noExplicitAny: rexUI Labelコンポーネントの型は複雑なため
+  ): any {
+    const buttonText = this.add.text(0, 0, text, {
+      fontSize: STYLES.BUTTON_FONT_SIZE,
+      color: THEME.colors.textOnPrimary,
+    });
+
+    const buttonBackground = this.rexUI.add
+      .roundRectangle({
+        width: SIZES.BUTTON_WIDTH,
+        height: SIZES.BUTTON_HEIGHT,
+        radius: SIZES.BUTTON_RADIUS,
+      })
+      .setFillStyle(backgroundColor);
+
+    const button = this.rexUI.add.label({
+      background: buttonBackground,
+      text: buttonText,
+      align: 'center',
+      x,
+      y,
+    });
+
+    button.setInteractive();
+    button.on('pointerdown', onClick);
+    button.layout();
+
+    return button;
+  }
+
+  // ===========================================================================
+  // イベントハンドラ（プライベート）
+  // ===========================================================================
+
+  /**
+   * タイトルへボタンクリック処理
+   */
+  private onToTitleClick(): void {
+    this.scene.start('TitleScene');
+  }
+
+  /**
+   * NEW GAME+ボタンクリック処理
+   * 🔴 拡張機能: Phase 1では新規ゲームとして実装
+   */
+  private onNewGamePlusClick(): void {
+    // 将来実装: NEW GAME+の引き継ぎ処理
+    this.scene.start('MainScene');
+  }
+}

--- a/atelier-guild-rank/src/presentation/scenes/GameOverScene.spec.ts
+++ b/atelier-guild-rank/src/presentation/scenes/GameOverScene.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * GameOverScene.spec.ts - GameOverSceneのテスト
+ * TASK-0027: リザルト画面（GameOver/GameClear）
+ *
+ * テストケース:
+ * T-0027-01: ゲームオーバー遷移 - 画面表示
+ * T-0027-03: 統計表示 - 正しい値
+ * T-0027-04: タイトルへボタン - TitleSceneへ遷移
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GameEndStats } from '../../shared/types';
+import { GameOverScene } from './GameOverScene';
+
+describe('GameOverScene', () => {
+  let scene: GameOverScene;
+  let mockRexUI: any;
+
+  beforeEach(() => {
+    scene = new GameOverScene();
+
+    // rexUIプラグインのモック
+    mockRexUI = {
+      add: {
+        roundRectangle: vi.fn(() => ({
+          setFillStyle: vi.fn().mockReturnThis(),
+        })),
+        label: vi.fn(() => ({
+          setInteractive: vi.fn().mockReturnThis(),
+          on: vi.fn().mockReturnThis(),
+          layout: vi.fn().mockReturnThis(),
+          destroy: vi.fn(),
+        })),
+      },
+    };
+
+    (scene as any).rexUI = mockRexUI;
+
+    // Phaserシーンのモック
+    (scene as any).cameras = {
+      main: {
+        centerX: 640,
+        centerY: 360,
+      },
+    };
+
+    (scene as any).scale = {
+      width: 1280,
+      height: 720,
+    };
+
+    (scene as any).add = {
+      rectangle: vi.fn().mockReturnThis(),
+      text: vi.fn(() => ({
+        setOrigin: vi.fn().mockReturnThis(),
+      })),
+    };
+
+    (scene as any).scene = {
+      start: vi.fn(),
+    };
+  });
+
+  describe('T-0027-01: ゲームオーバー遷移 - 画面表示', () => {
+    it('GameOverSceneが正しく初期化される', () => {
+      const stats: GameEndStats = {
+        finalRank: 'C',
+        totalDays: 30,
+        totalDeliveries: 45,
+        totalGold: 2350,
+      };
+
+      scene.init({ stats });
+      expect((scene as any).stats).toEqual(stats);
+    });
+
+    it('GameOverSceneのcreate()が正しく実行される', () => {
+      const stats: GameEndStats = {
+        finalRank: 'C',
+        totalDays: 30,
+        totalDeliveries: 45,
+        totalGold: 2350,
+      };
+
+      scene.init({ stats });
+      scene.create();
+
+      // 背景が作成される
+      expect((scene as any).add.rectangle).toHaveBeenCalled();
+      // テキストが作成される（タイトル、メッセージ、統計情報4行、ボタンテキスト2つ）
+      expect((scene as any).add.text).toHaveBeenCalled();
+      // ボタンが作成される（タイトルへ、リトライ）
+      expect(mockRexUI.add.label).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('T-0027-03: 統計表示 - 正しい値', () => {
+    it('統計情報が正しく表示される', () => {
+      const stats: GameEndStats = {
+        finalRank: 'C',
+        totalDays: 30,
+        totalDeliveries: 45,
+        totalGold: 2350,
+      };
+
+      scene.init({ stats });
+      scene.create();
+
+      const textCalls = (scene as any).add.text.mock.calls;
+
+      // 統計情報のテキストを確認
+      const statsTexts = textCalls.slice(2); // タイトルとメッセージをスキップ
+
+      expect(statsTexts.some((call: any) => call[2].includes('最終ランク: C'))).toBe(true);
+      expect(statsTexts.some((call: any) => call[2].includes('経過日数: 30日'))).toBe(true);
+      expect(statsTexts.some((call: any) => call[2].includes('総納品数: 45'))).toBe(true);
+      expect(statsTexts.some((call: any) => call[2].includes('獲得ゴールド: 2,350G'))).toBe(true);
+    });
+  });
+
+  describe('T-0027-04: タイトルへボタン - TitleSceneへ遷移', () => {
+    it('タイトルへボタンをクリックするとTitleSceneへ遷移する', () => {
+      const stats: GameEndStats = {
+        finalRank: 'C',
+        totalDays: 30,
+        totalDeliveries: 45,
+        totalGold: 2350,
+      };
+
+      scene.init({ stats });
+      scene.create();
+
+      // ボタンのonイベントを確認
+      const buttonElement = mockRexUI.add.label.mock.results[0].value;
+      const onHandler = buttonElement.on.mock.calls.find((call: any) => call[0] === 'pointerdown');
+
+      expect(onHandler).toBeDefined();
+
+      // ボタンをクリック
+      onHandler[1]();
+
+      // TitleSceneへ遷移することを確認
+      expect((scene as any).scene.start).toHaveBeenCalledWith('TitleScene');
+    });
+
+    it('リトライボタンをクリックするとMainSceneへ遷移する', () => {
+      const stats: GameEndStats = {
+        finalRank: 'C',
+        totalDays: 30,
+        totalDeliveries: 45,
+        totalGold: 2350,
+      };
+
+      scene.init({ stats });
+      scene.create();
+
+      // リトライボタンのクリックハンドラーを取得
+      const buttonElement = mockRexUI.add.label.mock.results[1].value;
+      const onHandler = buttonElement.on.mock.calls.find((call: any) => call[0] === 'pointerdown');
+
+      expect(onHandler).toBeDefined();
+
+      // ボタンをクリック
+      onHandler[1]();
+
+      // MainSceneへ遷移することを確認
+      expect((scene as any).scene.start).toHaveBeenCalledWith('MainScene');
+    });
+  });
+
+  describe('シーンのライフサイクル', () => {
+    it('shutdown()でリソースが解放される', () => {
+      const stats: GameEndStats = {
+        finalRank: 'C',
+        totalDays: 30,
+        totalDeliveries: 45,
+        totalGold: 2350,
+      };
+
+      scene.init({ stats });
+      scene.create();
+
+      // ボタンを取得
+      const buttons = [
+        mockRexUI.add.label.mock.results[0].value,
+        mockRexUI.add.label.mock.results[1].value,
+      ];
+
+      // shutdown実行
+      scene.shutdown();
+
+      // 各ボタンのdestroyが呼ばれることを確認
+      for (const button of buttons) {
+        expect(button.destroy).toHaveBeenCalled();
+      }
+    });
+  });
+});

--- a/atelier-guild-rank/src/presentation/scenes/GameOverScene.ts
+++ b/atelier-guild-rank/src/presentation/scenes/GameOverScene.ts
@@ -1,0 +1,358 @@
+/**
+ * GameOverScene.ts - ゲームオーバーシーン
+ * TASK-0027: リザルト画面（GameOver/GameClear）
+ *
+ * 【機能概要】
+ * ゲームオーバー時のリザルト画面を表示するシーン。
+ * プレイ統計（最終ランク、経過日数、総納品数、獲得ゴールド）を表示し、
+ * タイトルへ戻る・リトライのボタンを提供する。
+ *
+ * 【実装方針】
+ * 設計文書（TASK-0027.md）に基づいてゲームオーバー画面を実装。
+ * TitleSceneのスタイルを参考にしながら、シンプルで読みやすい画面を作成。
+ *
+ * @信頼性レベル 🔵 設計文書準拠
+ * @see docs/tasks/atelier-guild-rank/phase-3/TASK-0027.md
+ */
+
+import Phaser from 'phaser';
+import type { GameEndStats } from '../../shared/types';
+import { THEME } from '../ui/theme';
+
+// =============================================================================
+// 定数定義
+// =============================================================================
+
+/**
+ * ゲームオーバーシーンのレイアウト定数
+ * @信頼性レベル 🟡 実装者が決定
+ */
+const LAYOUT = {
+  /** タイトルのY座標 */
+  TITLE_Y: 150,
+  /** メッセージのY座標 */
+  MESSAGE_Y: 220,
+  /** 統計情報の開始Y座標 */
+  STATS_START_Y: 320,
+  /** 統計情報の行間 */
+  STATS_LINE_SPACING: 35,
+  /** ボタンの開始Y座標 */
+  BUTTON_START_Y: 550,
+  /** ボタン間のスペーシング */
+  BUTTON_SPACING: 150,
+} as const;
+
+/**
+ * スタイル定数
+ * @信頼性レベル 🟡 実装者が決定
+ */
+const STYLES = {
+  /** タイトルのフォントサイズ */
+  TITLE_FONT_SIZE: '48px',
+  /** タイトルの色（赤） */
+  TITLE_COLOR: '#8B0000',
+  /** メッセージのフォントサイズ */
+  MESSAGE_FONT_SIZE: '20px',
+  /** メッセージの色 */
+  MESSAGE_COLOR: '#666666',
+  /** 統計情報のフォントサイズ */
+  STATS_FONT_SIZE: '18px',
+  /** 統計情報の色 */
+  STATS_COLOR: '#333333',
+  /** ボタンのフォントサイズ */
+  BUTTON_FONT_SIZE: '16px',
+} as const;
+
+/**
+ * ボタンのサイズ定数
+ * @信頼性レベル 🟡 実装者が決定
+ */
+const SIZES = {
+  /** ボタンの幅 */
+  BUTTON_WIDTH: 180,
+  /** ボタンの高さ */
+  BUTTON_HEIGHT: 50,
+  /** ボタンの角丸半径 */
+  BUTTON_RADIUS: 8,
+} as const;
+
+/**
+ * テキスト定数
+ * @信頼性レベル 🔵 設計文書に基づく
+ */
+const TEXT = {
+  TITLE: '💀 GAME OVER',
+  MESSAGE_LINE1: '期限までにSランクに',
+  MESSAGE_LINE2: '到達できませんでした',
+  TO_TITLE: 'タイトルへ',
+  RETRY: 'リトライ',
+} as const;
+
+// =============================================================================
+// GameOverSceneクラス
+// =============================================================================
+
+/**
+ * GameOverScene - ゲームオーバー画面シーン
+ *
+ * 【責務】
+ * - ゲームオーバータイトルの表示
+ * - 失敗メッセージの表示
+ * - プレイ統計情報の表示
+ * - タイトルへ戻る・リトライボタンの提供
+ *
+ * @信頼性レベル 🔵 設計文書（TASK-0027.md）に基づく
+ */
+export class GameOverScene extends Phaser.Scene {
+  // ===========================================================================
+  // プロパティ
+  // ===========================================================================
+
+  /**
+   * rexUIプラグイン参照（テストでモックされる）
+   * @remarks rexUIプラグインの型は複雑なため、anyを使用
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: rexUIプラグインの型は複雑なため
+  protected rexUI: any;
+
+  /**
+   * ゲーム終了時の統計情報
+   */
+  private stats!: GameEndStats;
+
+  /**
+   * ボタン参照（破棄時に使用）
+   * @remarks rexUI Labelコンポーネントの型は複雑なため、anyを使用
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: rexUI Labelコンポーネントの型は複雑なため
+  private buttons: any[] = [];
+
+  // ===========================================================================
+  // コンストラクタ
+  // ===========================================================================
+
+  /**
+   * GameOverSceneのコンストラクタ
+   */
+  constructor() {
+    super({ key: 'GameOverScene' });
+  }
+
+  // ===========================================================================
+  // ライフサイクルメソッド
+  // ===========================================================================
+
+  /**
+   * init() - シーン初期化
+   *
+   * 【機能概要】
+   * 前のシーンから受け取った統計情報を保存する。
+   *
+   * @param data シーン初期化データ
+   */
+  init(data: { stats: GameEndStats }): void {
+    this.stats = data.stats;
+  }
+
+  /**
+   * create() - ゲームオーバー画面の生成
+   *
+   * 【機能概要】
+   * ゲームオーバー画面を構築し、統計情報とボタンを表示する。
+   *
+   * @信頼性レベル 🔵 設計文書に準拠
+   */
+  create(): void {
+    const centerX = this.cameras.main.centerX;
+
+    // 背景
+    this.createBackground();
+
+    // タイトル表示
+    this.createTitle(centerX);
+
+    // メッセージ表示
+    this.createMessage(centerX);
+
+    // 統計情報表示
+    this.createStats(centerX);
+
+    // ボタン表示
+    this.createButtons(centerX);
+
+    // ゲームオーバー音楽再生（将来実装）
+    // this.playGameOverMusic();
+  }
+
+  /**
+   * シャットダウン処理
+   * シーン破棄時にリソースを解放する。
+   */
+  shutdown(): void {
+    for (const button of this.buttons) {
+      if (button) {
+        button.destroy();
+      }
+    }
+    this.buttons = [];
+  }
+
+  // ===========================================================================
+  // UI生成メソッド（プライベート）
+  // ===========================================================================
+
+  /**
+   * 背景を生成する
+   */
+  private createBackground(): void {
+    const sceneWidth = this.scale?.width || 1280;
+    const sceneHeight = this.scale?.height || 720;
+
+    this.add.rectangle(
+      sceneWidth / 2,
+      sceneHeight / 2,
+      sceneWidth,
+      sceneHeight,
+      THEME.colors.background,
+    );
+  }
+
+  /**
+   * タイトルを生成する
+   * @param centerX 画面中央X座標
+   */
+  private createTitle(centerX: number): void {
+    this.add
+      .text(centerX, LAYOUT.TITLE_Y, TEXT.TITLE, {
+        fontSize: STYLES.TITLE_FONT_SIZE,
+        color: STYLES.TITLE_COLOR,
+      })
+      .setOrigin(0.5);
+  }
+
+  /**
+   * メッセージを生成する
+   * @param centerX 画面中央X座標
+   */
+  private createMessage(centerX: number): void {
+    const message = `${TEXT.MESSAGE_LINE1}\n${TEXT.MESSAGE_LINE2}`;
+    this.add
+      .text(centerX, LAYOUT.MESSAGE_Y, message, {
+        fontSize: STYLES.MESSAGE_FONT_SIZE,
+        color: STYLES.MESSAGE_COLOR,
+        align: 'center',
+      })
+      .setOrigin(0.5);
+  }
+
+  /**
+   * 統計情報を生成する
+   * @param centerX 画面中央X座標
+   */
+  private createStats(centerX: number): void {
+    const statsLines = [
+      `最終ランク: ${this.stats.finalRank}`,
+      `経過日数: ${this.stats.totalDays}日`,
+      `総納品数: ${this.stats.totalDeliveries}`,
+      `獲得ゴールド: ${this.stats.totalGold.toLocaleString()}G`,
+    ];
+
+    statsLines.forEach((line, index) => {
+      this.add
+        .text(centerX, LAYOUT.STATS_START_Y + index * LAYOUT.STATS_LINE_SPACING, line, {
+          fontSize: STYLES.STATS_FONT_SIZE,
+          color: STYLES.STATS_COLOR,
+        })
+        .setOrigin(0.5);
+    });
+  }
+
+  /**
+   * ボタンを生成する
+   * @param centerX 画面中央X座標
+   */
+  private createButtons(centerX: number): void {
+    // タイトルへボタン
+    const toTitleButton = this.createButton(
+      centerX - LAYOUT.BUTTON_SPACING / 2,
+      LAYOUT.BUTTON_START_Y,
+      TEXT.TO_TITLE,
+      THEME.colors.secondary,
+      () => this.onToTitleClick(),
+    );
+    this.buttons.push(toTitleButton);
+
+    // リトライボタン
+    const retryButton = this.createButton(
+      centerX + LAYOUT.BUTTON_SPACING / 2,
+      LAYOUT.BUTTON_START_Y,
+      TEXT.RETRY,
+      THEME.colors.primary,
+      () => this.onRetryClick(),
+    );
+    this.buttons.push(retryButton);
+  }
+
+  /**
+   * ボタンを生成する共通メソッド
+   * @param x X座標
+   * @param y Y座標
+   * @param text ボタンテキスト
+   * @param backgroundColor 背景色
+   * @param onClick クリック時のコールバック
+   * @returns 生成されたボタン（rexUI Labelコンポーネント）
+   */
+  private createButton(
+    x: number,
+    y: number,
+    text: string,
+    backgroundColor: number,
+    onClick: () => void,
+    // biome-ignore lint/suspicious/noExplicitAny: rexUI Labelコンポーネントの型は複雑なため
+  ): any {
+    const buttonText = this.add.text(0, 0, text, {
+      fontSize: STYLES.BUTTON_FONT_SIZE,
+      color: THEME.colors.textOnPrimary,
+    });
+
+    const buttonBackground = this.rexUI.add
+      .roundRectangle({
+        width: SIZES.BUTTON_WIDTH,
+        height: SIZES.BUTTON_HEIGHT,
+        radius: SIZES.BUTTON_RADIUS,
+      })
+      .setFillStyle(backgroundColor);
+
+    const button = this.rexUI.add.label({
+      background: buttonBackground,
+      text: buttonText,
+      align: 'center',
+      x,
+      y,
+    });
+
+    button.setInteractive();
+    button.on('pointerdown', onClick);
+    button.layout();
+
+    return button;
+  }
+
+  // ===========================================================================
+  // イベントハンドラ（プライベート）
+  // ===========================================================================
+
+  /**
+   * タイトルへボタンクリック処理
+   */
+  private onToTitleClick(): void {
+    this.scene.start('TitleScene');
+  }
+
+  /**
+   * リトライボタンクリック処理
+   */
+  private onRetryClick(): void {
+    this.scene.start('MainScene');
+  }
+}

--- a/atelier-guild-rank/src/presentation/scenes/index.ts
+++ b/atelier-guild-rank/src/presentation/scenes/index.ts
@@ -4,5 +4,7 @@
  */
 
 export { BootScene } from './BootScene';
+export { GameClearScene } from './GameClearScene';
+export { GameOverScene } from './GameOverScene';
 export { MainScene } from './MainScene';
 export { TitleScene } from './TitleScene';

--- a/atelier-guild-rank/src/shared/types/events.ts
+++ b/atelier-guild-rank/src/shared/types/events.ts
@@ -174,3 +174,22 @@ export interface IGameClearedEvent extends IGameEvent {
   /** 最終スコア */
   finalScore: number;
 }
+
+// =============================================================================
+// ゲーム終了統計情報
+// =============================================================================
+
+/**
+ * ゲーム終了時の統計情報
+ * GameOverScene/GameClearSceneで使用される
+ */
+export interface GameEndStats {
+  /** 最終ギルドランク */
+  finalRank: GuildRank;
+  /** 経過日数 */
+  totalDays: number;
+  /** 総納品数 */
+  totalDeliveries: number;
+  /** 獲得ゴールド */
+  totalGold: number;
+}

--- a/atelier-guild-rank/src/shared/types/index.ts
+++ b/atelier-guild-rank/src/shared/types/index.ts
@@ -45,6 +45,7 @@ export type { ErrorCode } from './errors';
 // =============================================================================
 export { ApplicationError, DomainError, ErrorCodes } from './errors';
 export type {
+  GameEndStats,
   GameOverReason,
   IAlchemyCompletedEvent,
   IGameClearedEvent,

--- a/atelier-guild-rank/tests/setup.ts
+++ b/atelier-guild-rank/tests/setup.ts
@@ -1,10 +1,20 @@
 import { vi } from 'vitest';
 
 // グローバルモックの設定
-vi.mock('phaser', () => ({
+const PhaserMock = {
   Game: vi.fn(),
-  Scene: vi.fn(),
+  Scene: class Scene {
+    cameras = { main: { centerX: 640, centerY: 360 } };
+    scale = { width: 1280, height: 720 };
+    add = {};
+    scene = {};
+  },
   AUTO: 'AUTO',
+};
+
+vi.mock('phaser', () => ({
+  default: PhaserMock,
+  ...PhaserMock,
 }));
 
 // LocalStorageモック


### PR DESCRIPTION
GameOverScene/GameClearSceneを実装し、ゲーム終了時の統計情報表示機能を追加。

実装内容:
- GameEndStats型定義を追加（最終ランク、経過日数、総納品数、獲得ゴールド）
- GameOverSceneの実装（ゲームオーバー画面、統計表示、リトライ機能）
- GameClearSceneの実装（ゲームクリア画面、統計表示、NEW GAME+スタブ）
- 各シーンの包括的なテストケース作成
- Phaserモックの改善（setup.tsでdefault export対応）

テスト結果:
- 全テスト成功 (1150 passed)
- ビルド成功

関連タスク: TASK-0027