### PR TITLE
chore: rexUI型安全性改善（biome-ignore 12件削除・as never解消）

### DIFF
--- a/atelier-guild-rank/src/features/gathering/components/GatheringPhaseUI.ts
+++ b/atelier-guild-rank/src/features/gathering/components/GatheringPhaseUI.ts
@@ -20,6 +20,7 @@ import type {
   DraftSession,
   IGatheringService,
 } from '@domain/interfaces/gathering-service.interface';
+import type { Card } from '@features/deck/types/card';
 import { Button } from '@presentation/ui/components/Button';
 import { THEME } from '@presentation/ui/theme';
 import { BaseComponent } from '@shared/components';
@@ -479,7 +480,10 @@ export class GatheringPhaseUI extends BaseComponent {
     // cardIdからCardオブジェクトを取得する処理は上位層が担当
     // ここではサービスに直接委譲
     // TODO(TASK-0114): startDraftGatheringの引数型をcardId直接受け取りに拡張する
-    const draftSession = this.gatheringService.startDraftGathering({ id: result.cardId } as never);
+    // 暫定: cardIdのみで仮のCardオブジェクトを構築（上位層でCard取得を行うべき）
+    const draftSession = this.gatheringService.startDraftGathering({
+      id: result.cardId,
+    } as unknown as Card);
 
     if (!draftSession) {
       console.warn(

--- a/atelier-guild-rank/src/scenes/MainScene.ts
+++ b/atelier-guild-rank/src/scenes/MainScene.ts
@@ -225,35 +225,27 @@ export class MainScene extends Phaser.Scene {
     this.unsubscribeHandlers = [];
 
     this.unsubscribeHandlers.push(
-      // biome-ignore lint/suspicious/noExplicitAny: EventBusのIBusEvent型に対応
-      this.eventBus.on(GameEventType.PHASE_CHANGED, (busEvent: any) => {
-        const event = busEvent.payload as IPhaseChangedEvent;
-        this.phaseManager.showPhase(event.newPhase);
+      this.eventBus.on<IPhaseChangedEvent>(GameEventType.PHASE_CHANGED, (busEvent) => {
+        this.phaseManager.showPhase(busEvent.payload.newPhase);
         this.phaseManager.updateSidebar(this.sidebarUI);
       }),
     );
 
     this.unsubscribeHandlers.push(
-      // biome-ignore lint/suspicious/noExplicitAny: EventBusのIBusEvent型に対応
-      this.eventBus.on(GameEventType.DAY_STARTED, (busEvent: any) => {
-        const event = busEvent.payload as { remainingDays: number };
-        this.handleDayStarted(event);
+      this.eventBus.on<{ remainingDays: number }>(GameEventType.DAY_STARTED, (busEvent) => {
+        this.handleDayStarted(busEvent.payload);
       }),
     );
 
     this.unsubscribeHandlers.push(
-      // biome-ignore lint/suspicious/noExplicitAny: EventBusのIBusEvent型に対応
-      this.eventBus.on(GameEventType.QUEST_GENERATED, (busEvent: any) => {
-        const event = busEvent.payload as { quests: IQuest[] };
-        this.phaseManager.handleQuestGenerated(event);
+      this.eventBus.on<{ quests: IQuest[] }>(GameEventType.QUEST_GENERATED, (busEvent) => {
+        this.phaseManager.handleQuestGenerated(busEvent.payload);
       }),
     );
 
     this.unsubscribeHandlers.push(
-      // biome-ignore lint/suspicious/noExplicitAny: EventBusのIBusEvent型に対応
-      this.eventBus.on(GameEventType.QUEST_ACCEPTED, (busEvent: any) => {
-        const event = busEvent.payload as { quest: IQuest };
-        this.phaseManager.handleQuestAccepted(event, this.sidebarUI);
+      this.eventBus.on<{ quest: IQuest }>(GameEventType.QUEST_ACCEPTED, (busEvent) => {
+        this.phaseManager.handleQuestAccepted(busEvent.payload, this.sidebarUI);
       }),
     );
   }

--- a/atelier-guild-rank/src/scenes/ShopScene.ts
+++ b/atelier-guild-rank/src/scenes/ShopScene.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IPurchaseResult, IShopItem, IShopService } from '@features/shop';
-import type { RexLabel, RexUIPlugin } from '@presentation/types/rexui';
+import type { RexLabel, RexSizer, RexUIPlugin } from '@presentation/types/rexui';
 import { THEME } from '@presentation/ui/theme';
 import { Container, ServiceKeys } from '@shared/services/di/container';
 import type { GuildRank } from '@shared/types';
@@ -162,11 +162,9 @@ export class ShopScene extends Phaser.Scene {
 
   /**
    * アイテムUIリスト
-   * 各アイテムUIにはカスタムプロパティ（item, buyButton, card）が追加されるため、
-   * RexSizer型では対応できず、anyを使用する必要がある
+   * 各アイテムUIにはrexUIコンポーネントとショップアイテムの参照を保持
    */
-  // biome-ignore lint/suspicious/noExplicitAny: カスタムプロパティを持つためanyが必要
-  private itemUIs: any[] = [];
+  private itemUIs: Array<{ card: RexSizer; item: IShopItem; buyButton: RexLabel }> = [];
 
   // ===========================================================================
   // rexUIプラグイン

--- a/atelier-guild-rank/src/scenes/TitleScene.ts
+++ b/atelier-guild-rank/src/scenes/TitleScene.ts
@@ -406,8 +406,7 @@ export class TitleScene extends Phaser.Scene {
     return dialog;
   }
 
-  // biome-ignore lint/suspicious/noExplicitAny: rexUI Labelの型は複雑
-  private createDialogButton(action: DialogAction): any {
+  private createDialogButton(action: DialogAction): RexLabel {
     const bg = this.rexUI.add.roundRectangle(
       0,
       0,
@@ -450,8 +449,7 @@ export class TitleScene extends Phaser.Scene {
     this.cameras.main.fadeIn(TITLE_ANIMATION.FADE_DURATION, 0, 0, 0);
   }
 
-  // biome-ignore lint/suspicious/noExplicitAny: シーンデータは任意の型を許容
-  private fadeOutToScene(targetScene: string, sceneData?: any): void {
+  private fadeOutToScene(targetScene: string, sceneData?: Record<string, unknown>): void {
     this.cameras.main.fadeOut(TITLE_ANIMATION.FADE_DURATION, 0, 0, 0);
     this.cameras.main.once('camerafadeoutcomplete', () => {
       sceneData !== undefined

--- a/atelier-guild-rank/src/scenes/types/main-scene-types.ts
+++ b/atelier-guild-rank/src/scenes/types/main-scene-types.ts
@@ -46,8 +46,7 @@ export interface IMainSceneGameFlowManager {
   startPhase(phase: GamePhase): void;
   endPhase(): void;
   startNewGame(): void;
-  // biome-ignore lint/suspicious/noExplicitAny: セーブデータは任意の型を許容（ISaveData）
-  continueGame(saveData: any): void;
+  continueGame(saveData: unknown): void;
   startDay(): void;
   endDay(): void;
   skipPhase(): void;
@@ -62,12 +61,21 @@ export interface IBasePhaseUI {
 }
 
 /**
+ * EventBusイベントの構造（IMainSceneEventBus用）
+ */
+interface IBusEvent<T = unknown> {
+  type: string;
+  payload: T;
+  timestamp: number;
+}
+
+/**
  * EventBus インターフェース（依存注入用）
  */
 export interface IMainSceneEventBus {
   emit(event: string, data: unknown): void;
-  on(event: string, handler: (...args: unknown[]) => void): () => void;
-  off(event: string, handler?: (...args: unknown[]) => void): void;
+  on<T = unknown>(event: string, handler: (busEvent: IBusEvent<T>) => void): () => void;
+  off(event: string, handler?: (busEvent: IBusEvent) => void): void;
 }
 
 /**
@@ -78,6 +86,5 @@ export interface MainSceneData {
   /** 新規ゲーム開始フラグ（TitleSceneから渡される） */
   isNewGame?: boolean;
   /** セーブデータ（コンティニュー時に渡される） */
-  // biome-ignore lint/suspicious/noExplicitAny: セーブデータは任意の型を許容
-  saveData?: any;
+  saveData?: unknown;
 }

--- a/atelier-guild-rank/src/shared/components/BaseComponent.ts
+++ b/atelier-guild-rank/src/shared/components/BaseComponent.ts
@@ -115,8 +115,7 @@ export abstract class BaseComponent {
       get(target, prop) {
         if (prop === 'x') return coordinates.x;
         if (prop === 'y') return coordinates.y;
-        // biome-ignore lint/suspicious/noExplicitAny: Proxyのため
-        return (target as any)[prop];
+        return (target as unknown as Record<string | symbol, unknown>)[prop];
       },
       set(target, prop, value) {
         if (prop === 'x') {
@@ -127,8 +126,7 @@ export abstract class BaseComponent {
           coordinates.y = value;
           return true;
         }
-        // biome-ignore lint/suspicious/noExplicitAny: Proxyのため
-        (target as any)[prop] = value;
+        (target as unknown as Record<string | symbol, unknown>)[prop] = value;
         return true;
       },
     });

--- a/atelier-guild-rank/src/shared/presentation/ui/components/QuestCardUI.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/components/QuestCardUI.ts
@@ -336,6 +336,14 @@ export class QuestCardUI extends BaseComponent {
   }
 
   /**
+   * 【背景を取得する】: カードクリックハンドラ設定用にbackgroundを公開
+   * @returns 背景のGameObject
+   */
+  public getBackground(): Phaser.GameObjects.Rectangle {
+    return this.background;
+  }
+
+  /**
    * 【コンポーネントを破棄する】: すべてのGameObjectsとコンテナを破棄
    * 【メモリリーク防止】: 各要素を個別に破棄し、メモリリークを防止
    * 【型安全性】: 各要素の存在確認を行ってから破棄

--- a/atelier-guild-rank/src/shared/presentation/ui/phases/QuestAcceptPhaseUI.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/phases/QuestAcceptPhaseUI.ts
@@ -370,9 +370,7 @@ export class QuestAcceptPhaseUI extends BaseComponent {
    * @param quest - 依頼データ
    */
   private setupCardClickHandler(questCard: QuestCardUI, quest: Quest): void {
-    // 【型安全性】: backgroundはprivateプロパティのためanyでアクセス
-    // biome-ignore lint/suspicious/noExplicitAny: backgroundはprivateプロパティのためanyでアクセス
-    const background = (questCard as any).background;
+    const background = questCard.getBackground();
     if (background?.on) {
       background.on('pointerdown', () => {
         this.openQuestDetailModal(quest);

--- a/atelier-guild-rank/tests/unit/presentation/ui/phases/QuestAcceptPhaseUI-board-visitor.test.ts
+++ b/atelier-guild-rank/tests/unit/presentation/ui/phases/QuestAcceptPhaseUI-board-visitor.test.ts
@@ -76,6 +76,9 @@ vi.mock('@presentation/ui/components/QuestCardUI', () => ({
     getContainer() {
       return this.mockContainer;
     }
+    getBackground() {
+      return this.background;
+    }
     setSelected() {}
   },
 }));


### PR DESCRIPTION
## Summary
- rexUI関連のbiome-ignoreコメントを12件削除（14件→2件）
- as neverキャストを1件解消（Card型に置換）
- EventBusハンドラにジェネリック型パラメータを追加し型安全性を向上
- BaseComponentのProxy型を改善
- QuestCardUIにgetBackground()公開メソッドを追加しprivateアクセスを解消

Closes #311

## Test plan
- [x] TypeScript型チェックがパスすること
- [x] Biome lintがパスすること
- [x] 全テスト（2621件）がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)