### PR TITLE
fix: フェーズUIのコンテナをcontentContainerに追加

### DIFF
--- a/atelier-guild-rank/src/presentation/scenes/MainScene.ts
+++ b/atelier-guild-rank/src/presentation/scenes/MainScene.ts
@@ -321,6 +321,7 @@ export class MainScene extends Phaser.Scene {
 
     // QuestAcceptPhaseUI
     const questAcceptUI = new QuestAcceptPhaseUI(this);
+    this._contentContainer.add(questAcceptUI.getContainer());
     this.phaseUIs.set(GamePhase.QUEST_ACCEPT, questAcceptUI);
 
     // GatheringPhaseUI
@@ -332,6 +333,7 @@ export class MainScene extends Phaser.Scene {
     if (gatheringService) {
       const gatheringUI = new GatheringPhaseUI(this, gatheringService);
       gatheringUI.create();
+      this._contentContainer.add(gatheringUI.getContainer());
       this.phaseUIs.set(GamePhase.GATHERING, gatheringUI);
     } else {
       // GatheringServiceが利用できない場合はダミーUIを作成
@@ -348,6 +350,7 @@ export class MainScene extends Phaser.Scene {
     if (alchemyService) {
       const alchemyUI = new AlchemyPhaseUI(this, alchemyService);
       alchemyUI.create();
+      this._contentContainer.add(alchemyUI.getContainer());
       this.phaseUIs.set(GamePhase.ALCHEMY, alchemyUI);
     } else {
       // AlchemyServiceが利用できない場合はダミーUIを作成
@@ -357,6 +360,7 @@ export class MainScene extends Phaser.Scene {
 
     // DeliveryPhaseUI
     const deliveryUI = new DeliveryPhaseUI(this);
+    this._contentContainer.add(deliveryUI.getContainer());
     this.phaseUIs.set(GamePhase.DELIVERY, deliveryUI);
 
     // 全てのフェーズUIを非表示に初期化


### PR DESCRIPTION
## Summary
- MainScene.createPhaseUIs()でフェーズUIのコンテナをcontentContainerに追加
- QuestAcceptPhaseUI、GatheringPhaseUI、AlchemyPhaseUI、DeliveryPhaseUIが対象
- これによりUIがヘッダー/サイドバーのオフセットを正しく反映

## Test plan
- [ ] ゲームを開始し、依頼受注フェーズの画面を確認
- [ ] UIの配置がヘッダー/サイドバーと重なっていないことを確認
- [ ] 各フェーズに遷移してUIの配置が正しいことを確認

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)