### PR TITLE
fix: E2Eテスト用のシーン遷移を修正 (Issue #89)

### DIFF
--- a/atelier-guild-rank/e2e/pages/result.page.ts
+++ b/atelier-guild-rank/e2e/pages/result.page.ts
@@ -5,7 +5,7 @@ import type { GameWindow } from '../types/game-window.types';
  * リザルト画面のPage Objectクラス
  *
  * @description
- * ResultSceneのUI要素とインタラクションを提供する。
+ * GameClearScene/GameOverSceneのUI要素とインタラクションを提供する。
  * ゲームクリア/ゲームオーバーの判定やタイトルへの遷移を行う。
  *
  * @example
@@ -23,11 +23,11 @@ export class ResultPage extends BasePage {
 	 * リザルト画面が表示されるまで待機
 	 *
 	 * @description
-	 * キャンバスの可視化とResultSceneの表示を待機する。
+	 * キャンバスの可視化とGameClearScene/GameOverSceneのいずれかの表示を待機する。
 	 */
 	async waitForResultScreen(): Promise<void> {
 		await this.waitForCanvasVisible();
-		await this.waitForScene('ResultScene');
+		await this.waitForResultScene();
 	}
 
 	/**
@@ -74,18 +74,17 @@ export class ResultPage extends BasePage {
 	}
 
 	/**
-	 * 指定したシーンになるまで待機
+	 * リザルトシーン（GameClearScene または GameOverScene）になるまで待機
 	 *
-	 * @param sceneName - 待機するシーン名
 	 * @param timeout - タイムアウト（ミリ秒）
 	 */
-	private async waitForScene(sceneName: string, timeout: number = BasePage.DEFAULT_TIMEOUT): Promise<void> {
+	private async waitForResultScene(timeout: number = BasePage.DEFAULT_TIMEOUT): Promise<void> {
 		await this.page.waitForFunction(
-			(name) => {
+			() => {
 				const state = (window as unknown as GameWindow).gameState?.();
-				return state?.currentScene === name;
+				const scene = state?.currentScene;
+				return scene === 'GameClearScene' || scene === 'GameOverScene';
 			},
-			sceneName,
 			{ timeout },
 		);
 	}

--- a/atelier-guild-rank/src/main.ts
+++ b/atelier-guild-rank/src/main.ts
@@ -9,7 +9,13 @@
 
 import type { IStateManager } from '@application/services/state-manager.interface';
 import { Container, ServiceKeys } from '@infrastructure/di/container';
-import { BootScene, MainScene, TitleScene } from '@presentation/scenes';
+import {
+  BootScene,
+  GameClearScene,
+  GameOverScene,
+  MainScene,
+  TitleScene,
+} from '@presentation/scenes';
 // debug.ts でグローバル型 (window.game, window.gameState, window.debug) が定義されている
 import '@shared/utils/debug';
 import Phaser from 'phaser';
@@ -48,6 +54,8 @@ const config: Phaser.Types.Core.GameConfig = {
     BootScene, // アセット読み込み・初期化
     TitleScene, // タイトル画面
     MainScene, // メインゲーム
+    GameClearScene, // ゲームクリア画面
+    GameOverScene, // ゲームオーバー画面
   ],
 
   /** プラグイン設定 🔵 */
@@ -141,6 +149,10 @@ window.gameState = () => {
     // StateManagerが初期化されていない場合は無視
   }
 
+  // ゲームクリア/ゲームオーバー判定
+  const isGameClear = currentScene === 'GameClearScene';
+  const isGameOver = currentScene === 'GameOverScene';
+
   return {
     currentScene,
     hasSaveData,
@@ -149,6 +161,8 @@ window.gameState = () => {
     gold: stateFromManager.gold,
     currentRank: stateFromManager.currentRank,
     actionPoints: stateFromManager.actionPoints,
+    isGameClear,
+    isGameOver,
   };
 };
 


### PR DESCRIPTION
## Summary
- ゲームクリア/ゲームオーバーのE2Eテスト（TC-E2E-040/041/050/051）が失敗していた問題を修正
- Phaserのシーン遷移で、scene.start()の前にscene.stop()を呼び出すことでシーン重複を防止
- gameState()にisGameClear/isGameOverフラグを追加

## Test plan
- [x] TC-E2E-040: Sランク到達でゲームクリア - ✅
- [x] TC-E2E-041: ゲームクリア画面からタイトルへ戻る - ✅
- [x] TC-E2E-050: 日数切れでゲームオーバー - ✅
- [x] TC-E2E-051: ゲームオーバー画面からタイトルへ戻る - ✅
- [x] 既存のE2Eテスト（game-flow.spec.ts）が全て成功

## Changes
- `src/main.ts`: GameClearScene/GameOverSceneを登録、gameState()にisGameClear/isGameOverを追加
- `src/shared/utils/debug.ts`: シーン遷移時にstop()を呼び出し、endDay()にゲームクリア/ゲームオーバー判定を追加
- `e2e/pages/result.page.ts`: ResultSceneではなくGameClearScene/GameOverSceneを待つように修正

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)