### PR TITLE
test: AP残量0での日終了テストを追加（#291）

### DIFF
--- a/atelier-guild-rank/tests/unit/application/services/game-flow-manager.test.ts
+++ b/atelier-guild-rank/tests/unit/application/services/game-flow-manager.test.ts
@@ -1298,6 +1298,59 @@ describe('GameFlowManager', () => {
       expect(mockEventBus.emit).toHaveBeenCalledWith(GameEventType.DAY_ENDED, expect.anything());
     });
 
+    it('TC-004-02: AP残量0でrequestEndDay()すると翌日AP=3で開始される', () => {
+      // 【テスト目的】: AP残量0の状態で「日終了」クリック→翌日AP=3で開始
+      // 🔵 信頼性レベル: REQ-004
+      let currentDay = 5;
+      let remainingDays = 146;
+
+      mockStateManager.getState = vi.fn(() => ({
+        currentRank: GuildRank.G,
+        rankHp: 100,
+        remainingDays,
+        currentDay,
+        gold: 200,
+        actionPoints: 0,
+        maxActionPoints: 3,
+        comboCount: 0,
+        currentPhase: GamePhase.ALCHEMY,
+        contribution: 0,
+        apOverflow: 0,
+        isPromotionTest: false,
+        promotionGauge: 0,
+        questBoard: {
+          boardQuests: [],
+          visitorQuests: [],
+          lastVisitorUpdateDay: 0,
+        },
+      }));
+      mockStateManager.updateState = vi.fn((update) => {
+        if (update.currentDay !== undefined) {
+          currentDay = update.currentDay;
+        }
+        if (update.remainingDays !== undefined) {
+          remainingDays = update.remainingDays;
+        }
+      });
+
+      gameFlowManager.requestEndDay();
+
+      const updateCalls = mockStateManager.updateState.mock.calls;
+
+      // requestEndDay()でAP=0, apOverflow=0のリセットが呼ばれる
+      expect(updateCalls[0][0]).toEqual(
+        expect.objectContaining({ actionPoints: 0, apOverflow: 0 }),
+      );
+
+      // endDay()→startDay()でAP=3（MAX_AP）で回復される
+      const startDayCall = updateCalls.find((call) => call[0].actionPoints === 3);
+      expect(startDayCall).toBeDefined();
+
+      // DAY_ENDEDとDAY_STARTEDイベントが発行される
+      expect(mockEventBus.emit).toHaveBeenCalledWith(GameEventType.DAY_ENDED, expect.anything());
+      expect(mockEventBus.emit).toHaveBeenCalledWith(GameEventType.DAY_STARTED, expect.anything());
+    });
+
     it('T-0108-04: requestEndDay()でapOverflowがリセットされ次日はMAX_APで開始', () => {
       // 🔵 信頼性レベル: REQ-004・REQ-003-01
       let currentApOverflow = 1;


### PR DESCRIPTION
## Summary
- TC-004-02テストケースを追加（REQ-004: 明示的日終了）
- AP残量0の状態でrequestEndDay()→翌日AP=3で開始を検証
- DAY_ENDED/DAY_STARTEDイベント発行確認

## Test plan
- [x] 全2600テストがパス（+1件追加）
- [x] ビルド成功
- [x] リント通過

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)