### PR TITLE
feat: PhaseTabUIコンポーネントを実装（TASK-0111）

### DIFF
--- a/atelier-guild-rank/tests/unit/shared/components/phase-tab-ui.test.ts
+++ b/atelier-guild-rank/tests/unit/shared/components/phase-tab-ui.test.ts
@@ -247,8 +247,13 @@ describe('PhaseTabUI（TASK-0111）', () => {
       )?.[1];
       expect(handler).toBeDefined();
 
-      // GATHERINGへの変更イベントをシミュレート（IBusEvent構造に合わせる）
-      handler?.({ payload: { newPhase: GamePhase.GATHERING } });
+      // GATHERINGへの変更イベントをシミュレート（IBusEvent<IPhaseChangedEvent>構造に合わせる）
+      handler?.({
+        payload: {
+          previousPhase: GamePhase.QUEST_ACCEPT,
+          newPhase: GamePhase.GATHERING,
+        },
+      });
 
       expect(phaseTabUI.getActivePhase()).toBe(GamePhase.GATHERING);
     });


### PR DESCRIPTION
## Summary
- フェーズ切り替え用タブUIコンポーネント（PhaseTabUI）を新規作成
- 4つのフェーズタブ（依頼・採取・調合・納品）にアクティブ強調表示機能
- タブクリックでGameFlowManager.switchPhase()を呼び出し
- 日終了ボタンでGameFlowManager.endDay()を呼び出し
- PHASE_CHANGEDイベント購読によるアクティブタブ自動更新

## Test plan
- [x] T-0111-01: 4つのタブが表示される（3テスト）
- [x] T-0111-02: アクティブタブの強調表示（2テスト）
- [x] T-0111-03: タブクリックでswitchPhase()呼び出し（3テスト）
- [x] T-0111-04: 日終了ボタンでendDay()呼び出し（1テスト）
- [x] destroy()でEventBus購読解除・コンテナ破棄（2テスト）
- 全11テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)