### PR TITLE
fix: alchemy/componentsレビュー指摘のTODOコメント追加

### DIFF
--- a/atelier-guild-rank/src/features/alchemy/components/AlchemyPhaseUI.ts
+++ b/atelier-guild-rank/src/features/alchemy/components/AlchemyPhaseUI.ts
@@ -7,6 +7,12 @@
  * レシピ選択、素材配置、品質プレビュー、調合実行を管理する。
  *
  * TODO(TASK-0078): 601行 > 300行上限。レシピリスト・素材スロット・品質プレビューに分割を検討
+ *
+ * TODO(Phase 11): @domain/依存（ItemInstance, MaterialInstance, IAlchemyService）を
+ * @features/または@shared/types経由に置き換える。UIコンポーネントはdomain層に直接依存すべきでない。
+ *
+ * TODO(Phase 11): createRecipeLabel, setLabelPosition, setupLabelInteractionが
+ * RecipeListUIと重複している。共通ヘルパー（recipe-label-factory.ts等）に抽出を検討する。
  */
 
 import type { ItemInstance } from '@domain/entities/ItemInstance';

--- a/atelier-guild-rank/src/features/alchemy/components/RecipeListUI.ts
+++ b/atelier-guild-rank/src/features/alchemy/components/RecipeListUI.ts
@@ -5,6 +5,9 @@
  * @description
  * レシピリストを縦方向に表示するUIコンポーネント。
  * 選択状態のハイライト表示とコールバック通知を実装。
+ *
+ * TODO(Phase 11): createRecipeLabel, setLabelPosition, setupLabelInteractionが
+ * AlchemyPhaseUIと重複している。共通ヘルパー（recipe-label-factory.ts等）に抽出を検討する。
  */
 
 import type { RexLabel, RexRoundRectangle } from '@presentation/types/rexui';


### PR DESCRIPTION
## Summary
- AlchemyPhaseUI.tsに@domain/依存のPhase 11向けTODOコメントを追加
- AlchemyPhaseUI.ts, RecipeListUI.tsにcreateRecipeLabel等の重複コードの共通化TODOを追加
- devils-advocateのHIGH指摘への対応（コメント追加による追跡）

## Test plan
- [x] alchemy関連テスト70件全て成功
- [x] Biome lint通過
- [x] TypeScript型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)