### PR TITLE
refactor: features/inventory/typesにインベントリ機能の型定義を作成（TASK-0084）

### DIFF
--- a/atelier-guild-rank/src/features/inventory/types/index.ts
+++ b/atelier-guild-rank/src/features/inventory/types/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Inventory Types - インベントリ機能の型定義バレルエクスポート
+ *
+ * TASK-0084: features/inventory/types作成
+ */
+
+// --- アイテム関連型 ---
+export type { IItem, IItemEffect } from './item';
+export { ItemInstance } from './item';
+
+// --- 素材関連型 ---
+export type { IMaterial, IMaterialInstance } from './material';
+export { MaterialInstance } from './material';
+
+// --- サービスインターフェース ---
+export type { IInventoryService, IMaterialService } from './service-interfaces';

--- a/atelier-guild-rank/src/features/inventory/types/item.ts
+++ b/atelier-guild-rank/src/features/inventory/types/item.ts
@@ -1,0 +1,11 @@
+/**
+ * item.ts - アイテム関連の型定義
+ *
+ * TASK-0084: features/inventory/types作成
+ *
+ * shared/typesのアイテム型とdomain/entitiesのItemInstanceクラスを
+ * 再エクスポートし、features/inventory経由でアクセスできるようにする。
+ */
+
+export { ItemInstance } from '@domain/entities/ItemInstance';
+export type { IItem, IItemEffect } from '@shared/types/materials';

--- a/atelier-guild-rank/src/features/inventory/types/material.ts
+++ b/atelier-guild-rank/src/features/inventory/types/material.ts
@@ -1,0 +1,11 @@
+/**
+ * material.ts - 素材関連の型定義
+ *
+ * TASK-0084: features/inventory/types作成
+ *
+ * shared/typesの素材型とdomain/entitiesのMaterialInstanceクラスを
+ * 再エクスポートし、features/inventory経由でアクセスできるようにする。
+ */
+
+export { MaterialInstance } from '@domain/entities/MaterialInstance';
+export type { IMaterial, IMaterialInstance } from '@shared/types';

--- a/atelier-guild-rank/src/features/inventory/types/service-interfaces.ts
+++ b/atelier-guild-rank/src/features/inventory/types/service-interfaces.ts
@@ -1,0 +1,11 @@
+/**
+ * service-interfaces.ts - サービスインターフェース定義
+ *
+ * TASK-0084: features/inventory/types作成
+ *
+ * domain/interfacesのIInventoryService, IMaterialServiceを
+ * 再エクスポートし、features/inventory経由でアクセスできるようにする。
+ */
+
+export type { IInventoryService } from '@domain/interfaces/inventory-service.interface';
+export type { IMaterialService } from '@domain/interfaces/material-service.interface';

--- a/atelier-guild-rank/tests/unit/features/inventory/types/inventory-types.test.ts
+++ b/atelier-guild-rank/tests/unit/features/inventory/types/inventory-types.test.ts
@@ -1,0 +1,139 @@
+/**
+ * inventory-types.test.ts - features/inventory/types エクスポートテスト
+ *
+ * TASK-0084: features/inventory/types作成
+ * 型定義が正しくエクスポートされていることを確認する
+ */
+
+import type {
+  IInventoryService,
+  IItem,
+  IItemEffect,
+  IMaterial,
+  IMaterialInstance,
+  IMaterialService,
+  ItemInstance,
+  MaterialInstance,
+} from '@features/inventory/types';
+import {
+  Attribute,
+  ItemCategory,
+  ItemEffectType,
+  Quality,
+  toItemId,
+  toMaterialId,
+} from '@shared/types';
+import { describe, expect, it } from 'vitest';
+
+describe('features/inventory/types', () => {
+  describe('MaterialInstance型', () => {
+    it('@features/inventory/typesからMaterialInstanceがインポートできること', () => {
+      const _typeCheck: MaterialInstance | undefined = undefined;
+      expect(_typeCheck).toBeUndefined();
+    });
+  });
+
+  describe('ItemInstance型', () => {
+    it('@features/inventory/typesからItemInstanceがインポートできること', () => {
+      const _typeCheck: ItemInstance | undefined = undefined;
+      expect(_typeCheck).toBeUndefined();
+    });
+  });
+
+  describe('IMaterial型', () => {
+    it('IMaterialオブジェクトを作成できること', () => {
+      const material: IMaterial = {
+        id: toMaterialId('mat-001'),
+        name: 'テスト素材',
+        baseQuality: Quality.C,
+        attributes: [Attribute.FIRE],
+      };
+      expect(material.id).toBe('mat-001');
+      expect(material.name).toBe('テスト素材');
+      expect(material.baseQuality).toBe(Quality.C);
+      expect(material.attributes).toContain(Attribute.FIRE);
+    });
+
+    it('descriptionがオプションであること', () => {
+      const material: IMaterial = {
+        id: toMaterialId('mat-002'),
+        name: '説明付き素材',
+        baseQuality: Quality.B,
+        attributes: [],
+        description: 'これはテスト素材です',
+      };
+      expect(material.description).toBe('これはテスト素材です');
+    });
+  });
+
+  describe('IMaterialInstance型', () => {
+    it('IMaterialInstanceオブジェクトを作成できること', () => {
+      const instance: IMaterialInstance = {
+        materialId: toMaterialId('mat-001'),
+        quality: Quality.B,
+        quantity: 3,
+      };
+      expect(instance.materialId).toBe('mat-001');
+      expect(instance.quality).toBe(Quality.B);
+      expect(instance.quantity).toBe(3);
+    });
+  });
+
+  describe('IItem型', () => {
+    it('IItemオブジェクトを作成できること', () => {
+      const item: IItem = {
+        id: toItemId('item-001'),
+        name: 'テストアイテム',
+        category: ItemCategory.MEDICINE,
+        effects: [{ type: ItemEffectType.HP_RECOVERY, baseValue: 50 }],
+      };
+      expect(item.id).toBe('item-001');
+      expect(item.name).toBe('テストアイテム');
+      expect(item.category).toBe(ItemCategory.MEDICINE);
+      expect(item.effects).toHaveLength(1);
+    });
+
+    it('descriptionがオプションであること', () => {
+      const item: IItem = {
+        id: toItemId('item-002'),
+        name: '説明付きアイテム',
+        category: ItemCategory.WEAPON,
+        effects: [],
+        description: 'テスト用のアイテム',
+      };
+      expect(item.description).toBe('テスト用のアイテム');
+    });
+  });
+
+  describe('IItemEffect型', () => {
+    it('IItemEffectオブジェクトを作成できること', () => {
+      const effect: IItemEffect = {
+        type: ItemEffectType.ATTACK_UP,
+        baseValue: 30,
+      };
+      expect(effect.type).toBe(ItemEffectType.ATTACK_UP);
+      expect(effect.baseValue).toBe(30);
+    });
+  });
+
+  describe('IInventoryService型', () => {
+    it('@features/inventory/typesからIInventoryServiceがインポートできること', () => {
+      const _typeCheck: IInventoryService | undefined = undefined;
+      expect(_typeCheck).toBeUndefined();
+    });
+  });
+
+  describe('IMaterialService型', () => {
+    it('@features/inventory/typesからIMaterialServiceがインポートできること', () => {
+      const _typeCheck: IMaterialService | undefined = undefined;
+      expect(_typeCheck).toBeUndefined();
+    });
+  });
+
+  describe('index.tsバレルエクスポート', () => {
+    it('すべての型が@features/inventory/typesから一括インポートできること', async () => {
+      const mod = await import('@features/inventory/types');
+      expect(mod).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- features/inventory/types/ にインベントリ機能の型定義を集約
- MaterialInstance, ItemInstance型の移行
- IInventoryService, IMaterialServiceインターフェースの移行
- バレルエクスポート(index.ts)の整備

## Test plan
- [ ] inventory types のエクスポート確認テスト通過（11テスト）
- [ ] pnpm lint エラーなし
- [ ] 既存テストへの影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)