### PR TITLE
fix: guild_ranks.jsonにE〜Aランクデータを追加（#258）

### DIFF
--- a/atelier-guild-rank/public/assets/data/master/cards/gathering_cards.json
+++ b/atelier-guild-rank/public/assets/data/master/cards/gathering_cards.json
@@ -34,5 +34,65 @@
     "rarity": "COMMON",
     "unlockRank": "F",
     "description": "水属性特化"
+  },
+  {
+    "id": "gathering_mountain_path",
+    "name": "山道",
+    "type": "GATHERING",
+    "baseCost": 0,
+    "presentationCount": 3,
+    "rareRate": 15,
+    "materialPool": ["ore", "mushroom", "herb", "wood"],
+    "rarity": "UNCOMMON",
+    "unlockRank": "E",
+    "description": "鉱石が採れる山道"
+  },
+  {
+    "id": "gathering_deep_forest",
+    "name": "深い森",
+    "type": "GATHERING",
+    "baseCost": 0,
+    "presentationCount": 4,
+    "rareRate": 20,
+    "materialPool": ["ancient_herb", "mushroom", "herb", "wood"],
+    "rarity": "UNCOMMON",
+    "unlockRank": "D",
+    "description": "希少な薬草が見つかる深い森"
+  },
+  {
+    "id": "gathering_cave",
+    "name": "洞窟",
+    "type": "GATHERING",
+    "baseCost": 0,
+    "presentationCount": 4,
+    "rareRate": 25,
+    "materialPool": ["ore", "crystal", "fire_stone", "sand"],
+    "rarity": "RARE",
+    "unlockRank": "C",
+    "description": "鉱物資源が豊富な洞窟"
+  },
+  {
+    "id": "gathering_ancient_ruins",
+    "name": "古代遺跡",
+    "type": "GATHERING",
+    "baseCost": 0,
+    "presentationCount": 4,
+    "rareRate": 30,
+    "materialPool": ["crystal", "ancient_herb", "fire_stone", "ore"],
+    "rarity": "RARE",
+    "unlockRank": "B",
+    "description": "太古の力が眠る遺跡"
+  },
+  {
+    "id": "gathering_dragon_peak",
+    "name": "竜の峰",
+    "type": "GATHERING",
+    "baseCost": 0,
+    "presentationCount": 5,
+    "rareRate": 40,
+    "materialPool": ["dragon_scale", "crystal", "fire_stone", "ancient_herb"],
+    "rarity": "LEGENDARY",
+    "unlockRank": "A",
+    "description": "伝説の竜が棲む山の頂"
   }
 ]

--- a/atelier-guild-rank/public/assets/data/master/cards/recipe_cards.json
+++ b/atelier-guild-rank/public/assets/data/master/cards/recipe_cards.json
@@ -28,5 +28,81 @@
     "rarity": "COMMON",
     "unlockRank": "F",
     "description": "医療系"
+  },
+  {
+    "id": "recipe_mana_potion",
+    "name": "魔力薬",
+    "type": "RECIPE",
+    "cost": 1,
+    "requiredMaterials": [
+      { "materialId": "herb", "quantity": 2 },
+      { "materialId": "water", "quantity": 2 }
+    ],
+    "outputItemId": "mana_potion",
+    "category": "MEDICINE",
+    "rarity": "UNCOMMON",
+    "unlockRank": "E",
+    "description": "魔力を回復する薬の調合"
+  },
+  {
+    "id": "recipe_bomb",
+    "name": "爆弾",
+    "type": "RECIPE",
+    "cost": 2,
+    "requiredMaterials": [
+      { "materialId": "fire_stone", "quantity": 1 },
+      { "materialId": "ore", "quantity": 1 }
+    ],
+    "outputItemId": "bomb",
+    "category": "TOOL",
+    "rarity": "UNCOMMON",
+    "unlockRank": "D",
+    "description": "危険な爆発物の調合"
+  },
+  {
+    "id": "recipe_elixir",
+    "name": "エリクサー",
+    "type": "RECIPE",
+    "cost": 3,
+    "requiredMaterials": [
+      { "materialId": "ancient_herb", "quantity": 2 },
+      { "materialId": "pure_water", "quantity": 2 }
+    ],
+    "outputItemId": "elixir",
+    "category": "MEDICINE",
+    "rarity": "RARE",
+    "unlockRank": "C",
+    "description": "高級回復薬の調合"
+  },
+  {
+    "id": "recipe_philosophers_stone",
+    "name": "賢者の石",
+    "type": "RECIPE",
+    "cost": 4,
+    "requiredMaterials": [
+      { "materialId": "crystal", "quantity": 3 },
+      { "materialId": "dragon_scale", "quantity": 1 }
+    ],
+    "outputItemId": "philosophers_stone",
+    "category": "MATERIAL",
+    "rarity": "RARE",
+    "unlockRank": "B",
+    "description": "伝説の錬金素材"
+  },
+  {
+    "id": "recipe_universal_remedy",
+    "name": "万能薬",
+    "type": "RECIPE",
+    "cost": 5,
+    "requiredMaterials": [
+      { "materialId": "ancient_herb", "quantity": 3 },
+      { "materialId": "crystal", "quantity": 1 },
+      { "materialId": "pure_water", "quantity": 2 }
+    ],
+    "outputItemId": "universal_remedy",
+    "category": "MEDICINE",
+    "rarity": "LEGENDARY",
+    "unlockRank": "A",
+    "description": "究極の医療薬"
   }
 ]

--- a/atelier-guild-rank/public/assets/data/master/items/items.json
+++ b/atelier-guild-rank/public/assets/data/master/items/items.json
@@ -12,5 +12,40 @@
     "category": "MEDICINE",
     "effects": [{ "type": "CURE_POISON", "baseValue": 1 }],
     "description": "毒を治療する薬"
+  },
+  {
+    "id": "mana_potion",
+    "name": "魔力薬",
+    "category": "MEDICINE",
+    "effects": [{ "type": "MP_RECOVERY", "baseValue": 30 }],
+    "description": "魔力を回復する薬"
+  },
+  {
+    "id": "bomb",
+    "name": "爆弾",
+    "category": "TOOL",
+    "effects": [{ "type": "DAMAGE", "baseValue": 50 }],
+    "description": "爆発する危険な道具"
+  },
+  {
+    "id": "elixir",
+    "name": "エリクサー",
+    "category": "MEDICINE",
+    "effects": [{ "type": "HP_RECOVERY", "baseValue": 100 }],
+    "description": "全てを癒す高級薬"
+  },
+  {
+    "id": "philosophers_stone",
+    "name": "賢者の石",
+    "category": "MATERIAL",
+    "effects": [{ "type": "TRANSFORM", "baseValue": 1 }],
+    "description": "万物を変換する伝説の石"
+  },
+  {
+    "id": "universal_remedy",
+    "name": "万能薬",
+    "category": "MEDICINE",
+    "effects": [{ "type": "CURE_ALL", "baseValue": 1 }],
+    "description": "あらゆる状態異常を治す究極の薬"
   }
 ]

--- a/atelier-guild-rank/public/assets/data/master/items/materials.json
+++ b/atelier-guild-rank/public/assets/data/master/items/materials.json
@@ -33,5 +33,75 @@
     "baseQuality": "C",
     "attributes": ["MUSHROOM"],
     "description": "毒を持つキノコ"
+  },
+  {
+    "id": "mushroom",
+    "name": "キノコ",
+    "baseQuality": "D",
+    "attributes": ["MUSHROOM"],
+    "description": "食用キノコ"
+  },
+  {
+    "id": "wood",
+    "name": "木材",
+    "baseQuality": "D",
+    "attributes": ["WOOD"],
+    "description": "丈夫な木材"
+  },
+  {
+    "id": "fish",
+    "name": "魚",
+    "baseQuality": "D",
+    "attributes": ["WATER"],
+    "description": "川魚"
+  },
+  {
+    "id": "water_grass",
+    "name": "水草",
+    "baseQuality": "D",
+    "attributes": ["GRASS", "WATER"],
+    "description": "水辺に生える草"
+  },
+  {
+    "id": "sand",
+    "name": "砂",
+    "baseQuality": "D",
+    "attributes": ["MINERAL"],
+    "description": "細かい砂"
+  },
+  {
+    "id": "ore",
+    "name": "鉱石",
+    "baseQuality": "C",
+    "attributes": ["MINERAL"],
+    "description": "山で採れる鉱石"
+  },
+  {
+    "id": "crystal",
+    "name": "水晶",
+    "baseQuality": "B",
+    "attributes": ["MINERAL"],
+    "description": "透明度の高い水晶"
+  },
+  {
+    "id": "fire_stone",
+    "name": "火石",
+    "baseQuality": "B",
+    "attributes": ["MINERAL", "FIRE"],
+    "description": "熱を帯びた不思議な石"
+  },
+  {
+    "id": "ancient_herb",
+    "name": "古代薬草",
+    "baseQuality": "A",
+    "attributes": ["GRASS"],
+    "description": "太古の力を宿す薬草"
+  },
+  {
+    "id": "dragon_scale",
+    "name": "竜鱗",
+    "baseQuality": "S",
+    "attributes": ["DRAGON"],
+    "description": "伝説の竜の鱗"
   }
 ]

--- a/atelier-guild-rank/public/assets/data/master/ranks/guild_ranks.json
+++ b/atelier-guild-rank/public/assets/data/master/ranks/guild_ranks.json
@@ -31,6 +31,95 @@
     "unlockedRecipeCards": ["recipe_antidote"]
   },
   {
+    "id": "E",
+    "name": "一般",
+    "requiredContribution": 300,
+    "dayLimit": 25,
+    "specialRules": [],
+    "promotionTest": {
+      "requirements": [
+        { "itemId": "healing_potion", "quantity": 3, "minQuality": "B" },
+        { "itemId": "mana_potion", "quantity": 2 }
+      ],
+      "dayLimit": 5
+    },
+    "unlockedGatheringCards": ["gathering_mountain_path"],
+    "unlockedRecipeCards": ["recipe_mana_potion"]
+  },
+  {
+    "id": "D",
+    "name": "中堅",
+    "requiredContribution": 500,
+    "dayLimit": 25,
+    "specialRules": [
+      { "type": "QUEST_LIMIT", "value": 3, "description": "同時受注3件まで" }
+    ],
+    "promotionTest": {
+      "requirements": [
+        { "itemId": "antidote", "quantity": 3, "minQuality": "B" },
+        { "itemId": "bomb", "quantity": 2 }
+      ],
+      "dayLimit": 5
+    },
+    "unlockedGatheringCards": ["gathering_deep_forest"],
+    "unlockedRecipeCards": ["recipe_bomb"]
+  },
+  {
+    "id": "C",
+    "name": "熟練",
+    "requiredContribution": 800,
+    "dayLimit": 20,
+    "specialRules": [
+      { "type": "QUALITY_REQUIRED", "value": 3, "description": "納品品質C以上必須" }
+    ],
+    "promotionTest": {
+      "requirements": [
+        { "itemId": "elixir", "quantity": 2, "minQuality": "B" }
+      ],
+      "dayLimit": 7
+    },
+    "unlockedGatheringCards": ["gathering_cave"],
+    "unlockedRecipeCards": ["recipe_elixir"]
+  },
+  {
+    "id": "B",
+    "name": "上級",
+    "requiredContribution": 1200,
+    "dayLimit": 20,
+    "specialRules": [
+      { "type": "QUALITY_REQUIRED", "value": 4, "description": "納品品質B以上必須" },
+      { "type": "DEADLINE_REDUCTION", "value": 1, "description": "依頼期限-1日" }
+    ],
+    "promotionTest": {
+      "requirements": [
+        { "itemId": "elixir", "quantity": 3, "minQuality": "A" },
+        { "itemId": "philosophers_stone", "quantity": 1 }
+      ],
+      "dayLimit": 7
+    },
+    "unlockedGatheringCards": ["gathering_ancient_ruins"],
+    "unlockedRecipeCards": ["recipe_philosophers_stone"]
+  },
+  {
+    "id": "A",
+    "name": "達人",
+    "requiredContribution": 2000,
+    "dayLimit": 15,
+    "specialRules": [
+      { "type": "QUALITY_REQUIRED", "value": 5, "description": "納品品質A以上必須" },
+      { "type": "DEADLINE_REDUCTION", "value": 2, "description": "依頼期限-2日" }
+    ],
+    "promotionTest": {
+      "requirements": [
+        { "itemId": "universal_remedy", "quantity": 2, "minQuality": "S" },
+        { "itemId": "philosophers_stone", "quantity": 2, "minQuality": "A" }
+      ],
+      "dayLimit": 10
+    },
+    "unlockedGatheringCards": ["gathering_dragon_peak"],
+    "unlockedRecipeCards": ["recipe_universal_remedy"]
+  },
+  {
     "id": "S",
     "name": "伝説",
     "requiredContribution": 0,

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,7 +9,7 @@ pre-commit:
     biome-check:
       root: atelier-guild-rank/
       glob: "**/*.{ts,tsx,js,jsx,json}"
-      run: pnpm biome check --write {staged_files}
+      run: pnpm biome check --write --no-errors-on-unmatched {staged_files}
       stage_fixed: true
     typecheck:
       root: atelier-guild-rank/


### PR DESCRIPTION
## Summary
- E（一般）、D（中堅）、C（熟練）、B（上級）、A（達人）の5ランクをguild_ranks.jsonに追加
- 各ランクの昇格条件・試験・特殊ルール・アンロック対象を設定
- 対応する採取カード5枚、レシピカード5枚、新アイテム5種、新素材10種を追加

## Test plan
- [x] 既存テスト2596件が全てパス
- [ ] ランク昇格フローの動作確認（G→F→E→...→S）
- [ ] 各ランクのアンロック対象が正しく反映されるか確認

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)