### PR TITLE
feat: Feature-Based Architecture用のパスエイリアスを追加

### DIFF
--- a/atelier-guild-rank/tsconfig.json
+++ b/atelier-guild-rank/tsconfig.json
@@ -30,7 +30,9 @@
       "@application/*": ["src/application/*"],
       "@infrastructure/*": ["src/infrastructure/*"],
       "@presentation/*": ["src/presentation/*"],
-      "@shared/*": ["src/shared/*"]
+      "@shared/*": ["src/shared/*"],
+      "@features/*": ["src/features/*"],
+      "@scenes/*": ["src/scenes/*"]
     }
   },
   "include": ["src"],

--- a/atelier-guild-rank/vite.config.ts
+++ b/atelier-guild-rank/vite.config.ts
@@ -18,6 +18,8 @@ export default defineConfig(({ mode }) => ({
       '@infrastructure': path.resolve(__dirname, './src/infrastructure'),
       '@presentation': path.resolve(__dirname, './src/presentation'),
       '@shared': path.resolve(__dirname, './src/shared'),
+      '@features': path.resolve(__dirname, './src/features'),
+      '@scenes': path.resolve(__dirname, './src/scenes'),
     },
   },
   build: {

--- a/atelier-guild-rank/vitest.config.ts
+++ b/atelier-guild-rank/vitest.config.ts
@@ -31,6 +31,8 @@ export default defineConfig({
       '@infrastructure': path.resolve(__dirname, './src/infrastructure'),
       '@presentation': path.resolve(__dirname, './src/presentation'),
       '@shared': path.resolve(__dirname, './src/shared'),
+      '@features': path.resolve(__dirname, './src/features'),
+      '@scenes': path.resolve(__dirname, './src/scenes'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- tsconfig.jsonに`@features/*`と`@scenes/*`エイリアスを追加
- vite.config.tsに`@features`と`@scenes`エイリアスを追加
- vitest.config.tsに`@features`と`@scenes`エイリアスを追加

## Test plan
- [x] TypeScriptコンパイル成功（`pnpm tsc --noEmit`）
- [x] ビルド成功（`pnpm build`）
- [x] 全テスト成功（1595件）

## Related
- TASK-0062: tsconfigパスエイリアス設定更新
- 依存: TASK-0061（完了済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)