### PR TITLE
docs: アーキテクチャ文書の整合性改善（Clean Arch vs FC/IS + DI設計）

### DIFF
--- a/docs/design/atelier-guild-rank/core-systems-support-services.md
+++ b/docs/design/atelier-guild-rank/core-systems-support-services.md
@@ -834,12 +834,13 @@ if (import.meta.env.DEV) {
 
 ## 関連文書
 
-- **要件定義書**: [../../spec/atelier-guild-rank-requirements.md](../../spec/atelier-guild-rank-requirements.md)
-- **アーキテクチャ設計書**: [architecture.md](architecture.md)
-- **データスキーマ設計書**: [data-schema.md](data-schema.md)
-- **ゲームメカニクス設計書**: [game-mechanics.md](game-mechanics.md)
-- **アーキテクチャ設計書（Phaser版）**: [../atelier-guild-rank-phaser/architecture.md](../atelier-guild-rank-phaser/architecture.md)
-- **UI設計概要（Phaser版）**: [../atelier-guild-rank-phaser/ui-design/overview.md](../atelier-guild-rank-phaser/ui-design/overview.md)
+- [← コアサービス](core-systems-core-services.md)
+- [インフラストラクチャシステム](core-systems-infrastructure.md)
+- [システム構成概要](core-systems-overview.md)
+- [アーキテクチャ設計 - 概要](architecture-overview.md)
+- [アーキテクチャ設計 - コンポーネント](architecture-components.md)
+- [データスキーマ設計 - セーブデータ](data-schema-save.md)
+- [データスキーマ設計 - マスターデータ（カード）](data-schema-master-cards.md)
 
 ---
 


### PR DESCRIPTION
## Summary
- 2つのアーキテクチャビュー（レイヤード/Feature-Based+FC/IS）の関係マッピング表を追加
- ドメインサービスの純粋計算/ステートフル分類を文書化
- DIコンテナ設計（Container, ServiceKeys, 初期化順序）をドキュメント化
- EventBusの使用パターン（DI注入 vs シングルトン参照）を明確化
- 分割前の古いファイル名リンクを最新に更新

Closes #309

## Test plan
- [ ] 各セクションの技術内容が実装コードと整合していることを確認
- [ ] 関連文書リンクが全て有効であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)