### PR TITLE
fix: Issue #120 フェーズ遷移時にモーダルをクリーンアップ

### DIFF
--- a/atelier-guild-rank/src/presentation/ui/phases/QuestAcceptPhaseUI.spec.ts
+++ b/atelier-guild-rank/src/presentation/ui/phases/QuestAcceptPhaseUI.spec.ts
@@ -39,6 +39,7 @@ function createMockScene(): Phaser.Scene {
         add: vi.fn(),
         setDepth: vi.fn(),
         destroy: vi.fn(),
+        setVisible: vi.fn(),
         x: 0,
         y: 0,
         active: true,
@@ -838,6 +839,93 @@ describe('QuestAcceptPhaseUI', () => {
 
       // 2件目のカードが1件目の下に配置されることを確認
       expect(targetY2).toBeGreaterThan(targetY1);
+    });
+  });
+
+  // =============================================================================
+  // Issue #120: フェーズ遷移時のクリーンアップテストケース
+  // =============================================================================
+
+  describe('TC-801: setVisible(false)時のクリーンアップ', () => {
+    // 【テスト目的】: setVisible(false)が呼ばれるとモーダルが閉じられることを確認
+    // 【対応Issue】: Issue #120 - 採取フェーズに移動しても依頼カードの表示が消えない
+    // 🔵 信頼性レベル: Issue #120に明記
+
+    test('setVisible(false)でモーダルが閉じられる', () => {
+      const mockQuest = createMockQuestEntity({ id: 'Q001' });
+
+      const phaseUI = new QuestAcceptPhaseUI(mockScene);
+      phaseUI.create();
+      phaseUI.updateQuests([mockQuest]);
+
+      // モーダルを開く
+      // biome-ignore lint/suspicious/noExplicitAny: テストでprivateメソッドにアクセスするために必要
+      (phaseUI as any).openQuestDetailModal(mockQuest);
+      // biome-ignore lint/suspicious/noExplicitAny: テストでprivateプロパティにアクセスするために必要
+      expect((phaseUI as any).currentModal).not.toBeNull();
+
+      // setVisible(false)を呼ぶ
+      phaseUI.setVisible(false);
+
+      // モーダルが閉じられていることを確認
+      // biome-ignore lint/suspicious/noExplicitAny: テストでprivateプロパティにアクセスするために必要
+      expect((phaseUI as any).currentModal).toBeNull();
+    });
+
+    test('setVisible(true)ではcleanup()が呼ばれない', () => {
+      const mockQuest = createMockQuestEntity({ id: 'Q001' });
+
+      const phaseUI = new QuestAcceptPhaseUI(mockScene);
+      phaseUI.create();
+      phaseUI.updateQuests([mockQuest]);
+
+      // モーダルを開く
+      // biome-ignore lint/suspicious/noExplicitAny: テストでprivateメソッドにアクセスするために必要
+      (phaseUI as any).openQuestDetailModal(mockQuest);
+      // biome-ignore lint/suspicious/noExplicitAny: テストでprivateプロパティにアクセスするために必要
+      expect((phaseUI as any).currentModal).not.toBeNull();
+
+      // setVisible(true)を呼ぶ
+      phaseUI.setVisible(true);
+
+      // モーダルが開いたままであることを確認
+      // biome-ignore lint/suspicious/noExplicitAny: テストでprivateプロパティにアクセスするために必要
+      expect((phaseUI as any).currentModal).not.toBeNull();
+    });
+  });
+
+  describe('TC-802: cleanup()メソッドの動作', () => {
+    // 【テスト目的】: cleanup()がモーダルを閉じることを確認
+    // 【対応Issue】: Issue #120
+    // 🔵 信頼性レベル: Issue #120に明記
+
+    test('cleanup()がモーダルを閉じる', () => {
+      const mockQuest = createMockQuestEntity({ id: 'Q001' });
+
+      const phaseUI = new QuestAcceptPhaseUI(mockScene);
+      phaseUI.create();
+      phaseUI.updateQuests([mockQuest]);
+
+      // モーダルを開く
+      // biome-ignore lint/suspicious/noExplicitAny: テストでprivateメソッドにアクセスするために必要
+      (phaseUI as any).openQuestDetailModal(mockQuest);
+      // biome-ignore lint/suspicious/noExplicitAny: テストでprivateプロパティにアクセスするために必要
+      expect((phaseUI as any).currentModal).not.toBeNull();
+
+      // cleanup()を呼ぶ
+      phaseUI.cleanup();
+
+      // モーダルが閉じられていることを確認
+      // biome-ignore lint/suspicious/noExplicitAny: テストでprivateプロパティにアクセスするために必要
+      expect((phaseUI as any).currentModal).toBeNull();
+    });
+
+    test('モーダルが開いていない場合もcleanup()はエラーにならない', () => {
+      const phaseUI = new QuestAcceptPhaseUI(mockScene);
+      phaseUI.create();
+
+      // モーダルを開かずにcleanup()を呼ぶ
+      expect(() => phaseUI.cleanup()).not.toThrow();
     });
   });
 });

--- a/atelier-guild-rank/src/presentation/ui/phases/QuestAcceptPhaseUI.ts
+++ b/atelier-guild-rank/src/presentation/ui/phases/QuestAcceptPhaseUI.ts
@@ -459,6 +459,39 @@ export class QuestAcceptPhaseUI extends BaseComponent {
     }
   }
 
+  /**
+   * 【クリーンアップ】: フェーズ遷移時に呼び出されるクリーンアップ処理
+   *
+   * Issue #120: フェーズ遷移時にモーダルを閉じる
+   *
+   * 【設計意図】:
+   * - setVisible(false)時に呼び出され、開いているモーダルを閉じる
+   * - UIを非表示にする際に不要な表示要素を確実にクリーンアップ
+   */
+  public cleanup(): void {
+    this.closeQuestDetailModal();
+  }
+
+  /**
+   * 【可視性設定オーバーライド】: 表示/非表示切り替え時にクリーンアップを実行
+   *
+   * Issue #120: 非表示時にモーダルを閉じる
+   *
+   * 【設計意図】:
+   * - 親クラスのsetVisibleを呼び出しつつ、非表示時はcleanup()を実行
+   * - フェーズ遷移で依頼カードやモーダルが残らないようにする
+   *
+   * @param visible - 表示するかどうか
+   * @returns this（チェイン可能）
+   */
+  public override setVisible(visible: boolean): this {
+    if (!visible) {
+      this.cleanup();
+    }
+    super.setVisible(visible);
+    return this;
+  }
+
   // =============================================================================
   // TASK-0043: サイドバー機能（将来実装用に保持）
   // =============================================================================


### PR DESCRIPTION
## Summary
- QuestAcceptPhaseUIに`cleanup()`メソッドを追加し、フェーズ遷移時にモーダルを閉じるように修正
- `setVisible()`をオーバーライドし、非表示時に`cleanup()`を実行
- 採取フェーズへの遷移時に依頼カードのモーダルが残らないようになった

## Test plan
- [x] TC-801: setVisible(false)時のクリーンアップテスト
- [x] TC-802: cleanup()メソッドの動作テスト
- [x] 全ユニットテストがパス

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)