### PR TITLE
feat: TASK-0040 サイドバー折りたたみアニメーション実装

### DIFF
--- a/atelier-guild-rank/tests/unit/presentation/ui/main/SidebarUI.test.ts
+++ b/atelier-guild-rank/tests/unit/presentation/ui/main/SidebarUI.test.ts
@@ -1,0 +1,126 @@
+/**
+ * SidebarUI - ユニットテスト
+ * TASK-0040 サイドバー折りたたみアニメーション
+ */
+
+import { SidebarUI } from '@presentation/ui/main/SidebarUI';
+import type Phaser from 'phaser';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('SidebarUI', () => {
+  let scene: Phaser.Scene;
+  let sidebar: SidebarUI;
+
+  beforeEach(() => {
+    // Phaserシーンのモックを作成
+    scene = {
+      add: {
+        container: vi.fn().mockReturnValue({
+          setDepth: vi.fn().mockReturnThis(),
+          add: vi.fn(),
+          destroy: vi.fn(),
+          setSize: vi.fn().mockReturnThis(),
+          setInteractive: vi.fn().mockReturnThis(),
+          on: vi.fn(),
+          setVisible: vi.fn().mockReturnThis(),
+          setAlpha: vi.fn().mockReturnThis(),
+        }),
+        text: vi.fn().mockReturnValue({
+          setText: vi.fn().mockReturnThis(),
+          setAngle: vi.fn().mockReturnThis(),
+          destroy: vi.fn(),
+        }),
+      },
+      tweens: {
+        add: vi.fn().mockImplementation((config) => {
+          // アニメーション完了をすぐに実行
+          if (config.onComplete) {
+            config.onComplete();
+          }
+          return {};
+        }),
+      },
+    } as unknown as Phaser.Scene;
+
+    // localStorageのモック
+    const localStorageMock = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    };
+    global.localStorage = localStorageMock as unknown as Storage;
+
+    sidebar = new SidebarUI(scene);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('3つのセクション（受注依頼、素材、完成品）を作成する', () => {
+      sidebar.create();
+
+      // containerが作成される
+      expect(scene.add.container).toHaveBeenCalled();
+      // テキストが作成される（アイコン×3 + タイトル×3 + コンテンツ×3 = 9回）
+      expect(scene.add.text).toHaveBeenCalled();
+    });
+
+    it('折りたたみ状態を復元する', () => {
+      const savedState = ['material'];
+      (localStorage.getItem as any).mockReturnValue(JSON.stringify(savedState));
+
+      sidebar.create();
+
+      expect(localStorage.getItem).toHaveBeenCalledWith('sidebar-collapsed');
+    });
+  });
+
+  describe('destroy', () => {
+    it('折りたたみ状態を保存する', () => {
+      sidebar.create();
+      sidebar.destroy();
+
+      expect(localStorage.setItem).toHaveBeenCalledWith('sidebar-collapsed', expect.any(String));
+    });
+
+    it('GameObjectsを破棄する', () => {
+      sidebar.create();
+      const container = (scene.add.container as any).mock.results[0].value;
+
+      sidebar.destroy();
+
+      expect(container.destroy).toHaveBeenCalled();
+    });
+  });
+
+  describe('折りたたみアニメーション', () => {
+    it('localStorageエラー時も正常動作する', () => {
+      (localStorage.getItem as any).mockImplementation(() => {
+        throw new Error('localStorage error');
+      });
+      (localStorage.setItem as any).mockImplementation(() => {
+        throw new Error('localStorage error');
+      });
+
+      expect(() => {
+        sidebar.create();
+        sidebar.destroy();
+      }).not.toThrow();
+    });
+  });
+
+  describe('状態保持', () => {
+    it('折りたたみ状態を配列形式で保存する', () => {
+      sidebar.create();
+      sidebar.destroy();
+
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        'sidebar-collapsed',
+        expect.stringMatching(/^\[.*\]$/),
+      );
+    });
+  });
+});


### PR DESCRIPTION
MainSceneのサイドバーに折りたたみ機能を追加しました。

## 実装内容
- セクション構造とコンテンツ領域の追加
- 折りたたみアイコン（▼/▶）と回転アニメーション
- セクション展開・折りたたみのスムーズなアニメーション
- localStorageを使った折りたたみ状態の永続化
- アニメーション中の連続クリック防止機能
- ユニットテストの追加

## 変更ファイル
- src/presentation/ui/main/SidebarUI.ts
- tests/unit/presentation/ui/main/SidebarUI.test.ts（新規）

## 完了条件
- ✅ セクションヘッダークリックで折りたたみ/展開
- ✅ 高さ変化のアニメーション実装
- ✅ アイコン回転アニメーション（▼/▶）
- ✅ 折りたたみ状態の保持
- ✅ 動作確認完了