### PR TITLE
fix: PhaseTabUI日終了ボタンをrequestEndDay()に修正（#287）

### DIFF
--- a/atelier-guild-rank/src/shared/components/PhaseTabUI.ts
+++ b/atelier-guild-rank/src/shared/components/PhaseTabUI.ts
@@ -396,10 +396,10 @@ export class PhaseTabUI extends BaseComponent {
 
   /**
    * 日終了ボタンクリック時の処理
-   * 🔵 信頼性レベル: REQ-004・architecture.md「日終了ボタン」より
+   * 🔵 信頼性レベル: REQ-004・REQ-004-01「残りAP破棄→日終了」より
    */
   private handleEndDayClick(): void {
-    this.gameFlowManager.endDay();
+    this.gameFlowManager.requestEndDay();
   }
 
   /**

--- a/atelier-guild-rank/tests/unit/presentation/ui/components/footer-ui-visual.test.ts
+++ b/atelier-guild-rank/tests/unit/presentation/ui/components/footer-ui-visual.test.ts
@@ -60,7 +60,7 @@ interface MockScene extends Phaser.Scene {
 
 interface MockGameFlowManager extends Partial<IGameFlowManager> {
   switchPhase: ReturnType<typeof vi.fn>;
-  endDay: ReturnType<typeof vi.fn>;
+  requestEndDay: ReturnType<typeof vi.fn>;
 }
 
 interface MockEventBus extends Partial<IEventBus> {
@@ -134,7 +134,7 @@ const createMockGameFlowManager = (): MockGameFlowManager => ({
     previousPhase: GamePhase.QUEST_ACCEPT,
     newPhase: GamePhase.ALCHEMY,
   }),
-  endDay: vi.fn(),
+  requestEndDay: vi.fn(),
 });
 
 const createMockEventBus = (): MockEventBus => ({
@@ -263,16 +263,16 @@ describe('FooterUI（TASK-0112）', () => {
   // ===========================================================================
 
   describe('T-0112-04: 「日終了」ボタンが存在する', () => {
-    it('PhaseTabUI経由で日終了ボタンクリックでendDay()が呼ばれる', () => {
-      // 【テスト目的】: 「日終了」ボタンがPhaseTabUI経由で機能することを確認
-      // 🔵 信頼性レベル: REQ-004・architecture.md「日終了ボタン」より
+    it('PhaseTabUI経由で日終了ボタンクリックでrequestEndDay()が呼ばれる', () => {
+      // 【テスト目的】: 「日終了」ボタンがPhaseTabUI経由でrequestEndDay()を呼ぶことを確認
+      // 🔵 信頼性レベル: REQ-004・REQ-004-01「残りAP破棄→日終了」より
 
       footerUI.create();
 
       const phaseTabUI = footerUI.getPhaseTabUI();
       phaseTabUI?.simulateEndDayClick();
 
-      expect(mockGameFlowManager.endDay).toHaveBeenCalledTimes(1);
+      expect(mockGameFlowManager.requestEndDay).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/atelier-guild-rank/tests/unit/shared/components/phase-tab-ui.test.ts
+++ b/atelier-guild-rank/tests/unit/shared/components/phase-tab-ui.test.ts
@@ -65,7 +65,7 @@ interface MockScene extends Phaser.Scene {
 
 interface MockGameFlowManager extends Partial<IGameFlowManager> {
   switchPhase: ReturnType<typeof vi.fn>;
-  endDay: ReturnType<typeof vi.fn>;
+  requestEndDay: ReturnType<typeof vi.fn>;
   rest: ReturnType<typeof vi.fn>;
 }
 
@@ -140,7 +140,7 @@ const createMockGameFlowManager = (): MockGameFlowManager => ({
     previousPhase: GamePhase.QUEST_ACCEPT,
     newPhase: GamePhase.ALCHEMY,
   }),
-  endDay: vi.fn(),
+  requestEndDay: vi.fn(),
   rest: vi.fn(),
 });
 
@@ -314,18 +314,18 @@ describe('PhaseTabUI（TASK-0111）', () => {
   });
 
   // ===========================================================================
-  // テストケース4: 日終了ボタンでendDay呼び出し
+  // テストケース4: 日終了ボタンでrequestEndDay呼び出し
   // ===========================================================================
 
-  describe('T-0111-04: 日終了ボタンでendDay()が呼ばれる', () => {
-    it('日終了ボタンクリックでendDay()が呼ばれる', () => {
-      // 【テスト目的】: 日終了ボタンクリック時にGameFlowManager.endDay()が呼ばれることを確認
-      // 🔵 信頼性レベル: REQ-004・architecture.md「日終了ボタン」より
+  describe('T-0111-04: 日終了ボタンでrequestEndDay()が呼ばれる', () => {
+    it('日終了ボタンクリックでrequestEndDay()が呼ばれる', () => {
+      // 【テスト目的】: 日終了ボタンクリック時にGameFlowManager.requestEndDay()が呼ばれることを確認
+      // 🔵 信頼性レベル: REQ-004・REQ-004-01「残りAP破棄→日終了」より
 
       phaseTabUI.create();
       phaseTabUI.simulateEndDayClick();
 
-      expect(mockGameFlowManager.endDay).toHaveBeenCalledTimes(1);
+      expect(mockGameFlowManager.requestEndDay).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Summary
- PhaseTabUIの「日終了」ボタンが `endDay()` を直接呼び出していたバグを `requestEndDay()` に修正
- `requestEndDay()` は残りAPを0に設定し、apOverflowをリセットしてからendDay()を呼び出す
- 関連テスト（phase-tab-ui.test.ts, footer-ui-visual.test.ts）も `requestEndDay` の検証に更新

## Test plan
- [x] 全2599テストがパス
- [x] ビルド成功
- [x] リント通過（既存warningのみ）

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)