### PR TITLE
refactor: APOverflowPreviewをshared/componentsに移動（#289）

### DIFF
--- a/atelier-guild-rank/src/features/gathering/components/index.ts
+++ b/atelier-guild-rank/src/features/gathering/components/index.ts
@@ -7,9 +7,9 @@
  * TASK-0115: APOverflowPreview追加
  */
 
-// APOverflowPreview
-export type { IAPOverflowPreviewData } from './APOverflowPreview';
-export { APOverflowPreview } from './APOverflowPreview';
+// APOverflowPreview（shared/componentsに移動済み、後方互換のため再エクスポート）
+export type { IAPOverflowPreviewData } from '@shared/components/APOverflowPreview';
+export { APOverflowPreview } from '@shared/components/APOverflowPreview';
 
 // GatheringPhaseUI
 export { GatheringPhaseUI } from './GatheringPhaseUI';

--- a/atelier-guild-rank/src/shared/components/APOverflowPreview.ts
+++ b/atelier-guild-rank/src/shared/components/APOverflowPreview.ts
@@ -11,7 +11,7 @@
  * @信頼性レベル 🟡 NFR-102・design-interview.md D7から妥当な推測
  */
 
-import type { IAPOverflowResult } from '../types';
+import type { IAPOverflowResult } from '@features/gathering';
 
 // =============================================================================
 // Types

--- a/atelier-guild-rank/tests/unit/shared/components/APOverflowPreview.test.ts
+++ b/atelier-guild-rank/tests/unit/shared/components/APOverflowPreview.test.ts
@@ -9,8 +9,8 @@
  */
 
 import type { IAPOverflowResult } from '@features/gathering';
-import type { IAPOverflowPreviewData } from '@features/gathering/components/APOverflowPreview';
-import { APOverflowPreview } from '@features/gathering/components/APOverflowPreview';
+import type { IAPOverflowPreviewData } from '@shared/components/APOverflowPreview';
+import { APOverflowPreview } from '@shared/components/APOverflowPreview';
 import type Phaser from 'phaser';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 


### PR DESCRIPTION
## Summary
- `APOverflowPreview`を`src/features/gathering/components/`から`src/shared/components/`に移動
- 採取・調合の両方で使用されるため、Feature-Based Architectureに従いshared配置に変更
- `gathering/components/index.ts`は後方互換のため再エクスポートを維持
- テストファイルも`tests/unit/shared/components/`に移動

## Test plan
- [x] 全2599テストがパス
- [x] ビルド成功
- [x] リント通過

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)