### PR TITLE
fix: Issue #115 EventBusをシーンデータに設定し依頼受注エラーを修正

### DIFF
--- a/atelier-guild-rank/src/presentation/scenes/MainScene.ts
+++ b/atelier-guild-rank/src/presentation/scenes/MainScene.ts
@@ -206,6 +206,7 @@ export class MainScene extends Phaser.Scene {
   /**
    * create() - メイン画面の生成
    * Issue #111: シーンデータを受け取り、新規ゲーム開始時はstartNewGame()を呼ぶ
+   * Issue #115: EventBusをシーンデータに設定（UIコンポーネントからアクセス可能にする）
    *
    * @param data - TitleSceneから渡されるシーンデータ
    * @throws {Error} StateManagerが未初期化の場合
@@ -218,6 +219,10 @@ export class MainScene extends Phaser.Scene {
 
     // サービスの検証
     this.validateServices();
+
+    // Issue #115: EventBusをシーンデータに設定
+    // QuestAcceptPhaseUI等のUIコンポーネントがthis.scene.data.get('eventBus')でアクセスできるようにする
+    this.data.set('eventBus', this.eventBus);
 
     // UIコンポーネントの作成
     this.createLayoutComponents();


### PR DESCRIPTION
## Summary

- MainScene.create()でDIコンテナから取得したEventBusをシーンデータに設定
- QuestAcceptPhaseUI等のUIコンポーネントがEventBusにアクセス可能に
- 依頼受注時のQUEST_ACCEPTEDイベント発行が正常に動作

## Test plan

- [x] MainSceneのユニットテストが全て成功することを確認
- [ ] 依頼受注ボタンクリック時にエラーが発生しないことを確認
- [ ] QUEST_ACCEPTEDイベントが正常に発行されることを確認

Closes #115

🤖 Generated with [Claude Code](https://claude.ai/claude-code)