### PR TITLE
refactor: rexUI型定義を既存コードに適用 (TASK-0059)

### DIFF
--- a/atelier-guild-rank/src/presentation/ui/components/RecipeListUI.ts
+++ b/atelier-guild-rank/src/presentation/ui/components/RecipeListUI.ts
@@ -10,6 +10,7 @@
 import type { CardId } from '@shared/types';
 import type { IRecipeCardMaster } from '@shared/types/master-data';
 import type Phaser from 'phaser';
+import type { RexLabel, RexRoundRectangle } from '../../types/rexui';
 import { THEME } from '../theme';
 import { BaseComponent } from './BaseComponent';
 
@@ -29,12 +30,13 @@ const RECIPE_LIST_LAYOUT = {
   PADDING_VERTICAL: 5,
 } as const;
 
-/** rexUIラベル情報の型定義 */
+/**
+ * rexUIラベル情報の型定義
+ * TASK-0059: rexUI型定義を適用
+ */
 interface RecipeLabelInfo {
-  // biome-ignore lint/suspicious/noExplicitAny: rexUIプラグインは型定義が複雑なため
-  label: any;
-  // biome-ignore lint/suspicious/noExplicitAny: rexUIプラグインは型定義が複雑なため
-  background: any;
+  label: RexLabel;
+  background: RexRoundRectangle;
   recipe: IRecipeCardMaster;
 }
 
@@ -147,13 +149,13 @@ export class RecipeListUI extends BaseComponent {
 
   /**
    * ラベルの位置を設定
+   * TASK-0059: rexUI型定義を適用
    *
    * @param label - rexUIラベル
    * @param x - X座標
    * @param y - Y座標
    */
-  // biome-ignore lint/suspicious/noExplicitAny: rexUIプラグインは型定義が複雑なため
-  private setLabelPosition(label: any, x: number, y: number): void {
+  private setLabelPosition(label: RexLabel, x: number, y: number): void {
     if (typeof label.setPosition === 'function') {
       label.setPosition(x, y);
     } else {
@@ -164,12 +166,12 @@ export class RecipeListUI extends BaseComponent {
 
   /**
    * ラベルのインタラクションを設定
+   * TASK-0059: rexUI型定義を適用
    *
    * @param label - rexUIラベル
    * @param recipeId - レシピID
    */
-  // biome-ignore lint/suspicious/noExplicitAny: rexUIプラグインは型定義が複雑なため
-  private setupLabelInteraction(label: any, recipeId: CardId): void {
+  private setupLabelInteraction(label: RexLabel, recipeId: CardId): void {
     if (typeof label.setInteractive === 'function') {
       label.setInteractive();
     }

--- a/atelier-guild-rank/src/presentation/ui/phases/AlchemyPhaseUI.ts
+++ b/atelier-guild-rank/src/presentation/ui/phases/AlchemyPhaseUI.ts
@@ -14,6 +14,7 @@ import { getSelectionIndexFromKey, isKeyForAction } from '@shared/constants/keyb
 import type { CardId, Quality } from '@shared/types';
 import type { IRecipeCardMaster } from '@shared/types/master-data';
 import type Phaser from 'phaser';
+import type { RexLabel, RexRoundRectangle } from '../../types/rexui';
 import { BaseComponent } from '../components/BaseComponent';
 import { THEME } from '../theme';
 
@@ -37,12 +38,13 @@ const ALCHEMY_PHASE_LAYOUT = {
   PADDING_VERTICAL: 5,
 } as const;
 
-/** rexUIラベル情報の型定義 */
+/**
+ * rexUIラベル情報の型定義
+ * TASK-0059: rexUI型定義を適用
+ */
 interface RecipeLabelInfo {
-  // biome-ignore lint/suspicious/noExplicitAny: rexUIプラグインは型定義が複雑なため
-  label: any;
-  // biome-ignore lint/suspicious/noExplicitAny: rexUIプラグインは型定義が複雑なため
-  background: any;
+  label: RexLabel;
+  background: RexRoundRectangle;
   recipe: IRecipeCardMaster;
 }
 
@@ -225,13 +227,13 @@ export class AlchemyPhaseUI extends BaseComponent {
 
   /**
    * ラベルの位置を設定
+   * TASK-0059: rexUI型定義を適用
    *
    * @param label - rexUIラベル
    * @param x - X座標
    * @param y - Y座標
    */
-  // biome-ignore lint/suspicious/noExplicitAny: rexUIプラグインは型定義が複雑なため
-  private setLabelPosition(label: any, x: number, y: number): void {
+  private setLabelPosition(label: RexLabel, x: number, y: number): void {
     if (typeof label.setPosition === 'function') {
       label.setPosition(x, y);
     } else {
@@ -242,12 +244,12 @@ export class AlchemyPhaseUI extends BaseComponent {
 
   /**
    * ラベルのインタラクションを設定
+   * TASK-0059: rexUI型定義を適用
    *
    * @param label - rexUIラベル
    * @param recipeId - レシピID
    */
-  // biome-ignore lint/suspicious/noExplicitAny: rexUIプラグインは型定義が複雑なため
-  private setupLabelInteraction(label: any, recipeId: CardId): void {
+  private setupLabelInteraction(label: RexLabel, recipeId: CardId): void {
     if (typeof label.setInteractive === 'function') {
       label.setInteractive();
     }

--- a/atelier-guild-rank/src/presentation/ui/phases/QuestAcceptPhaseUI.ts
+++ b/atelier-guild-rank/src/presentation/ui/phases/QuestAcceptPhaseUI.ts
@@ -19,10 +19,20 @@ import type Phaser from 'phaser';
 import type { Quest } from '../../../domain/entities/Quest';
 import { getSelectionIndexFromKey, isKeyForAction } from '../../../shared/constants/keybindings';
 import { GameEventType } from '../../../shared/types/events';
+import type { RexScrollablePanel } from '../../types/rexui';
 import { BaseComponent } from '../components/BaseComponent';
 import { QuestCardUI } from '../components/QuestCardUI';
 import { QuestDetailModal } from '../components/QuestDetailModal';
 import { AnimationPresets } from '../utils/AnimationPresets';
+
+/**
+ * テスト用モックScrollablePanel型
+ * TASK-0059: rexUI型定義と互換性を持つモック型
+ */
+interface MockScrollablePanel {
+  childOuter: Phaser.GameObjects.Container[];
+  destroy: () => void;
+}
 
 /**
  * EventBusインターフェース
@@ -53,10 +63,9 @@ export class QuestAcceptPhaseUI extends BaseComponent {
 
   /**
    * 受注済みリスト（ScrollablePanel）
-   * 【型安全性】: rexUIプラグインは型定義が複雑なため、anyで扱う
+   * TASK-0059: rexUI型定義を適用（モック互換のユニオン型）
    */
-  // biome-ignore lint/suspicious/noExplicitAny: rexUIプラグインは型定義が複雑なため、anyで扱う
-  private acceptedList: any;
+  private acceptedList: RexScrollablePanel | MockScrollablePanel | null = null;
 
   /** 受注済み依頼のコンテナ（UIコンテナを保持） */
   private acceptedQuestsContainer: Phaser.GameObjects.Container[] = [];

--- a/atelier-guild-rank/src/presentation/ui/scenes/components/shop/ShopHeader.ts
+++ b/atelier-guild-rank/src/presentation/ui/scenes/components/shop/ShopHeader.ts
@@ -9,6 +9,7 @@
  * - 戻るボタン
  */
 
+import type { RexLabel } from '@presentation/types/rexui';
 import { BaseComponent } from '@presentation/ui/components/BaseComponent';
 import { Colors, THEME } from '@presentation/ui/theme';
 import type Phaser from 'phaser';
@@ -34,9 +35,11 @@ export class ShopHeader extends BaseComponent {
   /** オプション */
   private options: ShopHeaderOptions;
 
-  /** 戻るボタン */
-  // biome-ignore lint/suspicious/noExplicitAny: rexUIのラベルコンポーネント
-  private backButton: any = null;
+  /**
+   * 戻るボタン
+   * TASK-0059: rexUI型定義を適用
+   */
+  private backButton: RexLabel | null = null;
 
   /**
    * コンストラクタ

--- a/atelier-guild-rank/src/presentation/ui/scenes/components/shop/ShopItemCard.ts
+++ b/atelier-guild-rank/src/presentation/ui/scenes/components/shop/ShopItemCard.ts
@@ -9,6 +9,7 @@
  * - ホバーエフェクト
  */
 
+import type { RexLabel } from '@presentation/types/rexui';
 import { BaseComponent } from '@presentation/ui/components/BaseComponent';
 import { Colors, THEME } from '@presentation/ui/theme';
 import { AnimationPresets, UIBackgroundBuilder } from '@presentation/ui/utils';
@@ -36,9 +37,11 @@ export class ShopItemCard extends BaseComponent {
   /** 購入コールバック */
   private onPurchase: OnPurchaseCallback;
 
-  /** 購入ボタン */
-  // biome-ignore lint/suspicious/noExplicitAny: rexUIのラベルコンポーネント
-  private purchaseButton: any = null;
+  /**
+   * 購入ボタン
+   * TASK-0059: rexUI型定義を適用
+   */
+  private purchaseButton: RexLabel | null = null;
 
   /** カード背景 */
   private background: Phaser.GameObjects.Graphics | null = null;

--- a/atelier-guild-rank/src/presentation/ui/scenes/components/title/TitleDialog.ts
+++ b/atelier-guild-rank/src/presentation/ui/scenes/components/title/TitleDialog.ts
@@ -9,6 +9,7 @@
  * - エラーダイアログ（OKのみ）
  */
 
+import type { RexDialog, RexLabel } from '@presentation/types/rexui';
 import { BaseComponent } from '@presentation/ui/components/BaseComponent';
 import { THEME } from '@presentation/ui/theme';
 import type Phaser from 'phaser';
@@ -38,9 +39,11 @@ export class TitleDialog extends BaseComponent {
   /** オーバーレイ */
   private overlay: Phaser.GameObjects.Rectangle | null = null;
 
-  /** ダイアログ参照 */
-  // biome-ignore lint/suspicious/noExplicitAny: rexUI Dialogコンポーネントの型は複雑なため
-  private dialog: any | null = null;
+  /**
+   * ダイアログ参照
+   * TASK-0059: rexUI型定義を適用
+   */
+  private dialog: RexDialog | null = null;
 
   /** クローズ済みフラグ */
   private isClosed = false;
@@ -142,8 +145,8 @@ export class TitleDialog extends BaseComponent {
       color: THEME.colors.textOnPrimary,
     });
 
-    // アクションボタン
-    const actionButtons = this.createActionButtons();
+    // アクションボタン（nullを除外）
+    const actionButtons = this.createActionButtons().filter((btn): btn is RexLabel => btn !== null);
 
     // ダイアログ
     this.dialog = this.rexUI.add.dialog({
@@ -196,9 +199,9 @@ export class TitleDialog extends BaseComponent {
 
   /**
    * アクションボタンを作成
+   * TASK-0059: rexUI型定義を適用
    */
-  // biome-ignore lint/suspicious/noExplicitAny: rexUI Labelコンポーネントの型は複雑なため
-  private createActionButtons(): any[] {
+  private createActionButtons(): Array<RexLabel | null> {
     if (this.config.type === 'confirm') {
       // 確認ダイアログ: はい/いいえ
       return [
@@ -223,13 +226,9 @@ export class TitleDialog extends BaseComponent {
 
   /**
    * ボタンを作成
+   * TASK-0059: rexUI型定義を適用
    */
-  private createButton(
-    text: string,
-    color: number,
-    onClick: () => void,
-    // biome-ignore lint/suspicious/noExplicitAny: rexUI Labelコンポーネントの型は複雑なため
-  ): any {
+  private createButton(text: string, color: number, onClick: () => void): RexLabel | null {
     if (!this.rexUI) {
       return null;
     }

--- a/atelier-guild-rank/src/presentation/ui/scenes/components/title/TitleMenu.ts
+++ b/atelier-guild-rank/src/presentation/ui/scenes/components/title/TitleMenu.ts
@@ -9,6 +9,7 @@
  * - 設定ボタン
  */
 
+import type { RexLabel } from '@presentation/types/rexui';
 import { BaseComponent } from '@presentation/ui/components/BaseComponent';
 import { THEME } from '@presentation/ui/theme';
 import type Phaser from 'phaser';
@@ -29,13 +30,17 @@ export class TitleMenu extends BaseComponent {
   /** メニュー設定 */
   private config: ITitleMenuConfig;
 
-  /** ボタン参照（破棄時に使用） */
-  // biome-ignore lint/suspicious/noExplicitAny: rexUI Labelコンポーネントの型は複雑なため
-  private buttons: any[] = [];
+  /**
+   * ボタン参照（破棄時に使用）
+   * TASK-0059: rexUI型定義を適用
+   */
+  private buttons: RexLabel[] = [];
 
-  /** コンティニューボタン参照 */
-  // biome-ignore lint/suspicious/noExplicitAny: rexUI Labelコンポーネントの型は複雑なため
-  private continueButton: any | null = null;
+  /**
+   * コンティニューボタン参照
+   * TASK-0059: rexUI型定義を適用
+   */
+  private continueButton: RexLabel | null = null;
 
   /**
    * コンストラクタ
@@ -69,7 +74,9 @@ export class TitleMenu extends BaseComponent {
       THEME.colors.primary,
       () => this.handleNewGameClick(),
     );
-    this.buttons.push(newGameButton);
+    if (newGameButton) {
+      this.buttons.push(newGameButton);
+    }
 
     // コンティニューボタン
     this.continueButton = this.createButton(
@@ -79,10 +86,12 @@ export class TitleMenu extends BaseComponent {
       THEME.colors.primary,
       () => this.handleContinueClick(),
     );
-    if (!this.config.hasSaveData) {
-      this.continueButton.setAlpha(TITLE_ANIMATION.DISABLED_ALPHA);
+    if (this.continueButton) {
+      if (!this.config.hasSaveData) {
+        this.continueButton.setAlpha(TITLE_ANIMATION.DISABLED_ALPHA);
+      }
+      this.buttons.push(this.continueButton);
     }
-    this.buttons.push(this.continueButton);
 
     // 設定ボタン
     const settingsButton = this.createButton(
@@ -92,11 +101,14 @@ export class TitleMenu extends BaseComponent {
       THEME.colors.secondary,
       () => this.handleSettingsClick(),
     );
-    this.buttons.push(settingsButton);
+    if (settingsButton) {
+      this.buttons.push(settingsButton);
+    }
   }
 
   /**
    * ボタンを生成する共通メソッド
+   * TASK-0059: rexUI型定義を適用
    * @param x X座標
    * @param y Y座標
    * @param text ボタンテキスト
@@ -110,8 +122,7 @@ export class TitleMenu extends BaseComponent {
     text: string,
     backgroundColor: number,
     onClick: () => void,
-    // biome-ignore lint/suspicious/noExplicitAny: rexUI Labelコンポーネントの型は複雑なため
-  ): any {
+  ): RexLabel | null {
     if (!this.rexUI) {
       console.warn('TitleMenu: rexUI is not available');
       return null;


### PR DESCRIPTION
## Summary
- 既存コードのany型をrexUI型定義（`rexui.d.ts`）で置き換え
- QuestAcceptPhaseUI, AlchemyPhaseUI, RecipeListUI, TitleDialog, TitleMenu, ShopHeader, ShopItemCard の8箇所以上で型安全性を向上
- TypeScriptコンパイルエラーなし、全テスト通過（1595テスト）

## Changes
- `QuestAcceptPhaseUI.ts`: `acceptedList` に `RexScrollablePanel | MockScrollablePanel` 型を適用
- `AlchemyPhaseUI.ts` / `RecipeListUI.ts`: `RecipeLabelInfo` インターフェースに `RexLabel` / `RexRoundRectangle` 型を適用
- `TitleDialog.ts`: `dialog` に `RexDialog` 型、`createButton` に `RexLabel` 型を適用
- `TitleMenu.ts`: `buttons` / `continueButton` / `createButton` に `RexLabel` 型を適用
- `ShopHeader.ts` / `ShopItemCard.ts`: `backButton` / `purchaseButton` に `RexLabel` 型を適用

## Test plan
- [x] TypeScriptコンパイルエラーがないこと (`pnpm tsc --noEmit`)
- [x] 全テストが通過すること (`pnpm test`)
- [x] ビルドが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)