### PR TITLE
fix: alchemy typesテストの未使用importを削除

### DIFF
--- a/atelier-guild-rank/tests/unit/features/alchemy/types/index.test.ts
+++ b/atelier-guild-rank/tests/unit/features/alchemy/types/index.test.ts
@@ -13,7 +13,7 @@ import type {
   RecipeCheckResult,
 } from '@features/alchemy/types';
 import { QUALITY_THRESHOLDS } from '@features/alchemy/types';
-import type { CardId, MaterialId, Quality } from '@shared/types';
+import type { Quality } from '@shared/types';
 import { describe, expect, it } from 'vitest';
 
 describe('features/alchemy/types', () => {


### PR DESCRIPTION
## Summary
- `tests/unit/features/alchemy/types/index.test.ts` から未使用の `CardId`, `MaterialId` importを削除
- PR #154 マージ時に含まれなかった修正

## Test plan
- [ ] biome-check パス
- [ ] typecheck パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)