### PR TITLE
fix: Issue #116 フェーズUIの二重オフセット問題を修正

### DIFF
--- a/atelier-guild-rank/src/presentation/ui/phases/AlchemyPhaseUI.ts
+++ b/atelier-guild-rank/src/presentation/ui/phases/AlchemyPhaseUI.ts
@@ -111,7 +111,8 @@ export class AlchemyPhaseUI extends BaseComponent {
       throw new Error('AlchemyPhaseUI: alchemyService is required');
     }
 
-    super(scene, 400, 100);
+    // Issue #116: コンテンツコンテナが既にオフセット済みなので(0, 0)を使用
+    super(scene, 0, 0);
     this.alchemyService = alchemyService;
     this.onCraftCompleteCallback = onCraftComplete;
   }

--- a/atelier-guild-rank/src/presentation/ui/phases/DeliveryPhaseUI.ts
+++ b/atelier-guild-rank/src/presentation/ui/phases/DeliveryPhaseUI.ts
@@ -27,8 +27,9 @@ import {
 // =============================================================================
 
 const UI_LAYOUT = {
-  COMPONENT_X: 160,
-  COMPONENT_Y: 80,
+  // Issue #116: コンテンツコンテナが既にオフセット済みなので(0, 0)を使用
+  COMPONENT_X: 0,
+  COMPONENT_Y: 0,
   QUEST_LIST_Y: 60,
   ITEM_SELECTOR_Y: 450,
   PREVIEW_Y: 350,

--- a/atelier-guild-rank/src/presentation/ui/phases/GatheringPhaseUI.ts
+++ b/atelier-guild-rank/src/presentation/ui/phases/GatheringPhaseUI.ts
@@ -44,6 +44,7 @@ export class GatheringPhaseUI extends BaseComponent {
 
   /**
    * コンストラクタ
+   * Issue #116: コンテンツコンテナが既にオフセット済みなので(0, 0)を使用
    *
    * @param scene - Phaserシーン
    * @param gatheringService - 採取サービス
@@ -54,7 +55,7 @@ export class GatheringPhaseUI extends BaseComponent {
     private gatheringService: IGatheringService,
     onEnd?: () => void,
   ) {
-    super(scene, 400, 100);
+    super(scene, 0, 0);
     this.onEndCallback = onEnd;
   }
 

--- a/atelier-guild-rank/src/presentation/ui/phases/QuestAcceptPhaseUI.spec.ts
+++ b/atelier-guild-rank/src/presentation/ui/phases/QuestAcceptPhaseUI.spec.ts
@@ -202,11 +202,11 @@ describe('QuestAcceptPhaseUI', () => {
       expect(phaseUI.getContainer()).toBeDefined();
     });
 
-    test('container.x = 160, container.y = 80 に配置される', () => {
+    test('container.x = 0, container.y = 0 に配置される（Issue #116: コンテンツコンテナが既にオフセット済み）', () => {
       const phaseUI = new QuestAcceptPhaseUI(mockScene);
       phaseUI.create();
 
-      expect(mockScene.add.container).toHaveBeenCalledWith(160, 80);
+      expect(mockScene.add.container).toHaveBeenCalledWith(0, 0);
     });
 
     test('タイトル「📋 本日の依頼」が表示される', () => {

--- a/atelier-guild-rank/src/presentation/ui/phases/QuestAcceptPhaseUI.ts
+++ b/atelier-guild-rank/src/presentation/ui/phases/QuestAcceptPhaseUI.ts
@@ -85,9 +85,10 @@ export class QuestAcceptPhaseUI extends BaseComponent {
 
   /**
    * 【コンポーネント配置定数】: UIコンポーネントの配置位置
+   * Issue #116: コンテンツコンテナが既にオフセット済みなので(0, 0)を使用
    */
-  private static readonly COMPONENT_X = 160;
-  private static readonly COMPONENT_Y = 80;
+  private static readonly COMPONENT_X = 0;
+  private static readonly COMPONENT_Y = 0;
 
   /**
    * 【タイトルスタイル定数】: タイトルテキストのスタイル


### PR DESCRIPTION
## Summary

- コンテンツコンテナが既にオフセット済み(SIDEBAR_WIDTH, HEADER_HEIGHT)のため、各フェーズUIの座標を(0, 0)に変更
- QuestAcceptPhaseUI, GatheringPhaseUI, AlchemyPhaseUI, DeliveryPhaseUI を修正

## Test plan

- [x] 全ユニットテストが成功することを確認
- [ ] フェーズUIが正しい位置に表示されることを視覚的に確認

Closes #116

🤖 Generated with [Claude Code](https://claude.ai/claude-code)