### PR TITLE
fix: E2Eテスト25件の失敗を修正

### DIFF
--- a/atelier-guild-rank/e2e/pages/main.page.ts
+++ b/atelier-guild-rank/e2e/pages/main.page.ts
@@ -186,6 +186,15 @@ export class MainPage extends BasePage {
     await this.executeDebugAction('clearSaveData');
   }
 
+  /**
+   * タイトル画面に戻る（デバッグ用）
+   *
+   * @throws デバッグツールが利用不可の場合
+   */
+  async returnToTitle(): Promise<void> {
+    await this.executeDebugAction('returnToTitle');
+  }
+
   // =============================================================================
   // プライベートヘルパーメソッド
   // =============================================================================

--- a/atelier-guild-rank/e2e/pages/mouse-interaction.page.ts
+++ b/atelier-guild-rank/e2e/pages/mouse-interaction.page.ts
@@ -284,8 +284,8 @@ export class MouseInteractionPage extends BasePage {
 
   /** UI要素の固定座標（1280x720基準） */
   static readonly COORDS = {
-    // フッター
-    NEXT_BUTTON: { x: 1144, y: 660 },
+    // フッター（サイドバー200px + フッター内ボタン位置744px = 944px）
+    NEXT_BUTTON: { x: 944, y: 660 },
     END_DAY_BUTTON: { x: 400, y: 630 },
 
     // サイドバー

--- a/atelier-guild-rank/e2e/specs/mouse/mouse-interaction.spec.ts-snapshots/alchemy-recipe-selected-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/mouse/mouse-interaction.spec.ts-snapshots/alchemy-recipe-selected-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c58b8d5eb5e350c61b1ad699cdfa68fd66568bb916f4a5b67eb55082edceabc9
+size 23873

--- a/atelier-guild-rank/e2e/specs/mouse/mouse-interaction.spec.ts-snapshots/quest-detail-modal-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/mouse/mouse-interaction.spec.ts-snapshots/quest-detail-modal-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:125a48f74f29ae28f432cf26b49bafef37bfa7a3d84f8593075cb44b7e34dec3
+size 36082

--- a/atelier-guild-rank/e2e/specs/visual/main-scene.spec.ts-snapshots/draft-card-hover-tooltip-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/main-scene.spec.ts-snapshots/draft-card-hover-tooltip-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:017c4ab359c43552fb83f50a8e1cd96e28acab4888a7fbaef6c3d56a7e1322d4
+size 33155

--- a/atelier-guild-rank/e2e/specs/visual/main-scene.spec.ts-snapshots/main-scene-alchemy-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/main-scene.spec.ts-snapshots/main-scene-alchemy-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c58b8d5eb5e350c61b1ad699cdfa68fd66568bb916f4a5b67eb55082edceabc9
+size 23873

--- a/atelier-guild-rank/e2e/specs/visual/main-scene.spec.ts-snapshots/main-scene-delivery-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/main-scene.spec.ts-snapshots/main-scene-delivery-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f611a255f15a47ee143dae5f829e69106cbb538186be3dad1b0c18cd6261e5e7
+size 27768

--- a/atelier-guild-rank/e2e/specs/visual/main-scene.spec.ts-snapshots/main-scene-gathering-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/main-scene.spec.ts-snapshots/main-scene-gathering-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:017c4ab359c43552fb83f50a8e1cd96e28acab4888a7fbaef6c3d56a7e1322d4
+size 33155

--- a/atelier-guild-rank/e2e/specs/visual/main-scene.spec.ts-snapshots/main-scene-header-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/main-scene.spec.ts-snapshots/main-scene-header-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e013ff70701bdb3d5873c1e2c5db8c180b3f4784a0f7e263b43734051815bfe4
+size 29097

--- a/atelier-guild-rank/e2e/specs/visual/main-scene.spec.ts-snapshots/main-scene-quest-accept-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/main-scene.spec.ts-snapshots/main-scene-quest-accept-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:607ff858cd5513a369547cb31006fc9fcba50e27f34c63d8606619f24a9fe0b4
+size 29410

--- a/atelier-guild-rank/e2e/specs/visual/main-scene.spec.ts-snapshots/main-scene-sidebar-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/main-scene.spec.ts-snapshots/main-scene-sidebar-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00041841d9a5c83ee06cdb82ca234e9a964b28b602d320904621ae2012db5142
+size 29352

--- a/atelier-guild-rank/e2e/specs/visual/main-scene.spec.ts-snapshots/quest-card-hover-tooltip-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/main-scene.spec.ts-snapshots/quest-card-hover-tooltip-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:415c07e676c99584ca7f3b9418ca29bbae832a144c525dc0997be0243db164bf
+size 29523

--- a/atelier-guild-rank/e2e/specs/visual/main-scene.spec.ts-snapshots/recipe-hover-tooltip-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/main-scene.spec.ts-snapshots/recipe-hover-tooltip-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c58b8d5eb5e350c61b1ad699cdfa68fd66568bb916f4a5b67eb55082edceabc9
+size 23873

--- a/atelier-guild-rank/e2e/specs/visual/result-screens.spec.ts-snapshots/game-clear-scene-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/result-screens.spec.ts-snapshots/game-clear-scene-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b36787ff3a8eb2fe247bd9e35edc88ef562f9da45daa95d2258adbd236a96b8d
+size 29297

--- a/atelier-guild-rank/e2e/specs/visual/result-screens.spec.ts-snapshots/game-clear-statistics-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/result-screens.spec.ts-snapshots/game-clear-statistics-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b36787ff3a8eb2fe247bd9e35edc88ef562f9da45daa95d2258adbd236a96b8d
+size 29297

--- a/atelier-guild-rank/e2e/specs/visual/result-screens.spec.ts-snapshots/game-over-scene-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/result-screens.spec.ts-snapshots/game-over-scene-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba6b8aaa99afea9fcea0bfbc067d8622cbf2102a8c225f8c954ad188fbf50947
+size 24261

--- a/atelier-guild-rank/e2e/specs/visual/result-screens.spec.ts-snapshots/game-over-statistics-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/result-screens.spec.ts-snapshots/game-over-statistics-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba6b8aaa99afea9fcea0bfbc067d8622cbf2102a8c225f8c954ad188fbf50947
+size 24261

--- a/atelier-guild-rank/e2e/specs/visual/title-screen.spec.ts-snapshots/title-button-hover-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/title-screen.spec.ts-snapshots/title-button-hover-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17be24c3670b0ce1a5e96431b9779f22b1a1730cb27e3edf4f13a632420437ac
+size 20734

--- a/atelier-guild-rank/e2e/specs/visual/title-screen.spec.ts-snapshots/title-button-normal-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/title-screen.spec.ts-snapshots/title-button-normal-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17be24c3670b0ce1a5e96431b9779f22b1a1730cb27e3edf4f13a632420437ac
+size 20734

--- a/atelier-guild-rank/e2e/specs/visual/title-screen.spec.ts-snapshots/title-screen-1280x720-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/title-screen.spec.ts-snapshots/title-screen-1280x720-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17be24c3670b0ce1a5e96431b9779f22b1a1730cb27e3edf4f13a632420437ac
+size 20734

--- a/atelier-guild-rank/e2e/specs/visual/title-screen.spec.ts-snapshots/title-screen-1920x1080-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/title-screen.spec.ts-snapshots/title-screen-1920x1080-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88ef2003044d5550c248870c9527fe022a30bd42d6b5a6197814b3c1752ff207
+size 49900

--- a/atelier-guild-rank/e2e/specs/visual/title-screen.spec.ts-snapshots/title-screen-960x540-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/title-screen.spec.ts-snapshots/title-screen-960x540-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acd80af3e75840ab5beefb09fc8940cb32e956124e4c939766348f0f16550332
+size 17744

--- a/atelier-guild-rank/e2e/specs/visual/title-screen.spec.ts-snapshots/title-screen-display-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/title-screen.spec.ts-snapshots/title-screen-display-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17be24c3670b0ce1a5e96431b9779f22b1a1730cb27e3edf4f13a632420437ac
+size 20734

--- a/atelier-guild-rank/e2e/specs/visual/title-screen.spec.ts-snapshots/title-screen-ultrawide-chromium-win32.png
+++ b/atelier-guild-rank/e2e/specs/visual/title-screen.spec.ts-snapshots/title-screen-ultrawide-chromium-win32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88ef2003044d5550c248870c9527fe022a30bd42d6b5a6197814b3c1752ff207
+size 49900

--- a/atelier-guild-rank/src/shared/utils/debug.ts
+++ b/atelier-guild-rank/src/shared/utils/debug.ts
@@ -9,7 +9,7 @@
 
 import { Container, ServiceKeys } from '@shared/services/di/container';
 import type { IStateManager } from '@shared/services/state-manager';
-import { GuildRank } from '@shared/types';
+import { GamePhase, GuildRank } from '@shared/types';
 import type Phaser from 'phaser';
 
 // =============================================================================
@@ -386,6 +386,9 @@ export class DebugTools {
         DebugTools.transitionToGameOver(stateAfter);
         return;
       }
+
+      // ゲーム継続: フェーズをQUEST_ACCEPTに戻して次の日を開始
+      stateManager.setPhase(GamePhase.QUEST_ACCEPT);
     } catch (e) {
       console.warn('endDay failed:', e);
     }


### PR DESCRIPTION
## Summary
- MainPageに`returnToTitle()`メソッドを追加（リザルト画面テスト2件修正）
- MouseInteractionPageのNEXT_BUTTON座標を修正（1144→944、サイドバーオフセット補正）
- DebugTools.endDay()にGamePhaseインポートを追加しフェーズ遷移を正常化
- ビジュアルリグレッションテスト用の初回ベースラインスクリーンショットを生成

## Test plan
- [x] マウス操作テスト「次へボタンをクリックしてフェーズを進める」成功
- [x] キーボードテスト「TC-E2E-DELIVER-004: キーボードで日を終了」成功
- [x] 全E2Eテスト実行: 85 passed, 0 failed, 32 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)