### PR TITLE
refactor: rank/components UIコンポーネントとindex.ts作成（TASK-0093）

### DIFF
--- a/atelier-guild-rank/src/features/rank/components/PromotionDialog.ts
+++ b/atelier-guild-rank/src/features/rank/components/PromotionDialog.ts
@@ -1,0 +1,164 @@
+/**
+ * PromotionDialog コンポーネント
+ * TASK-0093: features/rank/components作成
+ *
+ * 昇格時のダイアログを表示するコンポーネント。
+ * 新ランク情報、ボーナス報酬、解放される特殊ルールを表示する。
+ */
+
+import { BaseComponent } from '@shared/components';
+import { Colors, THEME } from '@shared/theme';
+import type { GuildRank } from '@shared/types';
+import type { ISpecialRule } from '@shared/types/master-data';
+import type Phaser from 'phaser';
+
+// =============================================================================
+// 定数
+// =============================================================================
+
+/** ダイアログ寸法 */
+const DIALOG = {
+  WIDTH: 400,
+  HEIGHT: 300,
+  PADDING: 20,
+} as const;
+
+/** テキストスタイル */
+const TEXT_STYLES = {
+  TITLE: { fontSize: `${THEME.sizes.xlarge}px`, color: '#ffd700', fontStyle: 'bold' },
+  RANK: { fontSize: `${THEME.sizes.large}px`, color: '#ffffff' },
+  BONUS: { fontSize: `${THEME.sizes.medium}px`, color: '#44ff44' },
+  RULE_HEADER: { fontSize: `${THEME.sizes.medium}px`, color: '#ffffff' },
+  RULE_ITEM: { fontSize: `${THEME.sizes.small}px`, color: '#cccccc' },
+} as const;
+
+/** レイアウトオフセット */
+const OFFSET = {
+  TITLE_Y: -110,
+  RANK_Y: -60,
+  BONUS_Y: -20,
+  RULES_HEADER_Y: 20,
+  RULES_START_Y: 50,
+  RULE_LINE_HEIGHT: 22,
+} as const;
+
+// =============================================================================
+// 型定義
+// =============================================================================
+
+/** PromotionDialogの設定 */
+export interface PromotionDialogConfig {
+  /** 昇格前のランク */
+  fromRank: GuildRank;
+  /** 昇格後のランク */
+  toRank: GuildRank;
+  /** ボーナス報酬（ゴールド） */
+  bonusGold: number;
+  /** 解放される特殊ルール */
+  unlockedRules?: readonly ISpecialRule[];
+}
+
+// =============================================================================
+// コンポーネント
+// =============================================================================
+
+/**
+ * 昇格ダイアログ
+ *
+ * ランク昇格時に表示されるダイアログ。
+ * 新ランク、ボーナス報酬、特殊ルールの解放情報を表示する。
+ */
+export class PromotionDialog extends BaseComponent {
+  private config: PromotionDialogConfig;
+  private created = false;
+
+  constructor(scene: Phaser.Scene, x: number, y: number, config: PromotionDialogConfig) {
+    super(scene, x, y);
+    if (!config) {
+      throw new Error('config is required');
+    }
+    this.config = config;
+  }
+
+  create(): void {
+    if (this.created) {
+      return;
+    }
+    this.created = true;
+
+    this.createBackground();
+    this.createTitle();
+    this.createRankDisplay();
+    this.createBonusDisplay();
+    this.createRulesDisplay();
+  }
+
+  destroy(): void {
+    this.container.destroy(true);
+  }
+
+  // ===========================================================================
+  // private
+  // ===========================================================================
+
+  private createBackground(): void {
+    const bg = this.scene.add.rectangle(
+      0,
+      0,
+      DIALOG.WIDTH,
+      DIALOG.HEIGHT,
+      Colors.background.primary,
+    );
+    bg.setStrokeStyle(2, Colors.border.gold);
+    this.container.add(bg);
+  }
+
+  private createTitle(): void {
+    const titleText = this.scene.add.text(0, OFFSET.TITLE_Y, '昇格おめでとう!', TEXT_STYLES.TITLE);
+    titleText.setOrigin(0.5);
+    this.container.add(titleText);
+  }
+
+  private createRankDisplay(): void {
+    const rankStr = `${this.config.fromRank} → ${this.config.toRank}`;
+    const rankText = this.scene.add.text(0, OFFSET.RANK_Y, rankStr, TEXT_STYLES.RANK);
+    rankText.setOrigin(0.5);
+    this.container.add(rankText);
+  }
+
+  private createBonusDisplay(): void {
+    const bonusStr = `ボーナス: ${this.config.bonusGold} G`;
+    const bonusText = this.scene.add.text(0, OFFSET.BONUS_Y, bonusStr, TEXT_STYLES.BONUS);
+    bonusText.setOrigin(0.5);
+    this.container.add(bonusText);
+  }
+
+  private createRulesDisplay(): void {
+    const rules = this.config.unlockedRules;
+    if (!rules || rules.length === 0) {
+      return;
+    }
+
+    const headerText = this.scene.add.text(
+      0,
+      OFFSET.RULES_HEADER_Y,
+      '解放された特殊ルール:',
+      TEXT_STYLES.RULE_HEADER,
+    );
+    headerText.setOrigin(0.5);
+    this.container.add(headerText);
+
+    for (let i = 0; i < rules.length; i++) {
+      const rule = rules[i];
+      if (!rule) continue;
+      const ruleText = this.scene.add.text(
+        0,
+        OFFSET.RULES_START_Y + i * OFFSET.RULE_LINE_HEIGHT,
+        `・${rule.description}`,
+        TEXT_STYLES.RULE_ITEM,
+      );
+      ruleText.setOrigin(0.5);
+      this.container.add(ruleText);
+    }
+  }
+}

--- a/atelier-guild-rank/src/features/rank/components/RankBadge.ts
+++ b/atelier-guild-rank/src/features/rank/components/RankBadge.ts
@@ -1,0 +1,150 @@
+/**
+ * RankBadge コンポーネント
+ * TASK-0093: features/rank/components作成
+ *
+ * ランクバッジ（ランクアイコンと名前）を表示するコンポーネント。
+ * 現在のギルドランクを視覚的に表現する。
+ */
+
+import { BaseComponent } from '@shared/components';
+import { Colors, THEME } from '@shared/theme';
+import type { GuildRank } from '@shared/types';
+import type Phaser from 'phaser';
+
+// =============================================================================
+// 定数
+// =============================================================================
+
+/** バッジ寸法 */
+const BADGE = {
+  SIZE: 48,
+  RADIUS: 8,
+} as const;
+
+/** テキストスタイル */
+const TEXT_STYLES = {
+  RANK: { fontSize: `${THEME.sizes.xlarge}px`, color: '#ffffff', fontStyle: 'bold' },
+  NAME: { fontSize: `${THEME.sizes.small}px`, color: '#cccccc' },
+} as const;
+
+/** ランクごとのバッジ色 */
+const RANK_BADGE_COLORS: Record<GuildRank, number> = {
+  G: 0x808080,
+  F: 0x6b8e23,
+  E: 0x2e8b57,
+  D: 0x4169e1,
+  C: 0x9932cc,
+  B: 0xdc143c,
+  A: 0xffd700,
+  S: 0xff1493,
+};
+
+/** ランク名称 */
+const RANK_NAMES: Record<GuildRank, string> = {
+  G: 'Gランク',
+  F: 'Fランク',
+  E: 'Eランク',
+  D: 'Dランク',
+  C: 'Cランク',
+  B: 'Bランク',
+  A: 'Aランク',
+  S: 'Sランク',
+};
+
+/** レイアウトオフセット */
+const OFFSET = {
+  NAME_Y: BADGE.SIZE / 2 + 8,
+} as const;
+
+// =============================================================================
+// 型定義
+// =============================================================================
+
+/** RankBadgeの設定 */
+export interface RankBadgeConfig {
+  /** 表示するランク */
+  rank: GuildRank;
+}
+
+// =============================================================================
+// コンポーネント
+// =============================================================================
+
+/**
+ * ランクバッジ
+ *
+ * ギルドランクをアイコンとテキストで表示する。
+ * ランクに応じた色でバッジが表示される。
+ */
+export class RankBadge extends BaseComponent {
+  private config: RankBadgeConfig;
+  private created = false;
+  private badgeBg!: Phaser.GameObjects.Rectangle;
+  private rankText!: Phaser.GameObjects.Text;
+  private nameText!: Phaser.GameObjects.Text;
+
+  constructor(scene: Phaser.Scene, x: number, y: number, config: RankBadgeConfig) {
+    super(scene, x, y);
+    if (!config) {
+      throw new Error('config is required');
+    }
+    this.config = config;
+  }
+
+  create(): void {
+    if (this.created) {
+      return;
+    }
+    this.created = true;
+
+    this.createBadge();
+    this.createNameLabel();
+  }
+
+  destroy(): void {
+    this.container.destroy(true);
+  }
+
+  /** ランクを更新 */
+  updateRank(rank: GuildRank): void {
+    this.config.rank = rank;
+    if (this.badgeBg) {
+      this.badgeBg.setFillStyle(RANK_BADGE_COLORS[rank] ?? Colors.ui.button.normal);
+    }
+    if (this.rankText) {
+      this.rankText.setText(rank);
+    }
+    if (this.nameText) {
+      this.nameText.setText(RANK_NAMES[rank] ?? rank);
+    }
+  }
+
+  // ===========================================================================
+  // private
+  // ===========================================================================
+
+  private createBadge(): void {
+    // バッジ背景
+    this.badgeBg = this.scene.add.rectangle(
+      0,
+      0,
+      BADGE.SIZE,
+      BADGE.SIZE,
+      RANK_BADGE_COLORS[this.config.rank] ?? Colors.ui.button.normal,
+    );
+    this.badgeBg.setStrokeStyle(2, Colors.border.gold);
+    this.container.add(this.badgeBg);
+
+    // ランク文字
+    this.rankText = this.scene.add.text(0, 0, this.config.rank, TEXT_STYLES.RANK);
+    this.rankText.setOrigin(0.5);
+    this.container.add(this.rankText);
+  }
+
+  private createNameLabel(): void {
+    const name = RANK_NAMES[this.config.rank] ?? this.config.rank;
+    this.nameText = this.scene.add.text(0, OFFSET.NAME_Y, name, TEXT_STYLES.NAME);
+    this.nameText.setOrigin(0.5, 0);
+    this.container.add(this.nameText);
+  }
+}

--- a/atelier-guild-rank/src/features/rank/components/RankProgressBar.ts
+++ b/atelier-guild-rank/src/features/rank/components/RankProgressBar.ts
@@ -1,0 +1,181 @@
+/**
+ * RankProgressBar コンポーネント
+ * TASK-0093: features/rank/components作成
+ *
+ * ランク進捗バーを表示するコンポーネント。
+ * 現在の貢献度と昇格に必要な貢献度をバーで可視化する。
+ */
+
+import { BaseComponent } from '@shared/components';
+import { Colors, THEME } from '@shared/theme';
+import type { GuildRank } from '@shared/types';
+import type Phaser from 'phaser';
+
+// =============================================================================
+// 定数
+// =============================================================================
+
+/** バー寸法 */
+const BAR = {
+  WIDTH: 300,
+  HEIGHT: 24,
+  RADIUS: 4,
+  PADDING: 2,
+} as const;
+
+/** テキストスタイル */
+const TEXT_STYLES = {
+  LABEL: { fontSize: `${THEME.sizes.small}px`, color: '#ffffff' },
+  GAUGE: { fontSize: `${THEME.sizes.small}px`, color: '#ffffff' },
+} as const;
+
+/** ランクごとのバー色 */
+const RANK_COLORS: Record<GuildRank, number> = {
+  G: 0x808080,
+  F: 0x6b8e23,
+  E: 0x2e8b57,
+  D: 0x4169e1,
+  C: 0x9932cc,
+  B: 0xdc143c,
+  A: 0xffd700,
+  S: 0xff1493,
+};
+
+/** レイアウトオフセット */
+const OFFSET = {
+  LABEL_Y: -20,
+  GAUGE_Y: -20,
+} as const;
+
+// =============================================================================
+// 型定義
+// =============================================================================
+
+/** RankProgressBarの設定 */
+export interface RankProgressBarConfig {
+  /** 現在のランク */
+  rank: GuildRank;
+  /** 進捗率（0-100+） */
+  gaugePercent: number;
+  /** 表示ラベル（省略時は「昇格ゲージ」） */
+  label?: string;
+}
+
+// =============================================================================
+// コンポーネント
+// =============================================================================
+
+/**
+ * ランク進捗バー
+ *
+ * 昇格ゲージの進捗状況をバーで表示する。
+ * ランクに応じた色でバーが塗られる。
+ */
+export class RankProgressBar extends BaseComponent {
+  private config: RankProgressBarConfig;
+  private created = false;
+  private barBg!: Phaser.GameObjects.Rectangle;
+  private barFill!: Phaser.GameObjects.Rectangle;
+  private labelText!: Phaser.GameObjects.Text;
+  private gaugeText!: Phaser.GameObjects.Text;
+
+  constructor(scene: Phaser.Scene, x: number, y: number, config: RankProgressBarConfig) {
+    super(scene, x, y);
+    if (!config) {
+      throw new Error('config is required');
+    }
+    this.config = config;
+  }
+
+  create(): void {
+    if (this.created) {
+      return;
+    }
+    this.created = true;
+
+    this.createBar();
+    this.createLabels();
+    this.updateFill();
+  }
+
+  destroy(): void {
+    this.container.destroy(true);
+  }
+
+  /** 進捗を更新 */
+  updateProgress(gaugePercent: number, rank?: GuildRank): void {
+    this.config.gaugePercent = gaugePercent;
+    if (rank !== undefined) {
+      this.config.rank = rank;
+    }
+    this.updateFill();
+  }
+
+  // ===========================================================================
+  // private
+  // ===========================================================================
+
+  private createBar(): void {
+    // バー背景
+    this.barBg = this.scene.add.rectangle(
+      0,
+      0,
+      BAR.WIDTH,
+      BAR.HEIGHT,
+      Colors.ui.progress.background,
+    );
+    this.barBg.setStrokeStyle(1, Colors.border.primary);
+    this.container.add(this.barBg);
+
+    // バー塗り部分（初期幅0）
+    this.barFill = this.scene.add.rectangle(
+      -(BAR.WIDTH / 2) + BAR.PADDING,
+      0,
+      0,
+      BAR.HEIGHT - BAR.PADDING * 2,
+      this.getBarColor(),
+    );
+    this.barFill.setOrigin(0, 0.5);
+    this.container.add(this.barFill);
+  }
+
+  private createLabels(): void {
+    const label = this.config.label ?? '昇格ゲージ';
+
+    this.labelText = this.scene.add.text(
+      -(BAR.WIDTH / 2),
+      OFFSET.LABEL_Y,
+      label,
+      TEXT_STYLES.LABEL,
+    );
+    this.labelText.setOrigin(0, 1);
+    this.container.add(this.labelText);
+
+    this.gaugeText = this.scene.add.text(
+      BAR.WIDTH / 2,
+      OFFSET.GAUGE_Y,
+      `${Math.min(this.config.gaugePercent, 100)}%`,
+      TEXT_STYLES.GAUGE,
+    );
+    this.gaugeText.setOrigin(1, 1);
+    this.container.add(this.gaugeText);
+  }
+
+  private updateFill(): void {
+    const clampedPercent = Math.min(Math.max(this.config.gaugePercent, 0), 100);
+    const maxFillWidth = BAR.WIDTH - BAR.PADDING * 2;
+    const fillWidth = (clampedPercent / 100) * maxFillWidth;
+
+    if (this.barFill) {
+      this.barFill.setSize(fillWidth, BAR.HEIGHT - BAR.PADDING * 2);
+      this.barFill.setFillStyle(this.getBarColor());
+    }
+    if (this.gaugeText) {
+      this.gaugeText.setText(`${Math.min(this.config.gaugePercent, 100)}%`);
+    }
+  }
+
+  private getBarColor(): number {
+    return RANK_COLORS[this.config.rank] ?? Colors.ui.progress.fill;
+  }
+}

--- a/atelier-guild-rank/src/features/rank/components/SpecialRuleDisplay.ts
+++ b/atelier-guild-rank/src/features/rank/components/SpecialRuleDisplay.ts
@@ -1,0 +1,143 @@
+/**
+ * SpecialRuleDisplay コンポーネント
+ * TASK-0093: features/rank/components作成
+ *
+ * 特殊ルール一覧を表示するコンポーネント。
+ * 有効なルールのハイライト表示と説明文を提供する。
+ */
+
+import { BaseComponent } from '@shared/components';
+import { Colors, THEME } from '@shared/theme';
+import type { ISpecialRule } from '@shared/types/master-data';
+import type Phaser from 'phaser';
+
+// =============================================================================
+// 定数
+// =============================================================================
+
+/** パネル寸法 */
+const PANEL = {
+  WIDTH: 320,
+  ITEM_HEIGHT: 32,
+  PADDING: 8,
+} as const;
+
+/** テキストスタイル */
+const TEXT_STYLES = {
+  HEADER: { fontSize: `${THEME.sizes.medium}px`, color: '#ffffff', fontStyle: 'bold' },
+  RULE_ACTIVE: { fontSize: `${THEME.sizes.small}px`, color: '#ffffff' },
+  RULE_INACTIVE: { fontSize: `${THEME.sizes.small}px`, color: '#666666' },
+} as const;
+
+/** レイアウトオフセット */
+const OFFSET = {
+  HEADER_Y: 0,
+  RULES_START_Y: 30,
+} as const;
+
+// =============================================================================
+// 型定義
+// =============================================================================
+
+/** 表示用ルール情報 */
+export interface DisplayRule {
+  /** 特殊ルール */
+  rule: ISpecialRule;
+  /** 有効かどうか */
+  active: boolean;
+}
+
+/** SpecialRuleDisplayの設定 */
+export interface SpecialRuleDisplayConfig {
+  /** 表示するルール一覧 */
+  rules: readonly DisplayRule[];
+  /** ヘッダーテキスト（省略時は「特殊ルール」） */
+  header?: string;
+}
+
+// =============================================================================
+// コンポーネント
+// =============================================================================
+
+/**
+ * 特殊ルール表示
+ *
+ * ランクに適用される特殊ルールの一覧を表示する。
+ * 有効なルールはハイライト、無効なルールはグレーアウトされる。
+ */
+export class SpecialRuleDisplay extends BaseComponent {
+  private config: SpecialRuleDisplayConfig;
+  private created = false;
+
+  constructor(scene: Phaser.Scene, x: number, y: number, config: SpecialRuleDisplayConfig) {
+    super(scene, x, y);
+    if (!config) {
+      throw new Error('config is required');
+    }
+    this.config = config;
+  }
+
+  create(): void {
+    if (this.created) {
+      return;
+    }
+    this.created = true;
+
+    this.createHeader();
+    this.createRuleList();
+  }
+
+  destroy(): void {
+    this.container.destroy(true);
+  }
+
+  // ===========================================================================
+  // private
+  // ===========================================================================
+
+  private createHeader(): void {
+    const headerStr = this.config.header ?? '特殊ルール';
+    const headerText = this.scene.add.text(
+      -(PANEL.WIDTH / 2) + PANEL.PADDING,
+      OFFSET.HEADER_Y,
+      headerStr,
+      TEXT_STYLES.HEADER,
+    );
+    headerText.setOrigin(0, 0);
+    this.container.add(headerText);
+  }
+
+  private createRuleList(): void {
+    for (let i = 0; i < this.config.rules.length; i++) {
+      const displayRule = this.config.rules[i];
+      if (!displayRule) continue;
+      this.createRuleItem(displayRule, i);
+    }
+  }
+
+  private createRuleItem(displayRule: DisplayRule, index: number): void {
+    const y = OFFSET.RULES_START_Y + index * PANEL.ITEM_HEIGHT;
+
+    // アクティブインジケーター
+    const indicatorColor = displayRule.active ? Colors.text.success : Colors.text.muted;
+    const indicator = this.scene.add.rectangle(
+      -(PANEL.WIDTH / 2) + PANEL.PADDING,
+      y + PANEL.ITEM_HEIGHT / 2,
+      8,
+      8,
+      indicatorColor,
+    );
+    this.container.add(indicator);
+
+    // ルール説明テキスト
+    const style = displayRule.active ? TEXT_STYLES.RULE_ACTIVE : TEXT_STYLES.RULE_INACTIVE;
+    const ruleText = this.scene.add.text(
+      -(PANEL.WIDTH / 2) + PANEL.PADDING + 16,
+      y + PANEL.ITEM_HEIGHT / 2,
+      displayRule.rule.description,
+      style,
+    );
+    ruleText.setOrigin(0, 0.5);
+    this.container.add(ruleText);
+  }
+}

--- a/atelier-guild-rank/src/features/rank/components/index.ts
+++ b/atelier-guild-rank/src/features/rank/components/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Rank Components Module
+ * TASK-0093: features/rank/components作成
+ *
+ * ランク関連UIコンポーネントの公開エクスポート
+ */
+
+export type { PromotionDialogConfig } from './PromotionDialog';
+export { PromotionDialog } from './PromotionDialog';
+export type { RankBadgeConfig } from './RankBadge';
+export { RankBadge } from './RankBadge';
+export type { RankProgressBarConfig } from './RankProgressBar';
+export { RankProgressBar } from './RankProgressBar';
+export type { DisplayRule, SpecialRuleDisplayConfig } from './SpecialRuleDisplay';
+export { SpecialRuleDisplay } from './SpecialRuleDisplay';

--- a/atelier-guild-rank/src/features/rank/index.ts
+++ b/atelier-guild-rank/src/features/rank/index.ts
@@ -1,0 +1,76 @@
+/**
+ * @module features/rank
+ * @description ランク機能モジュール
+ *
+ * ギルドランクの進捗管理、昇格判定、貢献度計算、
+ * およびUI表示コンポーネントを提供する。
+ *
+ * TASK-0093: features/rank/index.ts公開API作成
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   calculateRankProgress,
+ *   checkPromotion,
+ *   calculateContribution,
+ *   RankProgressBar,
+ * } from '@features/rank';
+ *
+ * // ランク進捗計算
+ * const progress = calculateRankProgress('D', 150, rankMaster);
+ *
+ * // 昇格判定
+ * const canPromote = checkPromotion('D', 300, rankMaster);
+ *
+ * // 貢献度計算
+ * const result = calculateContribution(context);
+ * ```
+ */
+
+// =============================================================================
+// Types - ランク関連の型定義
+// =============================================================================
+
+export type {
+  IGuildRankMaster,
+  IPromotionRequirement,
+  IPromotionTest,
+  IRankService,
+  ISpecialRule,
+  PromotionResult,
+  PromotionTest,
+  PromotionTestRequirement,
+  RankProgress,
+} from './types';
+export { GuildRank, SpecialRuleType } from './types';
+
+// =============================================================================
+// Services - ランク関連のビジネスロジック（純粋関数）
+// =============================================================================
+
+export type { ContributionContext, ContributionResult, SpecialRuleEffect } from './services';
+export {
+  applySpecialRules,
+  calculateContribution,
+  calculatePromotionBonus,
+  calculateRankProgress,
+  checkPromotion,
+  getClientModifier,
+  getComboModifier,
+  getNextRank,
+  getQualityModifier,
+  getRankOrder,
+} from './services';
+
+// =============================================================================
+// Components - ランク関連UIコンポーネント
+// =============================================================================
+
+export type {
+  DisplayRule,
+  PromotionDialogConfig,
+  RankBadgeConfig,
+  RankProgressBarConfig,
+  SpecialRuleDisplayConfig,
+} from './components';
+export { PromotionDialog, RankBadge, RankProgressBar, SpecialRuleDisplay } from './components';

--- a/atelier-guild-rank/tests/unit/features/rank/components/rank-components.test.ts
+++ b/atelier-guild-rank/tests/unit/features/rank/components/rank-components.test.ts
@@ -1,0 +1,456 @@
+/**
+ * rank-components.test.ts - ランクUIコンポーネントテスト
+ * TASK-0093: features/rank/components作成
+ */
+
+import type { PromotionDialogConfig } from '@features/rank/components/PromotionDialog';
+import { PromotionDialog } from '@features/rank/components/PromotionDialog';
+import type { RankBadgeConfig } from '@features/rank/components/RankBadge';
+import { RankBadge } from '@features/rank/components/RankBadge';
+import type { RankProgressBarConfig } from '@features/rank/components/RankProgressBar';
+import { RankProgressBar } from '@features/rank/components/RankProgressBar';
+import type { SpecialRuleDisplayConfig } from '@features/rank/components/SpecialRuleDisplay';
+import { SpecialRuleDisplay } from '@features/rank/components/SpecialRuleDisplay';
+import { SpecialRuleType } from '@shared/types';
+import type { ISpecialRule } from '@shared/types/master-data';
+import type Phaser from 'phaser';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// =============================================================================
+// モックヘルパー
+// =============================================================================
+
+function createMockScene(): Phaser.Scene {
+  const mockContainer = {
+    setPosition: vi.fn().mockReturnThis(),
+    setVisible: vi.fn().mockReturnThis(),
+    add: vi.fn().mockReturnThis(),
+    destroy: vi.fn(),
+    x: 0,
+    y: 0,
+  };
+
+  const scene = {
+    add: {
+      container: vi.fn().mockReturnValue(mockContainer),
+      rectangle: vi.fn().mockReturnValue({
+        setOrigin: vi.fn().mockReturnThis(),
+        setStrokeStyle: vi.fn().mockReturnThis(),
+        setFillStyle: vi.fn().mockReturnThis(),
+        setSize: vi.fn().mockReturnThis(),
+        setInteractive: vi.fn().mockReturnThis(),
+        on: vi.fn().mockReturnThis(),
+        off: vi.fn().mockReturnThis(),
+        destroy: vi.fn(),
+      }),
+      text: vi.fn().mockReturnValue({
+        setOrigin: vi.fn().mockReturnThis(),
+        setWordWrapWidth: vi.fn().mockReturnThis(),
+        setText: vi.fn().mockReturnThis(),
+        destroy: vi.fn(),
+      }),
+    },
+    cameras: {
+      main: { width: 1280, height: 720 },
+    },
+    children: {
+      remove: vi.fn(),
+    },
+    rexUI: undefined,
+  } as unknown as Phaser.Scene;
+
+  return scene;
+}
+
+function createSpecialRule(
+  type: SpecialRuleType,
+  description: string,
+  value?: number,
+  condition?: string,
+): ISpecialRule {
+  return { type, description, value, condition } as ISpecialRule;
+}
+
+// =============================================================================
+// テスト
+// =============================================================================
+
+describe('features/rank/components', () => {
+  let mockScene: Phaser.Scene;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockScene = createMockScene();
+  });
+
+  // ===========================================================================
+  // RankProgressBar
+  // ===========================================================================
+
+  describe('RankProgressBar', () => {
+    it('正しい設定でインスタンスを生成できる', () => {
+      const config: RankProgressBarConfig = { rank: 'D', gaugePercent: 50 };
+      const bar = new RankProgressBar(mockScene, 0, 0, config);
+      expect(bar).toBeDefined();
+    });
+
+    it('configがnullの場合エラーを投げる', () => {
+      expect(
+        () => new RankProgressBar(mockScene, 0, 0, null as unknown as RankProgressBarConfig),
+      ).toThrow('config is required');
+    });
+
+    it('create()で進捗バーが表示される', () => {
+      const config: RankProgressBarConfig = { rank: 'D', gaugePercent: 50 };
+      const bar = new RankProgressBar(mockScene, 0, 0, config);
+      bar.create();
+
+      // バー背景とバー塗り部分の2つ + テキストの呼び出し
+      expect(mockScene.add.rectangle).toHaveBeenCalled();
+      expect(mockScene.add.text).toHaveBeenCalled();
+    });
+
+    it('進捗率に応じたテキストが表示される', () => {
+      const config: RankProgressBarConfig = { rank: 'D', gaugePercent: 75 };
+      const bar = new RankProgressBar(mockScene, 0, 0, config);
+      bar.create();
+
+      const textCalls = (mockScene.add.text as ReturnType<typeof vi.fn>).mock.calls;
+      const gaugeCall = textCalls.find(
+        (call: unknown[]) => typeof call[2] === 'string' && (call[2] as string).includes('75%'),
+      );
+      expect(gaugeCall).toBeDefined();
+    });
+
+    it('ランクに応じた色が適用される', () => {
+      const config: RankProgressBarConfig = { rank: 'A', gaugePercent: 80 };
+      const bar = new RankProgressBar(mockScene, 0, 0, config);
+      bar.create();
+
+      // rectangleが呼ばれている（色はRANK_COLORSから適用される）
+      expect(mockScene.add.rectangle).toHaveBeenCalled();
+    });
+
+    it('updateProgress()で進捗を更新できる', () => {
+      const config: RankProgressBarConfig = { rank: 'D', gaugePercent: 30 };
+      const bar = new RankProgressBar(mockScene, 0, 0, config);
+      bar.create();
+
+      expect(() => bar.updateProgress(80, 'C')).not.toThrow();
+    });
+
+    it('destroy()でリソースが解放される', () => {
+      const config: RankProgressBarConfig = { rank: 'D', gaugePercent: 50 };
+      const bar = new RankProgressBar(mockScene, 0, 0, config);
+      bar.create();
+      expect(() => bar.destroy()).not.toThrow();
+    });
+
+    it('create()を複数回呼んでもUIが重複しない', () => {
+      const config: RankProgressBarConfig = { rank: 'D', gaugePercent: 50 };
+      const bar = new RankProgressBar(mockScene, 0, 0, config);
+      bar.create();
+      const callCount = (mockScene.add.rectangle as ReturnType<typeof vi.fn>).mock.calls.length;
+      bar.create();
+      expect((mockScene.add.rectangle as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
+        callCount,
+      );
+    });
+  });
+
+  // ===========================================================================
+  // RankBadge
+  // ===========================================================================
+
+  describe('RankBadge', () => {
+    it('正しい設定でインスタンスを生成できる', () => {
+      const config: RankBadgeConfig = { rank: 'D' };
+      const badge = new RankBadge(mockScene, 0, 0, config);
+      expect(badge).toBeDefined();
+    });
+
+    it('configがnullの場合エラーを投げる', () => {
+      expect(() => new RankBadge(mockScene, 0, 0, null as unknown as RankBadgeConfig)).toThrow(
+        'config is required',
+      );
+    });
+
+    it('create()でバッジが表示される', () => {
+      const config: RankBadgeConfig = { rank: 'B' };
+      const badge = new RankBadge(mockScene, 0, 0, config);
+      badge.create();
+
+      // バッジ背景の四角形
+      expect(mockScene.add.rectangle).toHaveBeenCalled();
+    });
+
+    it('ランク文字が正しく表示される', () => {
+      const config: RankBadgeConfig = { rank: 'A' };
+      const badge = new RankBadge(mockScene, 0, 0, config);
+      badge.create();
+
+      const textCalls = (mockScene.add.text as ReturnType<typeof vi.fn>).mock.calls;
+      const rankCall = textCalls.find((call: unknown[]) => call[2] === 'A');
+      expect(rankCall).toBeDefined();
+    });
+
+    it('ランク名が正しく表示される', () => {
+      const config: RankBadgeConfig = { rank: 'S' };
+      const badge = new RankBadge(mockScene, 0, 0, config);
+      badge.create();
+
+      const textCalls = (mockScene.add.text as ReturnType<typeof vi.fn>).mock.calls;
+      const nameCall = textCalls.find(
+        (call: unknown[]) => typeof call[2] === 'string' && (call[2] as string).includes('Sランク'),
+      );
+      expect(nameCall).toBeDefined();
+    });
+
+    it('updateRank()でランクを更新できる', () => {
+      const config: RankBadgeConfig = { rank: 'D' };
+      const badge = new RankBadge(mockScene, 0, 0, config);
+      badge.create();
+
+      expect(() => badge.updateRank('A')).not.toThrow();
+    });
+
+    it('destroy()でリソースが解放される', () => {
+      const config: RankBadgeConfig = { rank: 'D' };
+      const badge = new RankBadge(mockScene, 0, 0, config);
+      badge.create();
+      expect(() => badge.destroy()).not.toThrow();
+    });
+  });
+
+  // ===========================================================================
+  // PromotionDialog
+  // ===========================================================================
+
+  describe('PromotionDialog', () => {
+    it('正しい設定でインスタンスを生成できる', () => {
+      const config: PromotionDialogConfig = {
+        fromRank: 'D',
+        toRank: 'C',
+        bonusGold: 400,
+      };
+      const dialog = new PromotionDialog(mockScene, 0, 0, config);
+      expect(dialog).toBeDefined();
+    });
+
+    it('configがnullの場合エラーを投げる', () => {
+      expect(
+        () => new PromotionDialog(mockScene, 0, 0, null as unknown as PromotionDialogConfig),
+      ).toThrow('config is required');
+    });
+
+    it('create()で昇格ダイアログが表示される', () => {
+      const config: PromotionDialogConfig = {
+        fromRank: 'D',
+        toRank: 'C',
+        bonusGold: 400,
+      };
+      const dialog = new PromotionDialog(mockScene, 0, 0, config);
+      dialog.create();
+
+      expect(mockScene.add.rectangle).toHaveBeenCalled();
+      expect(mockScene.add.text).toHaveBeenCalled();
+    });
+
+    it('新しいランク情報が表示される', () => {
+      const config: PromotionDialogConfig = {
+        fromRank: 'E',
+        toRank: 'D',
+        bonusGold: 300,
+      };
+      const dialog = new PromotionDialog(mockScene, 0, 0, config);
+      dialog.create();
+
+      const textCalls = (mockScene.add.text as ReturnType<typeof vi.fn>).mock.calls;
+      const rankCall = textCalls.find(
+        (call: unknown[]) =>
+          typeof call[2] === 'string' &&
+          (call[2] as string).includes('E') &&
+          (call[2] as string).includes('D'),
+      );
+      expect(rankCall).toBeDefined();
+    });
+
+    it('ボーナス報酬が表示される', () => {
+      const config: PromotionDialogConfig = {
+        fromRank: 'D',
+        toRank: 'C',
+        bonusGold: 500,
+      };
+      const dialog = new PromotionDialog(mockScene, 0, 0, config);
+      dialog.create();
+
+      const textCalls = (mockScene.add.text as ReturnType<typeof vi.fn>).mock.calls;
+      const bonusCall = textCalls.find(
+        (call: unknown[]) => typeof call[2] === 'string' && (call[2] as string).includes('500'),
+      );
+      expect(bonusCall).toBeDefined();
+    });
+
+    it('特殊ルール解放が表示される', () => {
+      const rules: ISpecialRule[] = [
+        createSpecialRule(SpecialRuleType.QUEST_LIMIT, '依頼数制限: 5件まで', 5),
+      ];
+      const config: PromotionDialogConfig = {
+        fromRank: 'D',
+        toRank: 'C',
+        bonusGold: 400,
+        unlockedRules: rules,
+      };
+      const dialog = new PromotionDialog(mockScene, 0, 0, config);
+      dialog.create();
+
+      const textCalls = (mockScene.add.text as ReturnType<typeof vi.fn>).mock.calls;
+      const ruleCall = textCalls.find(
+        (call: unknown[]) =>
+          typeof call[2] === 'string' && (call[2] as string).includes('依頼数制限'),
+      );
+      expect(ruleCall).toBeDefined();
+    });
+
+    it('特殊ルールが空の場合ルール表示をスキップする', () => {
+      const config: PromotionDialogConfig = {
+        fromRank: 'D',
+        toRank: 'C',
+        bonusGold: 400,
+        unlockedRules: [],
+      };
+      const dialog = new PromotionDialog(mockScene, 0, 0, config);
+      dialog.create();
+
+      const textCalls = (mockScene.add.text as ReturnType<typeof vi.fn>).mock.calls;
+      const headerCall = textCalls.find(
+        (call: unknown[]) =>
+          typeof call[2] === 'string' && (call[2] as string).includes('解放された特殊ルール'),
+      );
+      expect(headerCall).toBeUndefined();
+    });
+
+    it('destroy()でリソースが解放される', () => {
+      const config: PromotionDialogConfig = {
+        fromRank: 'D',
+        toRank: 'C',
+        bonusGold: 400,
+      };
+      const dialog = new PromotionDialog(mockScene, 0, 0, config);
+      dialog.create();
+      expect(() => dialog.destroy()).not.toThrow();
+    });
+  });
+
+  // ===========================================================================
+  // SpecialRuleDisplay
+  // ===========================================================================
+
+  describe('SpecialRuleDisplay', () => {
+    it('正しい設定でインスタンスを生成できる', () => {
+      const config: SpecialRuleDisplayConfig = { rules: [] };
+      const display = new SpecialRuleDisplay(mockScene, 0, 0, config);
+      expect(display).toBeDefined();
+    });
+
+    it('configがnullの場合エラーを投げる', () => {
+      expect(
+        () => new SpecialRuleDisplay(mockScene, 0, 0, null as unknown as SpecialRuleDisplayConfig),
+      ).toThrow('config is required');
+    });
+
+    it('create()で特殊ルール一覧が表示される', () => {
+      const config: SpecialRuleDisplayConfig = {
+        rules: [
+          {
+            rule: createSpecialRule(SpecialRuleType.QUEST_LIMIT, '依頼数制限', 3),
+            active: true,
+          },
+        ],
+      };
+      const display = new SpecialRuleDisplay(mockScene, 0, 0, config);
+      display.create();
+
+      expect(mockScene.add.text).toHaveBeenCalled();
+    });
+
+    it('有効なルールのテキストが表示される', () => {
+      const config: SpecialRuleDisplayConfig = {
+        rules: [
+          {
+            rule: createSpecialRule(SpecialRuleType.QUALITY_PENALTY, '品質ペナルティ', 0.8),
+            active: true,
+          },
+        ],
+      };
+      const display = new SpecialRuleDisplay(mockScene, 0, 0, config);
+      display.create();
+
+      const textCalls = (mockScene.add.text as ReturnType<typeof vi.fn>).mock.calls;
+      const ruleCall = textCalls.find(
+        (call: unknown[]) =>
+          typeof call[2] === 'string' && (call[2] as string).includes('品質ペナルティ'),
+      );
+      expect(ruleCall).toBeDefined();
+    });
+
+    it('無効なルールのテキストが表示される', () => {
+      const config: SpecialRuleDisplayConfig = {
+        rules: [
+          {
+            rule: createSpecialRule(SpecialRuleType.DEADLINE_REDUCTION, '期限短縮', 2),
+            active: false,
+          },
+        ],
+      };
+      const display = new SpecialRuleDisplay(mockScene, 0, 0, config);
+      display.create();
+
+      const textCalls = (mockScene.add.text as ReturnType<typeof vi.fn>).mock.calls;
+      const ruleCall = textCalls.find(
+        (call: unknown[]) =>
+          typeof call[2] === 'string' && (call[2] as string).includes('期限短縮'),
+      );
+      expect(ruleCall).toBeDefined();
+    });
+
+    it('有効なルールにインジケーターが表示される', () => {
+      const config: SpecialRuleDisplayConfig = {
+        rules: [
+          {
+            rule: createSpecialRule(SpecialRuleType.QUEST_LIMIT, 'テストルール', 3),
+            active: true,
+          },
+        ],
+      };
+      const display = new SpecialRuleDisplay(mockScene, 0, 0, config);
+      display.create();
+
+      // ヘッダーのrectangle呼び出しはないが、インジケーターのrectangleがある
+      expect(mockScene.add.rectangle).toHaveBeenCalled();
+    });
+
+    it('カスタムヘッダーが表示される', () => {
+      const config: SpecialRuleDisplayConfig = {
+        rules: [],
+        header: 'カスタムヘッダー',
+      };
+      const display = new SpecialRuleDisplay(mockScene, 0, 0, config);
+      display.create();
+
+      const textCalls = (mockScene.add.text as ReturnType<typeof vi.fn>).mock.calls;
+      const headerCall = textCalls.find(
+        (call: unknown[]) =>
+          typeof call[2] === 'string' && (call[2] as string).includes('カスタムヘッダー'),
+      );
+      expect(headerCall).toBeDefined();
+    });
+
+    it('destroy()でリソースが解放される', () => {
+      const config: SpecialRuleDisplayConfig = { rules: [] };
+      const display = new SpecialRuleDisplay(mockScene, 0, 0, config);
+      display.create();
+      expect(() => display.destroy()).not.toThrow();
+    });
+  });
+});

--- a/atelier-guild-rank/tests/unit/features/rank/components/rank-index.test.ts
+++ b/atelier-guild-rank/tests/unit/features/rank/components/rank-index.test.ts
@@ -1,0 +1,201 @@
+/**
+ * rank/index.ts - 公開APIテスト
+ * TASK-0093: features/rank/index.ts作成
+ */
+
+import type {
+  ContributionContext,
+  ContributionResult,
+  DisplayRule,
+  IGuildRankMaster,
+  IRankService,
+  ISpecialRule,
+  PromotionDialogConfig,
+  PromotionResult,
+  PromotionTest,
+  PromotionTestRequirement,
+  RankBadgeConfig,
+  RankProgress,
+  RankProgressBarConfig,
+  SpecialRuleDisplayConfig,
+  SpecialRuleEffect,
+} from '@features/rank';
+import {
+  applySpecialRules,
+  calculateContribution,
+  calculatePromotionBonus,
+  calculateRankProgress,
+  checkPromotion,
+  GuildRank,
+  getClientModifier,
+  getComboModifier,
+  getNextRank,
+  getQualityModifier,
+  getRankOrder,
+  PromotionDialog,
+  RankBadge,
+  RankProgressBar,
+  SpecialRuleDisplay,
+  SpecialRuleType,
+} from '@features/rank';
+import { describe, expect, it } from 'vitest';
+
+describe('features/rank/index.ts', () => {
+  describe('型エクスポート', () => {
+    it('RankProgress型がインポートできること', () => {
+      const progress: RankProgress = {
+        currentRank: 'D',
+        accumulatedContribution: 150,
+        requiredContribution: 300,
+        promotionGauge: 50,
+        remainingContribution: 150,
+        canPromote: false,
+        nextRank: 'C',
+      };
+      expect(progress.currentRank).toBe('D');
+    });
+
+    it('ContributionContext型がインポートできること', () => {
+      const context: ContributionContext = {
+        baseContribution: 100,
+        itemQuality: 'B',
+        clientType: 'VILLAGER',
+        deliveryCount: 1,
+      };
+      expect(context.baseContribution).toBe(100);
+    });
+
+    it('ContributionResult型がインポートできること', () => {
+      const result: ContributionResult = {
+        contribution: 100,
+        qualityModifier: 1.0,
+        clientModifier: 1.0,
+        comboModifier: 1.0,
+      };
+      expect(result.contribution).toBe(100);
+    });
+
+    it('SpecialRuleEffect型がインポートできること', () => {
+      const effect: SpecialRuleEffect = {
+        questLimit: null,
+        qualityPenalty: 1.0,
+        deadlineReduction: 0,
+        qualityRequired: null,
+      };
+      expect(effect.qualityPenalty).toBe(1.0);
+    });
+
+    it('コンポーネント設定型がインポートできること', () => {
+      const barConfig: RankProgressBarConfig = { rank: 'D', gaugePercent: 50 };
+      const badgeConfig: RankBadgeConfig = { rank: 'A' };
+      const dialogConfig: PromotionDialogConfig = {
+        fromRank: 'D',
+        toRank: 'C',
+        bonusGold: 400,
+      };
+      const displayConfig: SpecialRuleDisplayConfig = { rules: [] };
+      const displayRule: DisplayRule = {
+        rule: {
+          type: SpecialRuleType.QUEST_LIMIT,
+          description: 'テスト',
+          value: 3,
+        } as ISpecialRule,
+        active: true,
+      };
+
+      expect(barConfig.rank).toBe('D');
+      expect(badgeConfig.rank).toBe('A');
+      expect(dialogConfig.bonusGold).toBe(400);
+      expect(displayConfig.rules).toHaveLength(0);
+      expect(displayRule.active).toBe(true);
+    });
+
+    it('マスターデータ型がインポートできること', () => {
+      // 型のみの検証（コンパイルが通ればOK）
+      const _rankMaster: IGuildRankMaster | null = null;
+      const _specialRule: ISpecialRule | null = null;
+      const _rankService: IRankService | null = null;
+      const _promotionResult: PromotionResult | null = null;
+      const _promotionTest: PromotionTest | null = null;
+      const _promotionTestReq: PromotionTestRequirement | null = null;
+      expect(_rankMaster).toBeNull();
+      expect(_specialRule).toBeNull();
+      expect(_rankService).toBeNull();
+      expect(_promotionResult).toBeNull();
+      expect(_promotionTest).toBeNull();
+      expect(_promotionTestReq).toBeNull();
+    });
+  });
+
+  describe('列挙値エクスポート', () => {
+    it('GuildRankがエクスポートされていること', () => {
+      expect(GuildRank.G).toBe('G');
+      expect(GuildRank.S).toBe('S');
+    });
+
+    it('SpecialRuleTypeがエクスポートされていること', () => {
+      expect(SpecialRuleType.QUEST_LIMIT).toBe('QUEST_LIMIT');
+      expect(SpecialRuleType.QUALITY_PENALTY).toBe('QUALITY_PENALTY');
+    });
+  });
+
+  describe('サービス関数エクスポート', () => {
+    it('calculateRankProgressが使用できること', () => {
+      expect(typeof calculateRankProgress).toBe('function');
+    });
+
+    it('checkPromotionが使用できること', () => {
+      expect(typeof checkPromotion).toBe('function');
+    });
+
+    it('calculatePromotionBonusが使用できること', () => {
+      expect(typeof calculatePromotionBonus).toBe('function');
+    });
+
+    it('getNextRankが使用できること', () => {
+      expect(typeof getNextRank).toBe('function');
+    });
+
+    it('getRankOrderが使用できること', () => {
+      expect(typeof getRankOrder).toBe('function');
+    });
+
+    it('applySpecialRulesが使用できること', () => {
+      expect(typeof applySpecialRules).toBe('function');
+    });
+
+    it('calculateContributionが使用できること', () => {
+      expect(typeof calculateContribution).toBe('function');
+    });
+
+    it('getQualityModifierが使用できること', () => {
+      expect(typeof getQualityModifier).toBe('function');
+    });
+
+    it('getClientModifierが使用できること', () => {
+      expect(typeof getClientModifier).toBe('function');
+    });
+
+    it('getComboModifierが使用できること', () => {
+      expect(typeof getComboModifier).toBe('function');
+    });
+  });
+
+  describe('コンポーネントエクスポート', () => {
+    it('RankProgressBarがエクスポートされていること', () => {
+      expect(RankProgressBar).toBeDefined();
+    });
+
+    it('RankBadgeがエクスポートされていること', () => {
+      expect(RankBadge).toBeDefined();
+    });
+
+    it('PromotionDialogがエクスポートされていること', () => {
+      expect(PromotionDialog).toBeDefined();
+    });
+
+    it('SpecialRuleDisplayがエクスポートされていること', () => {
+      expect(SpecialRuleDisplay).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `RankProgressBar`: ランク進捗バー（ランクに応じた色、進捗率表示、動的更新対応）
- `RankBadge`: ランクバッジ（ランクアイコン+ランク名表示、動的ランク変更対応）
- `PromotionDialog`: 昇格ダイアログ（新ランク情報、ボーナス報酬、特殊ルール解放表示）
- `SpecialRuleDisplay`: 特殊ルール一覧（有効/無効のハイライト、インジケーター表示）
- `components/index.ts`: コンポーネントバレルエクスポート
- `rank/index.ts`: 機能レベルの公開API（types + services + components統合）
- 全53テスト（コンポーネント: 31件、公開API: 22件）が合格

## Test plan
- [x] RankProgressBarテスト合格（8件）
- [x] RankBadgeテスト合格（7件）
- [x] PromotionDialogテスト合格（8件）
- [x] SpecialRuleDisplayテスト合格（8件）
- [x] 公開APIテスト合格（22件 - 型/列挙値/サービス/コンポーネント各エクスポート確認）
- [x] 既存rank/types + rank/servicesテストも含め全109テスト合格
- [x] Biome lint/format通過
- [x] TypeScript型チェック通過
- [x] Lefthook pre-commitフック通過

Generated with [Claude Code](https://claude.com/claude-code)