### PR TITLE
refactor: IBusEventのローカル重複定義を解消

### DIFF
--- a/atelier-guild-rank/src/scenes/types/main-scene-types.ts
+++ b/atelier-guild-rank/src/scenes/types/main-scene-types.ts
@@ -7,6 +7,7 @@
  * DIコンテナから取得するサービスの型定義を含む。
  */
 
+import type { EventHandler } from '@shared/services';
 import type { GamePhase, GuildRank } from '@shared/types/common';
 
 // =============================================================================
@@ -61,21 +62,13 @@ export interface IBasePhaseUI {
 }
 
 /**
- * EventBusイベントの構造（IMainSceneEventBus用）
- */
-interface IBusEvent<T = unknown> {
-  type: string;
-  payload: T;
-  timestamp: number;
-}
-
-/**
  * EventBus インターフェース（依存注入用）
+ * IBusEvent/EventHandler は shared/services/event-bus/types.ts の本家定義を再利用
  */
 export interface IMainSceneEventBus {
   emit(event: string, data: unknown): void;
-  on<T = unknown>(event: string, handler: (busEvent: IBusEvent<T>) => void): () => void;
-  off(event: string, handler?: (busEvent: IBusEvent) => void): void;
+  on<T = unknown>(event: string, handler: EventHandler<T>): () => void;
+  off(event: string, handler?: EventHandler): void;
 }
 
 /**


### PR DESCRIPTION
## Summary
- `main-scene-types.ts` のローカル `IBusEvent` 定義を削除し、`shared/services/event-bus/types.ts` の本家定義（`EventHandler`）を再利用するよう修正
- `IMainSceneEventBus` の `on`/`off` メソッドのハンドラー型を `EventHandler<T>` に統一
- DRY原則違反の解消と型不整合（`string` vs `GameEventType`）リスクの排除

Closes #343

## Test plan
- [x] TypeScript型チェック（`pnpm typecheck`）パス
- [x] Biome lint チェック パス
- [x] 全ユニットテスト（145ファイル、2621テスト）パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)