### PR TITLE
fix: MainScene遷移E2Eテストのデバッグツール依存を修正

### DIFF
--- a/atelier-guild-rank/e2e/pages/base.page.ts
+++ b/atelier-guild-rank/e2e/pages/base.page.ts
@@ -142,12 +142,30 @@ export abstract class BasePage {
   // =============================================================================
 
   /**
+   * デバッグツールが利用可能になるまで待機
+   * Issue #365: window.debugの初期化タイミング問題を解消
+   *
+   * @param timeout - 待機タイムアウト（ミリ秒）
+   */
+  protected async waitForDebugReady(timeout: number = BasePage.DEFAULT_TIMEOUT): Promise<void> {
+    await this.page.waitForFunction(
+      () => {
+        // biome-ignore lint/suspicious/noExplicitAny: window拡張型のため
+        return (window as any).debug !== undefined;
+      },
+      { timeout },
+    );
+  }
+
+  /**
    * デバッグアクションを実行（引数なし）
+   * Issue #365: デバッグツール初期化完了を待機してから実行
    *
    * @param actionName - 実行するアクション名
    * @throws デバッグツールが利用不可の場合
    */
   protected async executeDebugAction(actionName: string): Promise<void> {
+    await this.waitForDebugReady();
     await this.page.evaluate((name) => {
       const debug = (window as unknown as GameWindow).debug;
       // biome-ignore lint/suspicious/noExplicitAny: 動的メソッド呼び出しのため
@@ -162,12 +180,14 @@ export abstract class BasePage {
 
   /**
    * デバッグアクションを実行（引数あり）
+   * Issue #365: デバッグツール初期化完了を待機してから実行
    *
    * @param actionName - 実行するアクション名
    * @param arg - アクションに渡す引数
    * @throws デバッグツールが利用不可の場合
    */
   protected async executeDebugActionWithArg<T>(actionName: string, arg: T): Promise<void> {
+    await this.waitForDebugReady();
     await this.page.evaluate(
       ({ name, value }) => {
         const debug = (window as unknown as GameWindow).debug;

--- a/atelier-guild-rank/e2e/pages/main.page.ts
+++ b/atelier-guild-rank/e2e/pages/main.page.ts
@@ -201,15 +201,17 @@ export class MainPage extends BasePage {
 
   /**
    * フェーズが利用可能になるまで待機
+   * Issue #365: StateManager初期化完了を確実に待機するためタイムアウトを延長
    */
   private async waitForPhaseAvailable(): Promise<void> {
+    const extendedTimeout = BasePage.DEFAULT_TIMEOUT * 2;
     await this.page.waitForFunction(
       () => {
         // biome-ignore lint/suspicious/noExplicitAny: window拡張型のため
         const state = (window as any).gameState?.();
-        return state?.currentPhase !== undefined;
+        return state?.currentPhase !== undefined && state?.currentPhase !== null;
       },
-      { timeout: BasePage.DEFAULT_TIMEOUT },
+      { timeout: extendedTimeout },
     );
   }
 }

--- a/atelier-guild-rank/e2e/pages/phase-flow.page.ts
+++ b/atelier-guild-rank/e2e/pages/phase-flow.page.ts
@@ -193,6 +193,7 @@ export class PhaseFlowPage extends BasePage {
 
   /**
    * 1日分の全フェーズをデバッグスキップで進める
+   * Issue #365: シーン遷移によるコンテキスト破棄を安全にハンドリング
    *
    * @returns 日終了前後のゲーム状態
    */
@@ -202,6 +203,19 @@ export class PhaseFlowPage extends BasePage {
     // 4フェーズをスキップ: QuestAccept → Gathering → Alchemy → Delivery
     for (let i = 0; i < 4; i++) {
       await this.skipCurrentPhase();
+
+      // フェーズスキップ後にシーン遷移が発生した場合は中断
+      try {
+        const state = await this.getGameState();
+        if (state.currentScene !== 'MainScene') {
+          return { before, after: state };
+        }
+      } catch {
+        // コンテキスト破棄（シーン遷移中）の場合はリトライ
+        await this.page.waitForTimeout(PhaseFlowPage.WAIT.SCENE_TRANSITION);
+        const state = await this.getGameState();
+        return { before, after: state };
+      }
     }
 
     const after = await this.getGameState();

--- a/atelier-guild-rank/e2e/pages/title.page.ts
+++ b/atelier-guild-rank/e2e/pages/title.page.ts
@@ -29,6 +29,7 @@ export class TitlePage extends BasePage {
 
   /**
    * 新規ゲームボタンをクリック
+   * Issue #365: デバッグツール初期化完了を待機してから実行
    *
    * @description
    * デバッグツール経由で新規ゲームを開始する。
@@ -36,6 +37,7 @@ export class TitlePage extends BasePage {
    * @throws デバッグツールが利用不可の場合
    */
   async clickNewGame(): Promise<void> {
+    await this.waitForDebugReady();
     await this.page.evaluate(() => {
       const debug = (window as unknown as GameWindow).debug;
       if (debug?.clickNewGame) {
@@ -48,6 +50,7 @@ export class TitlePage extends BasePage {
 
   /**
    * コンティニューボタンをクリック
+   * Issue #365: デバッグツール初期化完了を待機してから実行
    *
    * @description
    * デバッグツール経由でコンティニューを実行する。
@@ -55,6 +58,7 @@ export class TitlePage extends BasePage {
    * @throws デバッグツールが利用不可の場合
    */
   async clickContinue(): Promise<void> {
+    await this.waitForDebugReady();
     await this.page.evaluate(() => {
       const debug = (window as unknown as GameWindow).debug;
       if (debug?.clickContinue) {

--- a/atelier-guild-rank/e2e/specs/scenario/multi-day-play.spec.ts
+++ b/atelier-guild-rank/e2e/specs/scenario/multi-day-play.spec.ts
@@ -16,6 +16,9 @@ import { PhaseFlowPage } from '../../pages/phase-flow.page';
 import { TitlePage } from '../../pages/title.page';
 
 test.describe('SCN-007: 複数日連続プレイ', () => {
+  // Issue #365: skipFullDay()×3回で12秒以上かかるためタイムアウトを延長
+  test.describe.configure({ timeout: 60000 });
+
   test.beforeEach(async ({ gamePage }) => {
     // セーブデータをクリア
     await gamePage.evaluate(() => {

--- a/atelier-guild-rank/src/main.ts
+++ b/atelier-guild-rank/src/main.ts
@@ -17,7 +17,7 @@ import {
 import { Container, ServiceKeys } from '@shared/services/di/container';
 import type { IStateManager } from '@shared/services/state-manager';
 // debug.ts でグローバル型 (window.game, window.gameState, window.debug) が定義されている
-import '@shared/utils/debug';
+import { DebugTools } from '@shared/utils/debug';
 import Phaser from 'phaser';
 import RexUIPlugin from 'phaser3-rex-plugins/templates/ui/ui-plugin';
 
@@ -180,11 +180,10 @@ window.gameState = () => {
 };
 
 /**
- * window.debug - デバッグツールを公開
+ * window.debug - デバッグツールを公開（同期初期化）
  *
  * 【用途】: 開発時のゲーム状態操作、E2Eテスト補助
  * 【注意】: 本番ビルドでは別途削除を検討
+ * Issue #365: 非同期importではE2Eテスト実行時に初期化が間に合わないため同期importに変更
  */
-import('@shared/utils/debug').then(({ DebugTools }) => {
-  window.debug = DebugTools;
-});
+window.debug = DebugTools;


### PR DESCRIPTION
## Summary
- `window.debug`の非同期初期化（動的import）を同期初期化に変更し、E2Eテスト実行時にデバッグツールが確実に利用可能になるよう修正
- 全デバッグアクション実行前に`waitForDebugReady()`で初期化完了を待機するガード処理を追加
- `skipFullDay()`でシーン遷移（ゲームオーバー/クリア）時のコンテキスト破棄を安全にハンドリング

## 変更内容

### 根本原因の修正
- **`src/main.ts`**: `import('@shared/utils/debug').then(...)` → `import { DebugTools } from '@shared/utils/debug'` + `window.debug = DebugTools` に変更

### E2E Page Object改善
- **`e2e/pages/base.page.ts`**: `waitForDebugReady()` ヘルパーメソッドを追加。`executeDebugAction()` / `executeDebugActionWithArg()` の先頭で呼び出し
- **`e2e/pages/title.page.ts`**: `clickNewGame()` / `clickContinue()` に `waitForDebugReady()` を追加
- **`e2e/pages/main.page.ts`**: `waitForPhaseAvailable()` のタイムアウトを2倍に延長、nullチェック追加
- **`e2e/pages/phase-flow.page.ts`**: `skipFullDay()` で各フェーズスキップ後にシーン遷移検知・コンテキスト破棄時のリトライ処理を追加
- **`e2e/specs/scenario/multi-day-play.spec.ts`**: SCN-007テストのタイムアウトを60秒に延長

## Test plan
- [x] `pnpm typecheck` パス
- [x] `pnpm test --run` 全2651ユニットテストパス
- [x] Issue #365対象の28件E2Eテスト全てパス（SCN-001, SCN-002, SCN-004, SCN-006, SCN-007, TC-E2E-002, TC-E2E-040等）

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)