### PR TITLE
fix: QuestCardUIのコンテナをQuestAcceptPhaseUIに追加

### DIFF
--- a/atelier-guild-rank/src/presentation/ui/phases/QuestAcceptPhaseUI.ts
+++ b/atelier-guild-rank/src/presentation/ui/phases/QuestAcceptPhaseUI.ts
@@ -279,6 +279,7 @@ export class QuestAcceptPhaseUI extends BaseComponent {
       const quest = quests[i];
       const position = this.calculateCardPosition(i);
       const questCard = this.createQuestCard(quest, position);
+      this.container.add(questCard.getContainer());
       this.setupCardClickHandler(questCard, quest);
       this.questCards.push(questCard);
     }


### PR DESCRIPTION
## Summary
- QuestAcceptPhaseUI.createQuestCards()でQuestCardUIのコンテナを親containerに追加
- これによりフェーズ遷移時に依頼カードが正しく非表示になる

## Test plan
- [ ] ゲームを開始し、依頼受注フェーズで依頼カードが表示されることを確認
- [ ] 「採取へ」ボタンをクリックして採取フェーズに移動
- [ ] 依頼カードが画面に残らず非表示になることを確認

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)