### PR TITLE
refactor: TASK-0097 シーンファイルのインポートパス整理

### DIFF
--- a/atelier-guild-rank/src/scenes/MainScene.ts
+++ b/atelier-guild-rank/src/scenes/MainScene.ts
@@ -11,24 +11,23 @@
  * @信頼性レベル 🔵 requirements.md セクション2.1に基づく
  */
 
-import { Card } from '@domain/entities/Card';
 import { Quest } from '@domain/entities/Quest';
-import type { IAlchemyService } from '@domain/interfaces/alchemy-service.interface';
-import type { IGatheringService } from '@domain/interfaces/gathering-service.interface';
 import type { IMasterDataRepository } from '@domain/interfaces/master-data-repository.interface';
-import type { IQuestService } from '@domain/interfaces/quest-service.interface';
+import type { IAlchemyService } from '@features/alchemy';
+import { AlchemyPhaseUI } from '@features/alchemy';
+import { Card, toCardId } from '@features/deck';
+import type { IGatheringService } from '@features/gathering';
+import { GatheringPhaseUI } from '@features/gathering';
+import type { IQuestService } from '@features/quest';
 import { Container, ServiceKeys } from '@infrastructure/di/container';
 import { FooterUI } from '@presentation/ui/components/FooterUI';
 import { HeaderUI } from '@presentation/ui/components/HeaderUI';
 import { SidebarUI } from '@presentation/ui/components/SidebarUI';
-import { AlchemyPhaseUI } from '@presentation/ui/phases/AlchemyPhaseUI';
 import { DeliveryPhaseUI } from '@presentation/ui/phases/DeliveryPhaseUI';
-import { GatheringPhaseUI } from '@presentation/ui/phases/GatheringPhaseUI';
 import { QuestAcceptPhaseUI } from '@presentation/ui/phases/QuestAcceptPhaseUI';
 import { GamePhase, type GuildRank, VALID_GAME_PHASES } from '@shared/types/common';
 import type { IPhaseChangedEvent } from '@shared/types/events';
 import { GameEventType } from '@shared/types/events';
-import { toCardId } from '@shared/types/ids';
 import type { IClient, IQuest } from '@shared/types/quests';
 import { generateUniqueId } from '@shared/utils';
 import Phaser from 'phaser';

--- a/atelier-guild-rank/src/scenes/RankUpScene.ts
+++ b/atelier-guild-rank/src/scenes/RankUpScene.ts
@@ -9,12 +9,12 @@
  * @信頼性レベル 🔵 TASK-0051.md セクション2に基づく
  */
 
-import type { IEventBus } from '@application/events/event-bus.interface';
-import type { IRankService, PromotionResult } from '@domain/interfaces/rank-service.interface';
+import type { IRankService, PromotionResult } from '@features/rank';
 import { Container, ServiceKeys } from '@infrastructure/di/container';
 import type { RexLabel, RexUIPlugin } from '@presentation/types/rexui';
 import { THEME } from '@presentation/ui/theme';
 import { isKeyForAction } from '@shared/constants/keybindings';
+import type { IEventBus } from '@shared/services';
 import { GameEventType, type GuildRank } from '@shared/types';
 import Phaser from 'phaser';
 

--- a/atelier-guild-rank/src/scenes/ShopScene.ts
+++ b/atelier-guild-rank/src/scenes/ShopScene.ts
@@ -9,11 +9,7 @@
  * @信頼性レベル 🔵 TASK-0050.md セクション2に基づく
  */
 
-import type {
-  IPurchaseResult,
-  IShopItem,
-  IShopService,
-} from '@domain/interfaces/shop-service.interface';
+import type { IPurchaseResult, IShopItem, IShopService } from '@features/shop';
 import { Container, ServiceKeys } from '@infrastructure/di/container';
 import type { RexLabel, RexUIPlugin } from '@presentation/types/rexui';
 import { THEME } from '@presentation/ui/theme';


### PR DESCRIPTION
## Summary
- MainScene/RankUpScene/ShopSceneのインポートパスを旧アーキテクチャ（@domain/、@application/）から新Feature-Based Architecture（@features/、@shared/）に統一
- 全129テストファイル・2323テストケースが通過
- Biomeリント・TypeScript型チェック問題なし

## 変更内容
| ファイル | 変更内容 |
|---------|---------|
| MainScene.ts | Card/toCardId→@features/deck、IAlchemyService/AlchemyPhaseUI→@features/alchemy、IGatheringService/GatheringPhaseUI→@features/gathering、IQuestService→@features/quest |
| RankUpScene.ts | IRankService/PromotionResult→@features/rank、IEventBus→@shared/services |
| ShopScene.ts | IPurchaseResult/IShopItem/IShopService→@features/shop |

## Test plan
- [x] TypeScript型チェック通過（tsc --noEmit）
- [x] Biome lint通過（biome check）
- [x] 全ユニットテスト通過（2323テスト）
- [x] Lefthook pre-commitフック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)