### PR TITLE
fix: ランク表示の型安全性を強化し防御的チェックを追加 (Issue #110)

### DIFF
--- a/atelier-guild-rank/src/presentation/scenes/MainScene.ts
+++ b/atelier-guild-rank/src/presentation/scenes/MainScene.ts
@@ -23,7 +23,7 @@ import { AlchemyPhaseUI } from '@presentation/ui/phases/AlchemyPhaseUI';
 import { DeliveryPhaseUI } from '@presentation/ui/phases/DeliveryPhaseUI';
 import { GatheringPhaseUI } from '@presentation/ui/phases/GatheringPhaseUI';
 import { QuestAcceptPhaseUI } from '@presentation/ui/phases/QuestAcceptPhaseUI';
-import { GamePhase, VALID_GAME_PHASES } from '@shared/types/common';
+import { GamePhase, type GuildRank, VALID_GAME_PHASES } from '@shared/types/common';
 import type { IPhaseChangedEvent } from '@shared/types/events';
 import { GameEventType } from '@shared/types/events';
 import { toCardId } from '@shared/types/ids';
@@ -66,7 +66,7 @@ const PHASE_BUTTON_LABELS: Record<GamePhase, string> = {
  */
 interface IStateManager {
   getState(): {
-    currentRank: string;
+    currentRank: GuildRank;
     promotionGauge: number;
     remainingDays: number;
     currentDay: number;

--- a/atelier-guild-rank/src/presentation/ui/components/HeaderUI.ts
+++ b/atelier-guild-rank/src/presentation/ui/components/HeaderUI.ts
@@ -9,6 +9,7 @@
  * @信頼性レベル 🔵 requirements.md セクション2.2に基づく
  */
 
+import { GuildRank, type GuildRank as GuildRankType } from '@shared/types/common';
 import type Phaser from 'phaser';
 import { BaseComponent } from './BaseComponent';
 
@@ -60,13 +61,22 @@ const HEADER_LAYOUT = {
  * HeaderUI更新データの型定義
  */
 export interface IHeaderUIData {
-  currentRank: string;
+  currentRank: GuildRankType;
   promotionGauge: number;
   remainingDays: number;
   gold: number;
   actionPoints: number;
   maxActionPoints: number;
 }
+
+/**
+ * 有効なGuildRankかどうかを検証
+ * @param value - 検証する値
+ * @returns 有効なGuildRankの場合true
+ */
+const isValidGuildRank = (value: unknown): value is GuildRankType => {
+  return Object.values(GuildRank).includes(value as GuildRankType);
+};
 
 // =============================================================================
 // HeaderUIクラス
@@ -309,8 +319,9 @@ export class HeaderUI extends BaseComponent {
     // 以前の点滅状態を保持
     const wasBlinking = this._remainingDaysBlinking;
 
-    // ランク表示
-    this._rankText = `ランク: ${data.currentRank}`;
+    // ランク表示（防御的チェック: 無効な値の場合はデフォルト値Gを使用）
+    const validRank = isValidGuildRank(data.currentRank) ? data.currentRank : GuildRank.G;
+    this._rankText = `ランク: ${validRank}`;
 
     // 昇格ゲージ
     this._promotionGaugeValue = data.promotionGauge;


### PR DESCRIPTION
## Summary
- IHeaderUIDataのcurrentRank型をstringからGuildRank型に変更して型安全性を強化
- MainSceneのIStateManagerインターフェースでもGuildRank型を使用
- HeaderUI.update()に無効な値の防御的チェックを追加
  - isValidGuildRank()関数で実行時検証
  - 無効な値の場合はデフォルト値'G'を使用

## 変更内容
- `atelier-guild-rank/src/presentation/scenes/MainScene.ts`
  - GuildRank型をインポート
  - IStateManagerインターフェースのcurrentRank型をGuildRankに変更
  
- `atelier-guild-rank/src/presentation/ui/components/HeaderUI.ts`
  - GuildRank定数と型をインポート
  - IHeaderUIDataのcurrentRank型をGuildRankに変更
  - isValidGuildRank()関数を追加
  - update()メソッドに防御的チェックを追加

## Test plan
- [x] ビルドが成功すること
- [x] 既存のHeaderUIテストが全て通ること
- [x] 全ユニットテストが通ること

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)