### PR TITLE
test: 各フェーズからの日終了統合テストを追加（TC-004-04）

### DIFF
--- a/atelier-guild-rank/tests/integration/free-phase-navigation/end-day-from-each-phase.test.ts
+++ b/atelier-guild-rank/tests/integration/free-phase-navigation/end-day-from-each-phase.test.ts
@@ -105,9 +105,8 @@ describe('TC-004-04: 各フェーズからの日終了（REQ-004）', () => {
       // 日が進んでいることを確認
       expect(stateManager.getState().currentDay).toBe(initialDay + 1);
 
-      // DAY_ENDEDとDAY_STARTEDイベントが順番に発行される
-      expect(events).toContain('DAY_ENDED');
-      expect(events).toContain('DAY_STARTED');
+      // DAY_ENDEDとDAY_STARTEDイベントがこの順番で発行される
+      expect(events).toEqual(['DAY_ENDED', 'DAY_STARTED']);
 
       // 翌日はQUEST_ACCEPTフェーズで開始される
       expect(stateManager.getState().currentPhase).toBe(GamePhase.QUEST_ACCEPT);


### PR DESCRIPTION
## Summary
- 依頼受注/採取/調合/納品の各フェーズから`requestEndDay()`で正常に日終了できることを検証する統合テストを追加
- GameFlowManager + StateManager + EventBus の連携テスト（TC-004-04）
- 4フェーズ×パラメタライズドテストで、日進行・AP回復・イベント発行・フェーズリセットを検証

Closes #292

## Test plan
- [x] 4テスト全てパス
- [x] 全2603テストパス（リグレッションなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)