### PR TITLE
feat: TASK-0050 ShopScene実装

### DIFF
--- a/atelier-guild-rank/src/presentation/scenes/ShopScene.ts
+++ b/atelier-guild-rank/src/presentation/scenes/ShopScene.ts
@@ -1,0 +1,607 @@
+/**
+ * ShopScene.ts - ショップシーン
+ * TASK-0050: ShopScene実装
+ *
+ * @description
+ * ショップ画面を表示するシーン。
+ * カード・アイテムの購入機能を提供する。
+ *
+ * @信頼性レベル 🔵 TASK-0050.md セクション2に基づく
+ */
+
+import type {
+  IPurchaseResult,
+  IShopItem,
+  IShopService,
+} from '@domain/interfaces/shop-service.interface';
+import { Container, ServiceKeys } from '@infrastructure/di/container';
+import { THEME } from '@presentation/ui/theme';
+import type { GuildRank } from '@shared/types';
+import Phaser from 'phaser';
+
+// =============================================================================
+// 定数
+// =============================================================================
+
+/**
+ * レイアウト定数
+ */
+const LAYOUT = {
+  /** ヘッダー高さ */
+  HEADER_HEIGHT: 60,
+  /** フッター高さ */
+  FOOTER_HEIGHT: 80,
+  /** サイドパディング */
+  SIDE_PADDING: 40,
+  /** グリッド列数 */
+  GRID_COLS: 3,
+  /** アイテムカードの幅 */
+  ITEM_WIDTH: 200,
+  /** アイテムカードの高さ */
+  ITEM_HEIGHT: 250,
+  /** アイテム間のスペーシング */
+  ITEM_SPACING: 20,
+  /** ボタンの幅 */
+  BUTTON_WIDTH: 120,
+  /** ボタンの高さ */
+  BUTTON_HEIGHT: 40,
+  /** ボタンの角丸半径 */
+  BUTTON_RADIUS: 8,
+} as const;
+
+/**
+ * スタイル定数
+ */
+const STYLES = {
+  /** ヘッダーフォントサイズ */
+  HEADER_FONT_SIZE: '28px',
+  /** アイテム名フォントサイズ */
+  ITEM_NAME_FONT_SIZE: '16px',
+  /** 価格フォントサイズ */
+  PRICE_FONT_SIZE: '14px',
+  /** 説明フォントサイズ */
+  DESCRIPTION_FONT_SIZE: '12px',
+  /** ボタンフォントサイズ */
+  BUTTON_FONT_SIZE: '14px',
+  /** フッターフォントサイズ */
+  FOOTER_FONT_SIZE: '18px',
+  /** 価格の色（ゴールド） */
+  PRICE_COLOR: '#FFD700',
+  /** 購入不可の色 */
+  UNAVAILABLE_COLOR: '#999999',
+  /** 在庫切れの色 */
+  OUT_OF_STOCK_COLOR: '#FF6B6B',
+} as const;
+
+/**
+ * テキスト定数
+ */
+const TEXT = {
+  HEADER: 'ショップ',
+  BACK: '戻る',
+  BUY: '購入',
+  SOLD_OUT: '売切',
+  GOLD_LABEL: '所持金: ',
+  GOLD_UNIT: 'G',
+  STOCK_UNLIMITED: '∞',
+} as const;
+
+/**
+ * アニメーション定数
+ */
+const ANIMATION = {
+  /** フェードイン・アウトの時間（ミリ秒） */
+  FADE_DURATION: 300,
+  /** 無効化時のアルファ値 */
+  DISABLED_ALPHA: 0.5,
+} as const;
+
+// =============================================================================
+// 型定義
+// =============================================================================
+
+/**
+ * StateManager インターフェース（依存注入用）
+ */
+interface IStateManager {
+  getState(): {
+    currentRank: GuildRank;
+    gold: number;
+  };
+}
+
+/**
+ * EventBus インターフェース（依存注入用）
+ */
+interface IEventBus {
+  emit(event: string, data: unknown): void;
+  on(event: string, handler: (...args: unknown[]) => void): () => void;
+  off(event: string, handler?: (...args: unknown[]) => void): void;
+}
+
+// =============================================================================
+// ShopSceneクラス
+// =============================================================================
+
+/**
+ * ShopScene - ショップ画面シーン
+ *
+ * 【責務】:
+ * - ショップアイテムの一覧表示
+ * - 購入処理の実行
+ * - MainSceneへの戻り処理
+ *
+ * @信頼性レベル 🔵 TASK-0050.md セクション2に基づく
+ */
+export class ShopScene extends Phaser.Scene {
+  // ===========================================================================
+  // 依存サービス
+  // ===========================================================================
+
+  /** 状態管理サービス */
+  private stateManager!: IStateManager;
+
+  /** ショップサービス */
+  private shopService!: IShopService;
+
+  /** イベントバス */
+  private eventBus!: IEventBus;
+
+  // ===========================================================================
+  // UIコンポーネント
+  // ===========================================================================
+
+  /** 戻るボタン */
+  // biome-ignore lint/suspicious/noExplicitAny: rexUI Labelコンポーネントの型は複雑なため
+  private backButton: any;
+
+  /** 所持金テキスト */
+  private goldText!: Phaser.GameObjects.Text;
+
+  /** アイテムコンテナ */
+  private itemContainer!: Phaser.GameObjects.Container;
+
+  /** ショップアイテムリスト */
+  private shopItems: IShopItem[] = [];
+
+  /** アイテムUIリスト */
+  // biome-ignore lint/suspicious/noExplicitAny: rexUI コンポーネントの型は複雑なため
+  private itemUIs: any[] = [];
+
+  // ===========================================================================
+  // rexUIプラグイン
+  // ===========================================================================
+
+  /** rexUIプラグイン参照 */
+  // biome-ignore lint/suspicious/noExplicitAny: rexUIプラグインの型は複雑なため
+  protected rexUI: any;
+
+  // ===========================================================================
+  // コンストラクタ
+  // ===========================================================================
+
+  constructor() {
+    super({ key: 'ShopScene' });
+  }
+
+  // ===========================================================================
+  // ライフサイクルメソッド
+  // ===========================================================================
+
+  /**
+   * create() - ショップ画面の生成
+   *
+   * @throws {Error} StateManagerが未初期化の場合
+   * @throws {Error} ShopServiceが未初期化の場合
+   */
+  create(): void {
+    // DIコンテナからサービスを取得
+    this.initializeServicesFromContainer();
+
+    // サービスの検証
+    this.validateServices();
+
+    // UIコンポーネントの作成
+    this.createHeader();
+    this.createItemGrid();
+    this.createFooter();
+
+    // フェードイン
+    this.fadeIn();
+  }
+
+  // ===========================================================================
+  // プライベートメソッド - 初期化
+  // ===========================================================================
+
+  /**
+   * DIコンテナからサービスを取得
+   */
+  private initializeServicesFromContainer(): void {
+    const container = Container.getInstance();
+    this.stateManager = container.resolve(ServiceKeys.StateManager);
+    this.shopService = container.resolve(ServiceKeys.ShopService);
+    this.eventBus = container.resolve(ServiceKeys.EventBus);
+  }
+
+  /**
+   * サービスの存在を検証
+   *
+   * @throws {Error} 必要なサービスが未初期化の場合
+   */
+  private validateServices(): void {
+    if (!this.stateManager) {
+      throw new Error('StateManager is required');
+    }
+    if (!this.shopService) {
+      throw new Error('ShopService is required');
+    }
+    if (!this.eventBus) {
+      throw new Error('EventBus is required');
+    }
+  }
+
+  // ===========================================================================
+  // プライベートメソッド - UI作成
+  // ===========================================================================
+
+  /**
+   * ヘッダーを作成
+   */
+  private createHeader(): void {
+    // ヘッダー背景
+    const headerBg = this.add.graphics();
+    headerBg.fillStyle(THEME.colors.primary, 1);
+    headerBg.fillRect(0, 0, this.cameras.main.width, LAYOUT.HEADER_HEIGHT);
+
+    // タイトルテキスト
+    this.add
+      .text(LAYOUT.SIDE_PADDING, LAYOUT.HEADER_HEIGHT / 2, TEXT.HEADER, {
+        fontFamily: THEME.fonts.primary,
+        fontSize: STYLES.HEADER_FONT_SIZE,
+        color: THEME.colors.textOnPrimary,
+      })
+      .setOrigin(0, 0.5);
+
+    // 戻るボタン
+    this.createBackButton();
+  }
+
+  /**
+   * 戻るボタンを作成
+   */
+  private createBackButton(): void {
+    const buttonX = this.cameras.main.width - LAYOUT.SIDE_PADDING - LAYOUT.BUTTON_WIDTH / 2;
+    const buttonY = LAYOUT.HEADER_HEIGHT / 2;
+
+    const buttonBackground = this.rexUI.add.roundRectangle(
+      0,
+      0,
+      LAYOUT.BUTTON_WIDTH,
+      LAYOUT.BUTTON_HEIGHT,
+      LAYOUT.BUTTON_RADIUS,
+      THEME.colors.secondary,
+    );
+
+    const buttonText = this.add.text(0, 0, TEXT.BACK, {
+      fontFamily: THEME.fonts.primary,
+      fontSize: STYLES.BUTTON_FONT_SIZE,
+      color: THEME.colors.textOnPrimary,
+    });
+
+    this.backButton = this.rexUI.add.label({
+      width: LAYOUT.BUTTON_WIDTH,
+      height: LAYOUT.BUTTON_HEIGHT,
+      background: buttonBackground,
+      text: buttonText,
+      align: 'center',
+      space: {
+        left: 10,
+        right: 10,
+        top: 5,
+        bottom: 5,
+      },
+      x: buttonX,
+      y: buttonY,
+    });
+
+    this.backButton.setInteractive();
+    this.backButton.on('pointerdown', () => this.onBackButtonClick());
+    this.backButton.layout();
+  }
+
+  /**
+   * アイテムグリッドを作成
+   */
+  private createItemGrid(): void {
+    const state = this.stateManager.getState();
+    this.shopItems = this.shopService.getAvailableItems(state.currentRank);
+
+    // アイテムコンテナを作成
+    const contentY = LAYOUT.HEADER_HEIGHT + LAYOUT.ITEM_SPACING;
+    this.itemContainer = this.add.container(0, contentY);
+
+    // グリッドでアイテムを配置
+    const startX = LAYOUT.SIDE_PADDING + LAYOUT.ITEM_WIDTH / 2;
+    const startY = LAYOUT.ITEM_SPACING + LAYOUT.ITEM_HEIGHT / 2;
+
+    this.shopItems.forEach((item, index) => {
+      const col = index % LAYOUT.GRID_COLS;
+      const row = Math.floor(index / LAYOUT.GRID_COLS);
+
+      const x = startX + col * (LAYOUT.ITEM_WIDTH + LAYOUT.ITEM_SPACING);
+      const y = startY + row * (LAYOUT.ITEM_HEIGHT + LAYOUT.ITEM_SPACING);
+
+      this.createItemCard(item, x, y);
+    });
+  }
+
+  /**
+   * アイテムカードを作成
+   *
+   * @param item - ショップアイテム
+   * @param x - X座標
+   * @param y - Y座標
+   */
+  private createItemCard(item: IShopItem, x: number, y: number): void {
+    const state = this.stateManager.getState();
+    const canPurchase = this.shopService.canPurchase(item.id, state.gold, state.currentRank);
+    const isSoldOut = item.stock === 0;
+
+    // カード背景
+    const cardBg = this.rexUI.add.roundRectangle(
+      0,
+      0,
+      LAYOUT.ITEM_WIDTH,
+      LAYOUT.ITEM_HEIGHT,
+      8,
+      THEME.colors.background,
+    );
+
+    // アイテム名
+    const nameText = this.add
+      .text(0, -80, item.name, {
+        fontFamily: THEME.fonts.primary,
+        fontSize: STYLES.ITEM_NAME_FONT_SIZE,
+        color: `#${THEME.colors.text.toString(16)}`,
+      })
+      .setOrigin(0.5, 0.5);
+
+    // タイプ表示
+    const typeLabel =
+      item.type === 'card' ? 'カード' : item.type === 'material' ? '素材' : 'アーティファクト';
+    const typeText = this.add
+      .text(0, -55, `[${typeLabel}]`, {
+        fontFamily: THEME.fonts.primary,
+        fontSize: STYLES.DESCRIPTION_FONT_SIZE,
+        color: `#${THEME.colors.textLight.toString(16)}`,
+      })
+      .setOrigin(0.5, 0.5);
+
+    // 説明
+    const descText = this.add
+      .text(0, -20, item.description, {
+        fontFamily: THEME.fonts.primary,
+        fontSize: STYLES.DESCRIPTION_FONT_SIZE,
+        color: `#${THEME.colors.textLight.toString(16)}`,
+        wordWrap: { width: LAYOUT.ITEM_WIDTH - 20 },
+        align: 'center',
+      })
+      .setOrigin(0.5, 0.5);
+
+    // 価格
+    const priceColor = canPurchase ? STYLES.PRICE_COLOR : STYLES.UNAVAILABLE_COLOR;
+    const priceText = this.add
+      .text(0, 30, `${item.price}${TEXT.GOLD_UNIT}`, {
+        fontFamily: THEME.fonts.primary,
+        fontSize: STYLES.PRICE_FONT_SIZE,
+        color: priceColor,
+      })
+      .setOrigin(0.5, 0.5);
+
+    // 在庫表示
+    const stockDisplay = item.stock === -1 ? TEXT.STOCK_UNLIMITED : `在庫: ${item.stock}`;
+    const stockColor = isSoldOut
+      ? STYLES.OUT_OF_STOCK_COLOR
+      : `#${THEME.colors.textLight.toString(16)}`;
+    const stockText = this.add
+      .text(0, 50, stockDisplay, {
+        fontFamily: THEME.fonts.primary,
+        fontSize: STYLES.DESCRIPTION_FONT_SIZE,
+        color: stockColor,
+      })
+      .setOrigin(0.5, 0.5);
+
+    // 購入ボタン
+    const buttonLabel = isSoldOut ? TEXT.SOLD_OUT : TEXT.BUY;
+    const buttonColor = isSoldOut
+      ? THEME.colors.disabled
+      : canPurchase
+        ? THEME.colors.primary
+        : THEME.colors.disabled;
+
+    const buyButtonBg = this.rexUI.add.roundRectangle(0, 0, 80, 30, 4, buttonColor);
+
+    const buyButtonText = this.add.text(0, 0, buttonLabel, {
+      fontFamily: THEME.fonts.primary,
+      fontSize: STYLES.DESCRIPTION_FONT_SIZE,
+      color: THEME.colors.textOnPrimary,
+    });
+
+    const buyButton = this.rexUI.add.label({
+      width: 80,
+      height: 30,
+      background: buyButtonBg,
+      text: buyButtonText,
+      align: 'center',
+      space: { left: 5, right: 5, top: 3, bottom: 3 },
+    });
+
+    if (canPurchase && !isSoldOut) {
+      buyButton.setInteractive();
+      buyButton.on('pointerdown', () => this.handlePurchase(item.id));
+    } else {
+      buyButton.setAlpha(ANIMATION.DISABLED_ALPHA);
+    }
+
+    buyButton.layout();
+
+    // カードにすべての要素を配置
+    const card = this.rexUI.add.sizer({
+      x,
+      y,
+      orientation: 'y',
+      space: { item: 5 },
+    });
+
+    card.add(cardBg);
+    card.add(nameText);
+    card.add(typeText);
+    card.add(descText);
+    card.add(priceText);
+    card.add(stockText);
+    card.add(buyButton);
+    card.layout();
+
+    this.itemUIs.push({ card, item, buyButton });
+    this.itemContainer.add(card);
+  }
+
+  /**
+   * フッターを作成
+   */
+  private createFooter(): void {
+    const state = this.stateManager.getState();
+    const footerY = this.cameras.main.height - LAYOUT.FOOTER_HEIGHT;
+
+    // フッター背景
+    const footerBg = this.add.graphics();
+    footerBg.fillStyle(THEME.colors.primary, 1);
+    footerBg.fillRect(0, footerY, this.cameras.main.width, LAYOUT.FOOTER_HEIGHT);
+
+    // 所持金表示
+    this.goldText = this.add
+      .text(
+        LAYOUT.SIDE_PADDING,
+        footerY + LAYOUT.FOOTER_HEIGHT / 2,
+        `${TEXT.GOLD_LABEL}${state.gold}${TEXT.GOLD_UNIT}`,
+        {
+          fontFamily: THEME.fonts.primary,
+          fontSize: STYLES.FOOTER_FONT_SIZE,
+          color: THEME.colors.textOnPrimary,
+        },
+      )
+      .setOrigin(0, 0.5);
+  }
+
+  // ===========================================================================
+  // 購入処理
+  // ===========================================================================
+
+  /**
+   * アイテム購入可能かチェック
+   *
+   * @param itemId - ショップアイテムID
+   * @returns 購入可能な場合true
+   */
+  canPurchaseItem(itemId: string): boolean {
+    const state = this.stateManager.getState();
+    return this.shopService.canPurchase(itemId, state.gold, state.currentRank);
+  }
+
+  /**
+   * 購入処理を実行
+   *
+   * @param itemId - ショップアイテムID
+   * @returns 購入結果
+   */
+  handlePurchase(itemId: string): IPurchaseResult {
+    const result = this.shopService.purchase(itemId);
+
+    if (result.success) {
+      // 所持金表示を更新
+      this.updateGoldDisplay();
+
+      // アイテムリストを更新
+      this.refreshItemList();
+    }
+
+    return result;
+  }
+
+  /**
+   * 所持金表示を更新
+   */
+  private updateGoldDisplay(): void {
+    const state = this.stateManager.getState();
+    this.goldText.setText(`${TEXT.GOLD_LABEL}${state.gold}${TEXT.GOLD_UNIT}`);
+  }
+
+  /**
+   * アイテムリストを更新
+   */
+  private refreshItemList(): void {
+    const state = this.stateManager.getState();
+    this.shopItems = this.shopService.getAvailableItems(state.currentRank);
+
+    // 購入ボタンの状態を更新
+    for (const ui of this.itemUIs) {
+      const canPurchase = this.shopService.canPurchase(ui.item.id, state.gold, state.currentRank);
+      const item = this.shopService.getShopItem(ui.item.id);
+      const isSoldOut = item ? item.stock === 0 : false;
+
+      if (!canPurchase || isSoldOut) {
+        ui.buyButton.setAlpha(ANIMATION.DISABLED_ALPHA);
+        ui.buyButton.removeInteractive();
+      }
+    }
+  }
+
+  // ===========================================================================
+  // 公開メソッド（テスト用）
+  // ===========================================================================
+
+  /**
+   * 所持金テキストを取得
+   *
+   * @returns 所持金表示テキスト
+   */
+  getGoldText(): string {
+    const state = this.stateManager.getState();
+    return `${TEXT.GOLD_LABEL}${state.gold}${TEXT.GOLD_UNIT}`;
+  }
+
+  // ===========================================================================
+  // シーン遷移
+  // ===========================================================================
+
+  /**
+   * 戻るボタンクリック処理
+   */
+  onBackButtonClick(): void {
+    this.fadeOutToScene('MainScene');
+  }
+
+  // ===========================================================================
+  // アニメーション
+  // ===========================================================================
+
+  /**
+   * フェードイン処理
+   */
+  private fadeIn(): void {
+    this.cameras.main.fadeIn(ANIMATION.FADE_DURATION, 0, 0, 0);
+  }
+
+  /**
+   * フェードアウト後にシーン遷移
+   *
+   * @param targetScene - 遷移先のシーン名
+   */
+  private fadeOutToScene(targetScene: string): void {
+    this.cameras.main.fadeOut(ANIMATION.FADE_DURATION, 0, 0, 0);
+    this.cameras.main.once('camerafadeoutcomplete', () => {
+      this.scene.start(targetScene);
+    });
+  }
+}

--- a/atelier-guild-rank/tests/unit/presentation/scenes/shop-scene.test.ts
+++ b/atelier-guild-rank/tests/unit/presentation/scenes/shop-scene.test.ts
@@ -1,0 +1,785 @@
+/**
+ * ShopScene ユニットテスト
+ * TASK-0050 ShopScene実装
+ *
+ * @description
+ * ショップ画面のテストケース
+ *
+ * テストカテゴリ:
+ * - 正常系: シーン初期化、アイテム表示、購入処理
+ * - 異常系: 所持金不足、在庫切れ
+ * - シーン遷移: MainSceneへの戻り
+ */
+
+import type { IPurchaseResult, IShopItem } from '@domain/interfaces/shop-service.interface';
+import { GamePhase, GuildRank } from '@shared/types/common';
+import type Phaser from 'phaser';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// =============================================================================
+// モック定義
+// =============================================================================
+
+/**
+ * Phaserモック
+ */
+vi.mock('phaser', () => {
+  return {
+    default: {
+      Scene: class MockScene {},
+      GameObjects: {
+        Container: class MockContainer {},
+        Text: class MockText {},
+        Graphics: class MockGraphics {},
+      },
+    },
+  };
+});
+
+// DIコンテナのモックインスタンス
+// biome-ignore lint/suspicious/noExplicitAny: テスト用のモック変数
+let mockStateManagerInstance: any;
+// biome-ignore lint/suspicious/noExplicitAny: テスト用のモック変数
+let mockShopServiceInstance: any;
+// biome-ignore lint/suspicious/noExplicitAny: テスト用のモック変数
+let mockEventBusInstance: any;
+
+const mockContainerInstance = {
+  resolve: vi.fn((key: string) => {
+    if (key === 'StateManager') return mockStateManagerInstance;
+    if (key === 'ShopService') return mockShopServiceInstance;
+    if (key === 'EventBus') return mockEventBusInstance;
+    throw new Error(`Service not found: ${key}`);
+  }),
+  register: vi.fn(),
+};
+
+vi.mock('@infrastructure/di/container', () => ({
+  Container: {
+    getInstance: vi.fn(() => mockContainerInstance),
+  },
+  ServiceKeys: {
+    StateManager: 'StateManager',
+    ShopService: 'ShopService',
+    EventBus: 'EventBus',
+  },
+}));
+
+// =============================================================================
+// モック作成ヘルパー
+// =============================================================================
+
+/**
+ * Phaserコンテナのモックを作成
+ */
+const createMockContainer = () => ({
+  setVisible: vi.fn().mockReturnThis(),
+  setPosition: vi.fn().mockReturnThis(),
+  setDepth: vi.fn().mockReturnThis(),
+  add: vi.fn().mockReturnThis(),
+  destroy: vi.fn(),
+  bringToTop: vi.fn().mockReturnThis(),
+  x: 0,
+  y: 0,
+  visible: true,
+});
+
+/**
+ * Phaserテキストのモックを作成
+ */
+const createMockText = () => ({
+  setText: vi.fn().mockReturnThis(),
+  setOrigin: vi.fn().mockReturnThis(),
+  setStyle: vi.fn().mockReturnThis(),
+  setColor: vi.fn().mockReturnThis(),
+  setFontSize: vi.fn().mockReturnThis(),
+  destroy: vi.fn(),
+  text: '',
+});
+
+/**
+ * Phaserグラフィックスのモックを作成
+ */
+const createMockGraphics = () => ({
+  fillStyle: vi.fn().mockReturnThis(),
+  fillRect: vi.fn().mockReturnThis(),
+  fillRoundedRect: vi.fn().mockReturnThis(),
+  clear: vi.fn().mockReturnThis(),
+  destroy: vi.fn(),
+  lineStyle: vi.fn().mockReturnThis(),
+  beginPath: vi.fn().mockReturnThis(),
+  moveTo: vi.fn().mockReturnThis(),
+  lineTo: vi.fn().mockReturnThis(),
+  stroke: vi.fn().mockReturnThis(),
+  strokePath: vi.fn().mockReturnThis(),
+});
+
+/**
+ * rexUIモックを作成
+ */
+const createMockRexUI = () => ({
+  add: {
+    sizer: vi.fn().mockReturnValue({
+      layout: vi.fn(),
+      add: vi.fn().mockReturnThis(),
+      destroy: vi.fn(),
+    }),
+    label: vi.fn().mockReturnValue({
+      layout: vi.fn(),
+      setInteractive: vi.fn().mockReturnThis(),
+      on: vi.fn().mockReturnThis(),
+      destroy: vi.fn(),
+      setText: vi.fn().mockReturnThis(),
+      setAlpha: vi.fn().mockReturnThis(),
+    }),
+    roundRectangle: vi.fn().mockReturnValue({
+      setFillStyle: vi.fn().mockReturnThis(),
+      destroy: vi.fn(),
+    }),
+    scrollablePanel: vi.fn().mockReturnValue({
+      layout: vi.fn(),
+      destroy: vi.fn(),
+    }),
+  },
+});
+
+/**
+ * Phaserシーンのモックを作成
+ */
+const createMockScene = () => {
+  const mockContainer = createMockContainer();
+  const mockText = createMockText();
+  const mockGraphics = createMockGraphics();
+  const mockRexUI = createMockRexUI();
+
+  return {
+    scene: {
+      add: {
+        container: vi.fn().mockImplementation((x: number, y: number) => ({
+          ...mockContainer,
+          x,
+          y,
+        })),
+        text: vi.fn().mockReturnValue(mockText),
+        graphics: vi.fn().mockReturnValue(mockGraphics),
+        rectangle: vi.fn().mockReturnValue({
+          setFillStyle: vi.fn().mockReturnThis(),
+          setStrokeStyle: vi.fn().mockReturnThis(),
+          setOrigin: vi.fn().mockReturnThis(),
+          setInteractive: vi.fn().mockReturnThis(),
+          on: vi.fn().mockReturnThis(),
+          destroy: vi.fn(),
+        }),
+      },
+      cameras: {
+        main: {
+          centerX: 640,
+          centerY: 360,
+          width: 1280,
+          height: 720,
+          fadeIn: vi.fn(),
+          fadeOut: vi.fn(),
+          once: vi.fn().mockImplementation((event, callback) => {
+            // 即時にコールバックを呼び出す
+            if (event === 'camerafadeoutcomplete') {
+              setTimeout(callback, 0);
+            }
+          }),
+        },
+      },
+      rexUI: mockRexUI,
+      tweens: {
+        add: vi.fn().mockImplementation((config) => {
+          if (config.onComplete) {
+            config.onComplete();
+          }
+          return {};
+        }),
+      },
+      scene: {
+        start: vi.fn(),
+      },
+    } as unknown as Phaser.Scene,
+    mockContainer,
+    mockText,
+    mockGraphics,
+    mockRexUI,
+  };
+};
+
+/**
+ * StateManagerモックを作成
+ */
+const createMockStateManager = () => ({
+  getState: vi.fn().mockReturnValue({
+    currentRank: GuildRank.E,
+    promotionGauge: 35,
+    remainingDays: 25,
+    currentDay: 6,
+    currentPhase: GamePhase.QUEST_ACCEPT,
+    gold: 500,
+    actionPoints: 3,
+    comboCount: 0,
+    rankHp: 100,
+    isPromotionTest: false,
+  }),
+  updateState: vi.fn(),
+  spendGold: vi.fn().mockReturnValue(true),
+});
+
+/**
+ * ShopServiceモックを作成
+ */
+const createMockShopService = () => ({
+  getAvailableItems: vi.fn().mockReturnValue([
+    {
+      id: 'shop-card-001',
+      type: 'card' as const,
+      itemId: 'card-001',
+      name: '強化ポーション',
+      price: 100,
+      stock: 3,
+      unlockRank: GuildRank.G,
+      description: '攻撃力を強化するカード',
+    },
+    {
+      id: 'shop-card-002',
+      type: 'card' as const,
+      itemId: 'card-002',
+      name: '防御ポーション',
+      price: 150,
+      stock: -1, // 無制限
+      unlockRank: GuildRank.G,
+      description: '防御力を強化するカード',
+    },
+    {
+      id: 'shop-material-001',
+      type: 'material' as const,
+      itemId: 'herb',
+      name: '薬草',
+      price: 50,
+      stock: 10,
+      unlockRank: GuildRank.G,
+      description: '基本的な素材',
+    },
+  ] as IShopItem[]),
+  getAllItems: vi.fn().mockReturnValue([]),
+  canPurchase: vi.fn().mockReturnValue(true),
+  purchase: vi.fn().mockReturnValue({
+    success: true,
+    itemId: 'shop-card-001',
+    remainingGold: 400,
+    remainingStock: 2,
+  } as IPurchaseResult),
+  getItemPrice: vi.fn().mockReturnValue(100),
+  getShopItem: vi.fn().mockReturnValue(null),
+  getStock: vi.fn().mockReturnValue(3),
+});
+
+/**
+ * EventBusモックを作成
+ */
+const createMockEventBus = () => {
+  const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+  return {
+    emit: vi.fn().mockImplementation((event: string, data: unknown) => {
+      const handlers = listeners.get(event) || [];
+      for (const handler of handlers) {
+        handler(data);
+      }
+    }),
+    on: vi.fn().mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+      const existing = listeners.get(event) || [];
+      existing.push(handler);
+      listeners.set(event, existing);
+      return () => {
+        const index = existing.indexOf(handler);
+        if (index > -1) {
+          existing.splice(index, 1);
+        }
+      };
+    }),
+    off: vi.fn(),
+    listeners,
+  };
+};
+
+// =============================================================================
+// テストスイート
+// =============================================================================
+
+describe('ShopScene', () => {
+  beforeEach(() => {
+    mockStateManagerInstance = createMockStateManager();
+    mockShopServiceInstance = createMockShopService();
+    mockEventBusInstance = createMockEventBus();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ===========================================================================
+  // 基本テスト
+  // ===========================================================================
+
+  describe('create()', () => {
+    it('TC-0050-001: シーンが正しく初期化されること', async () => {
+      // 【テスト目的】: ShopScene生成時にレイアウトコンポーネントが正しく作成されることを確認
+      // 【対応要件】: REQ-050-01
+      // 🔵 信頼性レベル: TASK-0050.md セクション2に明記
+
+      const { ShopScene } = await import('@presentation/scenes/ShopScene');
+      const { scene: mockScene } = createMockScene();
+
+      const shopScene = new ShopScene();
+
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.add = mockScene.add;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.cameras = mockScene.cameras;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.rexUI = mockScene.rexUI;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.scene = mockScene.scene;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.stateManager = mockStateManagerInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.shopService = mockShopServiceInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.eventBus = mockEventBusInstance;
+
+      shopScene.create();
+
+      // 戻るボタンが生成されていることを確認
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      expect(shopScene.backButton).toBeDefined();
+    });
+
+    it('TC-0050-002: カード一覧が表示されること', async () => {
+      // 【テスト目的】: ShopScene生成時にカード一覧が正しく表示されることを確認
+      // 【対応要件】: REQ-050-02
+      // 🔵 信頼性レベル: TASK-0050.md セクション2に明記
+
+      const { ShopScene } = await import('@presentation/scenes/ShopScene');
+      const { scene: mockScene } = createMockScene();
+
+      const shopScene = new ShopScene();
+
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.add = mockScene.add;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.cameras = mockScene.cameras;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.rexUI = mockScene.rexUI;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.scene = mockScene.scene;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.stateManager = mockStateManagerInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.shopService = mockShopServiceInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.eventBus = mockEventBusInstance;
+
+      shopScene.create();
+
+      // getAvailableItemsが呼ばれていることを確認
+      expect(mockShopServiceInstance.getAvailableItems).toHaveBeenCalledWith(GuildRank.E);
+
+      // アイテムが表示されていることを確認
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      expect(shopScene.shopItems.length).toBe(3);
+    });
+
+    it('TC-0050-003: アイテム一覧が表示されること', async () => {
+      // 【テスト目的】: ShopScene生成時にアイテム（素材・カード）が正しく表示されることを確認
+      // 【対応要件】: REQ-050-03
+      // 🔵 信頼性レベル: TASK-0050.md セクション2に明記
+
+      const { ShopScene } = await import('@presentation/scenes/ShopScene');
+      const { scene: mockScene } = createMockScene();
+
+      const shopScene = new ShopScene();
+
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.add = mockScene.add;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.cameras = mockScene.cameras;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.rexUI = mockScene.rexUI;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.scene = mockScene.scene;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.stateManager = mockStateManagerInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.shopService = mockShopServiceInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.eventBus = mockEventBusInstance;
+
+      shopScene.create();
+
+      // カードと素材の両方が表示されていることを確認
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      const cardItems = shopScene.shopItems.filter((item) => item.type === 'card');
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      const materialItems = shopScene.shopItems.filter((item) => item.type === 'material');
+
+      expect(cardItems.length).toBe(2);
+      expect(materialItems.length).toBe(1);
+    });
+
+    it('TC-0050-004: 所持金が表示されること', async () => {
+      // 【テスト目的】: ShopSceneで所持金が正しく表示されることを確認
+      // 【対応要件】: REQ-050-04
+      // 🔵 信頼性レベル: TASK-0050.md セクション2に明記
+
+      const { ShopScene } = await import('@presentation/scenes/ShopScene');
+      const { scene: mockScene } = createMockScene();
+
+      const shopScene = new ShopScene();
+
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.add = mockScene.add;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.cameras = mockScene.cameras;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.rexUI = mockScene.rexUI;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.scene = mockScene.scene;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.stateManager = mockStateManagerInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.shopService = mockShopServiceInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.eventBus = mockEventBusInstance;
+
+      shopScene.create();
+
+      // 所持金表示が正しいことを確認
+      expect(shopScene.getGoldText()).toBe('所持金: 500G');
+    });
+
+    it('TC-0050-005: 「戻る」ボタンが表示されること', async () => {
+      // 【テスト目的】: ShopSceneで戻るボタンが表示されることを確認
+      // 【対応要件】: REQ-050-07
+      // 🔵 信頼性レベル: TASK-0050.md セクション2に明記
+
+      const { ShopScene } = await import('@presentation/scenes/ShopScene');
+      const { scene: mockScene } = createMockScene();
+
+      const shopScene = new ShopScene();
+
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.add = mockScene.add;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.cameras = mockScene.cameras;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.rexUI = mockScene.rexUI;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.scene = mockScene.scene;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.stateManager = mockStateManagerInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.shopService = mockShopServiceInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.eventBus = mockEventBusInstance;
+
+      shopScene.create();
+
+      // 戻るボタンが存在することを確認
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      expect(shopScene.backButton).toBeDefined();
+    });
+  });
+
+  // ===========================================================================
+  // 購入処理テスト
+  // ===========================================================================
+
+  describe('購入処理', () => {
+    it('TC-0050-006: カード購入ボタンクリックで購入処理が実行されること', async () => {
+      // 【テスト目的】: 購入ボタンクリック時にShopService.purchase()が呼ばれることを確認
+      // 【対応要件】: REQ-050-05
+      // 🔵 信頼性レベル: TASK-0050.md セクション2に明記
+
+      const { ShopScene } = await import('@presentation/scenes/ShopScene');
+      const { scene: mockScene } = createMockScene();
+
+      const shopScene = new ShopScene();
+
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.add = mockScene.add;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.cameras = mockScene.cameras;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.rexUI = mockScene.rexUI;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.scene = mockScene.scene;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.stateManager = mockStateManagerInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.shopService = mockShopServiceInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.eventBus = mockEventBusInstance;
+
+      shopScene.create();
+
+      // 購入処理を実行
+      // @ts-expect-error - テストのためにprivateメソッドにアクセス
+      shopScene.handlePurchase('shop-card-001');
+
+      // purchase()が呼ばれていることを確認
+      expect(mockShopServiceInstance.purchase).toHaveBeenCalledWith('shop-card-001');
+    });
+
+    it('TC-0050-007: 所持金が購入金額以上ある場合に購入可能であること', async () => {
+      // 【テスト目的】: 所持金が十分な場合に購入可能であることを確認
+      // 【対応要件】: REQ-050-05
+      // 🔵 信頼性レベル: TASK-0050.md セクション2に明記
+
+      const { ShopScene } = await import('@presentation/scenes/ShopScene');
+      const { scene: mockScene } = createMockScene();
+
+      const shopScene = new ShopScene();
+
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.add = mockScene.add;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.cameras = mockScene.cameras;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.rexUI = mockScene.rexUI;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.scene = mockScene.scene;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.stateManager = mockStateManagerInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.shopService = mockShopServiceInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.eventBus = mockEventBusInstance;
+
+      shopScene.create();
+
+      // 購入可能かチェック
+      // @ts-expect-error - テストのためにprivateメソッドにアクセス
+      const canPurchase = shopScene.canPurchaseItem('shop-card-001');
+
+      expect(canPurchase).toBe(true);
+      expect(mockShopServiceInstance.canPurchase).toHaveBeenCalledWith(
+        'shop-card-001',
+        500,
+        GuildRank.E,
+      );
+    });
+
+    it('TC-0050-008: 所持金不足時に購入ボタンが無効化されること', async () => {
+      // 【テスト目的】: 所持金不足の場合に購入ボタンが無効化されることを確認
+      // 【対応要件】: REQ-050-06
+      // 🔵 信頼性レベル: TASK-0050.md セクション2に明記
+
+      const { ShopScene } = await import('@presentation/scenes/ShopScene');
+      const { scene: mockScene } = createMockScene();
+
+      // 所持金不足のモック
+      mockShopServiceInstance.canPurchase.mockReturnValue(false);
+
+      const shopScene = new ShopScene();
+
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.add = mockScene.add;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.cameras = mockScene.cameras;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.rexUI = mockScene.rexUI;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.scene = mockScene.scene;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.stateManager = mockStateManagerInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.shopService = mockShopServiceInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.eventBus = mockEventBusInstance;
+
+      shopScene.create();
+
+      // 購入可能かチェック
+      // @ts-expect-error - テストのためにprivateメソッドにアクセス
+      const canPurchase = shopScene.canPurchaseItem('shop-card-001');
+
+      expect(canPurchase).toBe(false);
+    });
+
+    it('TC-0050-009: 購入成功時に所持金が減少すること', async () => {
+      // 【テスト目的】: 購入成功後に所持金が更新されることを確認
+      // 【対応要件】: REQ-050-05
+      // 🔵 信頼性レベル: TASK-0050.md セクション2に明記
+
+      const { ShopScene } = await import('@presentation/scenes/ShopScene');
+      const { scene: mockScene } = createMockScene();
+
+      const shopScene = new ShopScene();
+
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.add = mockScene.add;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.cameras = mockScene.cameras;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.rexUI = mockScene.rexUI;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.scene = mockScene.scene;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.stateManager = mockStateManagerInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.shopService = mockShopServiceInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.eventBus = mockEventBusInstance;
+
+      shopScene.create();
+
+      // 購入処理を実行
+      // @ts-expect-error - テストのためにprivateメソッドにアクセス
+      shopScene.handlePurchase('shop-card-001');
+
+      // 購入結果で残りゴールドが400になっていることを確認
+      // purchase()が成功を返す
+      expect(mockShopServiceInstance.purchase).toHaveBeenCalledWith('shop-card-001');
+    });
+
+    it('TC-0050-010: 購入成功時にデッキにカードが追加されること', async () => {
+      // 【テスト目的】: カード購入成功時にデッキにカードが追加されることを確認
+      // 【対応要件】: REQ-050-05
+      // 🔵 信頼性レベル: TASK-0050.md セクション2に明記
+      // 注: ShopServiceの内部でDeckServiceが呼ばれる
+
+      const { ShopScene } = await import('@presentation/scenes/ShopScene');
+      const { scene: mockScene } = createMockScene();
+
+      const shopScene = new ShopScene();
+
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.add = mockScene.add;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.cameras = mockScene.cameras;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.rexUI = mockScene.rexUI;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.scene = mockScene.scene;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.stateManager = mockStateManagerInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.shopService = mockShopServiceInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.eventBus = mockEventBusInstance;
+
+      shopScene.create();
+
+      // 購入処理を実行
+      // @ts-expect-error - テストのためにprivateメソッドにアクセス
+      const result = shopScene.handlePurchase('shop-card-001');
+
+      // 成功結果を確認（ShopService内部でDeckServiceが呼ばれる）
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // ===========================================================================
+  // シーン遷移テスト
+  // ===========================================================================
+
+  describe('シーン遷移', () => {
+    it('TC-0050-011: 「戻る」ボタンクリックでMainSceneに戻ること', async () => {
+      // 【テスト目的】: 戻るボタンクリック時にMainSceneに遷移することを確認
+      // 【対応要件】: REQ-050-07
+      // 🔵 信頼性レベル: TASK-0050.md セクション2に明記
+
+      const { ShopScene } = await import('@presentation/scenes/ShopScene');
+      const { scene: mockScene } = createMockScene();
+
+      const shopScene = new ShopScene();
+
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.add = mockScene.add;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.cameras = mockScene.cameras;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.rexUI = mockScene.rexUI;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.scene = mockScene.scene;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.stateManager = mockStateManagerInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.shopService = mockShopServiceInstance;
+      // @ts-expect-error - テストのためにprivateプロパティにアクセス
+      shopScene.eventBus = mockEventBusInstance;
+
+      shopScene.create();
+
+      // 戻るボタンをクリック
+      // @ts-expect-error - テストのためにprivateメソッドにアクセス
+      shopScene.onBackButtonClick();
+
+      // MainSceneへの遷移を確認（フェードアウト後）
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(mockScene.scene.start).toHaveBeenCalledWith('MainScene');
+    });
+  });
+
+  // ===========================================================================
+  // エラーハンドリングテスト
+  // ===========================================================================
+
+  describe('Error Handling', () => {
+    it('TC-0050-E01: StateManager未初期化時にエラー処理される', async () => {
+      // 【テスト目的】: StateManager未初期化時のエラーハンドリングを確認
+      // 【対応要件】: REQ-050-01（異常系）
+
+      const { ShopScene } = await import('@presentation/scenes/ShopScene');
+      const { scene: mockScene } = createMockScene();
+
+      const originalStateManager = mockStateManagerInstance;
+      mockStateManagerInstance = undefined;
+
+      try {
+        const shopScene = new ShopScene();
+        // @ts-expect-error - テストのためにprivateプロパティにアクセス
+        shopScene.add = mockScene.add;
+        // @ts-expect-error - テストのためにprivateプロパティにアクセス
+        shopScene.cameras = mockScene.cameras;
+        // @ts-expect-error - テストのためにprivateプロパティにアクセス
+        shopScene.rexUI = mockScene.rexUI;
+        // @ts-expect-error - テストのためにprivateプロパティにアクセス
+        shopScene.scene = mockScene.scene;
+
+        expect(() => shopScene.create()).toThrow('StateManager is required');
+      } finally {
+        mockStateManagerInstance = originalStateManager;
+      }
+    });
+
+    it('TC-0050-E02: ShopService未初期化時にエラー処理される', async () => {
+      // 【テスト目的】: ShopService未初期化時のエラーハンドリングを確認
+      // 【対応要件】: REQ-050-01（異常系）
+
+      const { ShopScene } = await import('@presentation/scenes/ShopScene');
+      const { scene: mockScene } = createMockScene();
+
+      const originalShopService = mockShopServiceInstance;
+      mockShopServiceInstance = undefined;
+
+      try {
+        const shopScene = new ShopScene();
+        // @ts-expect-error - テストのためにprivateプロパティにアクセス
+        shopScene.add = mockScene.add;
+        // @ts-expect-error - テストのためにprivateプロパティにアクセス
+        shopScene.cameras = mockScene.cameras;
+        // @ts-expect-error - テストのためにprivateプロパティにアクセス
+        shopScene.rexUI = mockScene.rexUI;
+        // @ts-expect-error - テストのためにprivateプロパティにアクセス
+        shopScene.scene = mockScene.scene;
+
+        expect(() => shopScene.create()).toThrow('ShopService is required');
+      } finally {
+        mockShopServiceInstance = originalShopService;
+      }
+    });
+  });
+});


### PR DESCRIPTION
ショップ画面（ShopScene）を実装し、カード・アイテムの購入機能を提供する。

- ShopSceneの基本レイアウト（ヘッダー、アイテムグリッド、フッター）
- カード・素材・アーティファクトの一覧表示
- 購入処理（ShopServiceとの連携）
- 所持金表示と更新
- MainSceneへの戻る機能
- ユニットテスト13ケース作成