### PR TITLE
feat: 採取場所選択UIをマップ形式に変更（REQ-002-01）

### DIFF
--- a/atelier-guild-rank/tests/unit/features/gathering/components/LocationSelectUI.test.ts
+++ b/atelier-guild-rank/tests/unit/features/gathering/components/LocationSelectUI.test.ts
@@ -353,6 +353,22 @@ describe('LocationSelectUI（Issue #288: マップ形式）', () => {
       // getSelectableLocationCount()で選択可能な場所数を確認
       expect(ui.getSelectableLocationCount()).toBe(2);
     });
+
+    it('選択不可ノードのコンテナにsetAlphaが呼ばれる', () => {
+      const ui = new LocationSelectUI(mockScene, 0, 0);
+      ui.create();
+      ui.updateLocations(mockLocations);
+
+      // ノード用コンテナ（ルートコンテナ以降）を取得
+      const containerCalls = (mockScene.add.container as ReturnType<typeof vi.fn>).mock.results;
+      // ルートコンテナ(index 0)を除外し、ノード用コンテナを取得
+      const nodeContainers = containerCalls.slice(1).map((r: { value: unknown }) => r.value);
+
+      // 選択不可のノード（鉱山 = 2番目のノード）のコンテナでsetAlphaが呼ばれること
+      // mockLocations: [森(selectable), 鉱山(unselectable), 遺跡(selectable)]
+      const unselectableContainer = nodeContainers[1];
+      expect(unselectableContainer.setAlpha).toHaveBeenCalledWith(0.4);
+    });
   });
 
   // ===========================================================================


### PR DESCRIPTION
## Summary
- 採取場所選択UIをカードリスト形式（縦並び）からマップ形式（2D座標ベース）に変更
- `IGatheringLocationData`の`mapX`, `mapY`フィールドを活用し、各場所をマップ上に配置
- マップ座標の動的スケーリング機能（`calculateMapBounds`, `scaleToMapArea`）を実装

## 変更内容
### LocationSelectUI.ts
- カードリスト形式 → マップ形式に全面改修
- 場所ノードを円形アイコン（`scene.add.circle`）で描画
- 各ノードに場所名、APコスト、素材プレビューを表示
- マップ背景とタイトルを追加
- 選択可能/不可の視覚フィードバック（色、アルファ値）を維持
- ホバーエフェクト（ボーダー強調）を維持
- 公開APIインターフェースは変更なし（後方互換性維持）

### LocationSelectUI.test.ts
- マップ形式対応のテストに更新（25件、全パス）
- 新規テスト追加: マップ背景生成、タイトル表示、円形ノード描画、座標ベース配置
- 既存の振る舞いテスト（選択コールバック、空手札メッセージ等）は維持

## Test plan
- [x] ユニットテスト25件全パス
- [x] 全テストスイート2620件パス（リグレッションなし）
- [x] Biome lint/format チェックパス
- [x] TypeScript型チェックパス（pre-commitフック）

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)