### PR TITLE
fix: Issue #117 依頼カードのインタラクティブ設定を改善

### DIFF
--- a/atelier-guild-rank/src/presentation/ui/components/QuestCardUI.ts
+++ b/atelier-guild-rank/src/presentation/ui/components/QuestCardUI.ts
@@ -375,7 +375,8 @@ export class QuestCardUI extends BaseComponent {
     // 【早期リターン】: インタラクティブ機能が無効な場合は何もしない
     if (!this.config.interactive) return;
 
-    this.background.setInteractive();
+    // Issue #117: useHandCursorを設定
+    this.background.setInteractive({ useHandCursor: true });
 
     // 【型安全性】: モックの場合、on と emit を実際のイベントエミッターとして動作させる
     this.setupEventEmitter(this.background);


### PR DESCRIPTION
## Summary

- `setInteractive()` に `useHandCursor: true` を追加
- 白枠問題の調査結果: コード上では金色（0xffd54f）が設定されており、白枠は設定されていない
- Issue #116（二重オフセット問題）の修正後に再確認が必要

## Test plan

- [x] 全ユニットテストが成功することを確認
- [ ] Issue #116のマージ後に視覚的に確認

Related to #116
Closes #117

🤖 Generated with [Claude Code](https://claude.ai/claude-code)