### PR TITLE
refactor: スクロール機能をScrollableContainerとして共通コンポーネント化

### DIFF
--- a/atelier-guild-rank/src/features/alchemy/components/AlchemyPhaseUI.ts
+++ b/atelier-guild-rank/src/features/alchemy/components/AlchemyPhaseUI.ts
@@ -21,6 +21,7 @@ import type { IAlchemyService } from '@domain/interfaces/alchemy-service.interfa
 import type { RexRoundRectangle } from '@presentation/types/rexui';
 import { BaseComponent } from '@presentation/ui/components/BaseComponent';
 import { THEME } from '@presentation/ui/theme';
+import { ScrollableContainer } from '@shared/components/ScrollableContainer';
 import { MAIN_LAYOUT } from '@shared/constants';
 import { getSelectionIndexFromKey, isKeyForAction } from '@shared/constants/keybindings';
 import type { CardId, Quality } from '@shared/types';
@@ -120,27 +121,8 @@ export class AlchemyPhaseUI extends BaseComponent {
   /** 現在のフォーカスインデックス（キーボードナビゲーション用） */
   private focusedRecipeIndex = 0;
 
-  /** スクロール用サブコンテナ（Issue #357） */
-  private recipeScrollContainer: Phaser.GameObjects.Container | null = null;
-
-  /** スクロールマスク用グラフィックス */
-  private scrollMaskGraphics: Phaser.GameObjects.Graphics | null = null;
-
-  /** スクロールオフセット */
-  private scrollOffset = 0;
-
-  /** マウスホイールハンドラ参照 */
-  private wheelHandler:
-    | ((
-        pointer: Phaser.Input.Pointer,
-        gameObjects: Phaser.GameObjects.GameObject[],
-        deltaX: number,
-        deltaY: number,
-      ) => void)
-    | null = null;
-
-  /** レシピリストの総コンテンツ高さ（スクロール計算用） */
-  private recipeListTotalHeight = 0;
+  /** スクロール可能なコンテナ（Issue #357 → Issue #368: ScrollableContainerに統合） */
+  private scrollableContainer: ScrollableContainer | null = null;
 
   /**
    * コンストラクタ
@@ -248,8 +230,8 @@ export class AlchemyPhaseUI extends BaseComponent {
       currentY += cardHeight + ALCHEMY_PHASE_LAYOUT.ITEM_SPACING;
     }
 
-    // スクロール計算用にリスト全体の高さを記録
-    this.recipeListTotalHeight = currentY;
+    // Issue #368: ScrollableContainerにコンテンツ高さを通知
+    this.scrollableContainer?.setContentHeight(currentY);
     this.resetScroll();
   }
 
@@ -341,8 +323,8 @@ export class AlchemyPhaseUI extends BaseComponent {
       materialY += ALCHEMY_PHASE_LAYOUT.MATERIAL_LINE_HEIGHT;
     }
 
-    // スクロールコンテナに追加（Issue #357: スクロール対応）
-    const targetContainer = this.recipeScrollContainer ?? this.container;
+    // スクロールコンテナに追加（Issue #357 → Issue #368: ScrollableContainerに統合）
+    const targetContainer = this.scrollableContainer?.getScrollContainer() ?? this.container;
     targetContainer.add(cardContainer);
 
     // インタラクション設定（調合可能なレシピのみ）
@@ -614,7 +596,6 @@ export class AlchemyPhaseUI extends BaseComponent {
    */
   destroy(): void {
     this.removeKeyboardListener();
-    this.removeScrollHandler();
     for (const item of this.recipeLabels) {
       item.cardContainer.destroy(true);
     }
@@ -717,126 +698,47 @@ export class AlchemyPhaseUI extends BaseComponent {
   }
 
   // =============================================================================
-  // Issue #357: スクロール機能
+  // Issue #357 → Issue #368: スクロール機能（ScrollableContainerに統合）
   // =============================================================================
 
   /**
    * レシピリスト用のスクロールエリアを作成
    */
   private createRecipeScrollArea(): void {
-    this.recipeScrollContainer = this.scene.add.container(0, 0);
-    this.container.add(this.recipeScrollContainer);
-    this.applyScrollMask();
-    this.setupScrollHandler();
-  }
+    const gameWidth = this.scene.cameras.main.width;
+    const gameHeight = this.scene.cameras.main.height;
 
-  /**
-   * GeometryMaskを適用してフッター領域をクリッピング
-   */
-  private applyScrollMask(): void {
-    if (!this.recipeScrollContainer) return;
-
-    try {
-      const gameWidth = this.scene.cameras.main.width;
-      const maskX = MAIN_LAYOUT.SIDEBAR_WIDTH;
-      const maskY = MAIN_LAYOUT.HEADER_HEIGHT + ALCHEMY_PHASE_LAYOUT.RECIPE_LIST_START_Y;
-      const maskWidth = gameWidth - MAIN_LAYOUT.SIDEBAR_WIDTH;
-      const maskHeight =
-        this.scene.cameras.main.height -
-        MAIN_LAYOUT.HEADER_HEIGHT -
-        MAIN_LAYOUT.FOOTER_HEIGHT -
-        ALCHEMY_PHASE_LAYOUT.RECIPE_LIST_START_Y;
-
-      this.scrollMaskGraphics = this.scene.make.graphics({});
-      this.scrollMaskGraphics.fillStyle(0xffffff);
-      this.scrollMaskGraphics.fillRect(maskX, maskY, maskWidth, maskHeight);
-
-      const mask = this.scrollMaskGraphics.createGeometryMask();
-      this.recipeScrollContainer.setMask(mask);
-    } catch {
-      // make.graphicsが使用できない場合はマスクなしで動作
-    }
-  }
-
-  /**
-   * マウスホイールスクロールハンドラを設定
-   */
-  private setupScrollHandler(): void {
-    this.wheelHandler = (
-      _pointer: Phaser.Input.Pointer,
-      _gameObjects: Phaser.GameObjects.GameObject[],
-      _deltaX: number,
-      deltaY: number,
-    ) => {
-      if (!this.container.visible) return;
-      this.applyScroll(deltaY);
-    };
-    this.scene.input?.on?.('wheel', this.wheelHandler);
-  }
-
-  /**
-   * スクロールを適用
-   */
-  private applyScroll(deltaY: number): void {
-    if (!this.recipeScrollContainer) return;
-
-    const maxOffset = this.getMaxScrollOffset();
-    if (maxOffset <= 0) return;
-
-    this.scrollOffset += deltaY * ALCHEMY_PHASE_LAYOUT.SCROLL_SPEED;
-    this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, maxOffset));
-    this.recipeScrollContainer.y = -this.scrollOffset;
+    this.scrollableContainer = new ScrollableContainer(this.scene, this.container, {
+      maskBounds: {
+        x: MAIN_LAYOUT.SIDEBAR_WIDTH,
+        y: MAIN_LAYOUT.HEADER_HEIGHT + ALCHEMY_PHASE_LAYOUT.RECIPE_LIST_START_Y,
+        width: gameWidth - MAIN_LAYOUT.SIDEBAR_WIDTH,
+        height:
+          gameHeight -
+          MAIN_LAYOUT.HEADER_HEIGHT -
+          MAIN_LAYOUT.FOOTER_HEIGHT -
+          ALCHEMY_PHASE_LAYOUT.RECIPE_LIST_START_Y,
+      },
+      scrollSpeed: ALCHEMY_PHASE_LAYOUT.SCROLL_SPEED,
+      isScrollEnabled: () => this.container.visible,
+    });
+    this.scrollableContainer.create();
   }
 
   /**
    * スクロール位置をリセット
    */
   private resetScroll(): void {
-    this.scrollOffset = 0;
-    if (this.recipeScrollContainer) {
-      this.recipeScrollContainer.y = 0;
-    }
-  }
-
-  /**
-   * 最大スクロールオフセットを計算
-   */
-  private getMaxScrollOffset(): number {
-    const visibleHeight = this.getRecipeAreaVisibleHeight();
-    return Math.max(0, this.recipeListTotalHeight - visibleHeight);
-  }
-
-  /**
-   * レシピエリアの可視高さを取得
-   */
-  private getRecipeAreaVisibleHeight(): number {
-    const gameHeight = this.scene.cameras.main.height;
-    return (
-      gameHeight -
-      MAIN_LAYOUT.HEADER_HEIGHT -
-      MAIN_LAYOUT.FOOTER_HEIGHT -
-      ALCHEMY_PHASE_LAYOUT.RECIPE_LIST_START_Y
-    );
-  }
-
-  /**
-   * マウスホイールハンドラを解除
-   */
-  private removeScrollHandler(): void {
-    if (this.wheelHandler) {
-      this.scene.input?.off?.('wheel', this.wheelHandler);
-      this.wheelHandler = null;
-    }
+    this.scrollableContainer?.resetScroll();
   }
 
   /**
    * スクロールエリアを破棄
    */
   private destroyScrollArea(): void {
-    if (this.scrollMaskGraphics) {
-      this.scrollMaskGraphics.destroy();
-      this.scrollMaskGraphics = null;
+    if (this.scrollableContainer) {
+      this.scrollableContainer.destroy();
+      this.scrollableContainer = null;
     }
-    this.recipeScrollContainer = null;
   }
 }

--- a/atelier-guild-rank/src/shared/components/ScrollableContainer.ts
+++ b/atelier-guild-rank/src/shared/components/ScrollableContainer.ts
@@ -1,0 +1,246 @@
+/**
+ * ScrollableContainer - スクロール可能なコンテナコンポーネント
+ * Issue #368: QuestAcceptPhaseUI/AlchemyPhaseUIの共通スクロールパターンを抽出
+ *
+ * @description
+ * GeometryMask + マウスホイールスクロールの共通パターンを提供する。
+ * コンテンツをマスク範囲内にクリッピングし、ホイール操作でスクロールできる。
+ */
+
+import type Phaser from 'phaser';
+
+/**
+ * マスク領域の矩形定義（ワールド座標）
+ */
+export interface ScrollMaskBounds {
+  /** マスク左上X座標 */
+  x: number;
+  /** マスク左上Y座標 */
+  y: number;
+  /** マスク幅 */
+  width: number;
+  /** マスク高さ */
+  height: number;
+}
+
+/**
+ * ScrollableContainerの設定
+ */
+export interface ScrollableContainerConfig {
+  /** マスク領域の矩形（ワールド座標） */
+  maskBounds: ScrollMaskBounds;
+  /** スクロール速度係数（デフォルト: 0.5） */
+  scrollSpeed?: number;
+  /** スクロール可能かを判定するコールバック（デフォルト: 常にtrue） */
+  isScrollEnabled?: () => boolean;
+}
+
+/** デフォルトのスクロール速度 */
+const DEFAULT_SCROLL_SPEED = 0.5;
+
+/**
+ * スクロール可能なコンテナコンポーネント
+ *
+ * GeometryMaskによるクリッピングとマウスホイールスクロールを提供する。
+ * 利用側は getScrollContainer() で内部コンテナを取得し、コンテンツを追加する。
+ *
+ * @example
+ * ```typescript
+ * const scrollable = new ScrollableContainer(scene, parentContainer, {
+ *   maskBounds: { x: 200, y: 140, width: 1080, height: 460 },
+ *   scrollSpeed: 0.5,
+ *   isScrollEnabled: () => this.container.visible,
+ * });
+ * scrollable.create();
+ *
+ * // コンテンツを追加
+ * scrollable.getScrollContainer().add(someGameObject);
+ *
+ * // コンテンツ高さを更新
+ * scrollable.setContentHeight(800);
+ *
+ * // 破棄
+ * scrollable.destroy();
+ * ```
+ */
+export class ScrollableContainer {
+  private readonly scene: Phaser.Scene;
+  private readonly parentContainer: Phaser.GameObjects.Container;
+  private readonly config: Required<ScrollableContainerConfig>;
+
+  /** スクロール用サブコンテナ */
+  private scrollContainer: Phaser.GameObjects.Container | null = null;
+
+  /** マスク用Graphicsオブジェクト */
+  private maskGraphics: Phaser.GameObjects.Graphics | null = null;
+
+  /** 現在のスクロールオフセット（px） */
+  private scrollOffset = 0;
+
+  /** マウスホイールハンドラ参照 */
+  private wheelHandler:
+    | ((
+        pointer: Phaser.Input.Pointer,
+        gameObjects: Phaser.GameObjects.GameObject[],
+        deltaX: number,
+        deltaY: number,
+      ) => void)
+    | null = null;
+
+  /** コンテンツの総高さ */
+  private contentHeight = 0;
+
+  /**
+   * @param scene - Phaserシーン
+   * @param parentContainer - スクロールコンテナを追加する親コンテナ
+   * @param config - スクロール設定
+   */
+  constructor(
+    scene: Phaser.Scene,
+    parentContainer: Phaser.GameObjects.Container,
+    config: ScrollableContainerConfig,
+  ) {
+    if (!scene) {
+      throw new Error('ScrollableContainer: scene is required');
+    }
+    if (!parentContainer) {
+      throw new Error('ScrollableContainer: parentContainer is required');
+    }
+    if (!config.maskBounds) {
+      throw new Error('ScrollableContainer: maskBounds is required');
+    }
+
+    this.scene = scene;
+    this.parentContainer = parentContainer;
+    this.config = {
+      maskBounds: config.maskBounds,
+      scrollSpeed: config.scrollSpeed ?? DEFAULT_SCROLL_SPEED,
+      isScrollEnabled: config.isScrollEnabled ?? (() => true),
+    };
+  }
+
+  /**
+   * スクロールエリアを作成
+   * マスク付きコンテナとホイールハンドラをセットアップする
+   */
+  create(): void {
+    this.scrollContainer = this.scene.add.container(0, 0);
+    this.parentContainer.add(this.scrollContainer);
+    this.applyMask();
+    this.setupWheelHandler();
+  }
+
+  /**
+   * スクロール用コンテナを取得
+   * コンテンツはこのコンテナに追加する
+   */
+  getScrollContainer(): Phaser.GameObjects.Container | null {
+    return this.scrollContainer;
+  }
+
+  /**
+   * コンテンツの総高さを設定
+   * スクロール上限の計算に使用される
+   *
+   * @param height - コンテンツの総高さ（px）
+   */
+  setContentHeight(height: number): void {
+    this.contentHeight = height;
+  }
+
+  /**
+   * スクロール位置を先頭にリセット
+   */
+  resetScroll(): void {
+    this.scrollOffset = 0;
+    if (this.scrollContainer) {
+      this.scrollContainer.y = 0;
+    }
+  }
+
+  /**
+   * 現在のスクロールオフセットを取得
+   */
+  getScrollOffset(): number {
+    return this.scrollOffset;
+  }
+
+  /**
+   * 最大スクロールオフセットを取得
+   */
+  getMaxScrollOffset(): number {
+    return Math.max(0, this.contentHeight - this.config.maskBounds.height);
+  }
+
+  /**
+   * リソースを破棄
+   */
+  destroy(): void {
+    this.removeWheelHandler();
+    if (this.maskGraphics) {
+      this.maskGraphics.destroy();
+      this.maskGraphics = null;
+    }
+    this.scrollContainer = null;
+  }
+
+  /**
+   * GeometryMaskを適用してマスク範囲外をクリッピング
+   */
+  private applyMask(): void {
+    if (!this.scrollContainer) return;
+
+    const { x, y, width, height } = this.config.maskBounds;
+
+    try {
+      this.maskGraphics = this.scene.make.graphics({});
+      this.maskGraphics.fillStyle(0xffffff);
+      this.maskGraphics.fillRect(x, y, width, height);
+
+      const mask = this.maskGraphics.createGeometryMask();
+      this.scrollContainer.setMask(mask);
+    } catch {
+      // make.graphicsが使用できない場合はマスクなしで動作
+    }
+  }
+
+  /**
+   * マウスホイールハンドラを設定
+   */
+  private setupWheelHandler(): void {
+    this.wheelHandler = (
+      _pointer: Phaser.Input.Pointer,
+      _gameObjects: Phaser.GameObjects.GameObject[],
+      _deltaX: number,
+      deltaY: number,
+    ) => {
+      if (!this.config.isScrollEnabled()) return;
+      this.applyScroll(deltaY);
+    };
+    this.scene.input?.on?.('wheel', this.wheelHandler);
+  }
+
+  /**
+   * deltaYに基づいてスクロールオフセットを更新
+   */
+  private applyScroll(deltaY: number): void {
+    if (!this.scrollContainer) return;
+
+    const maxOffset = this.getMaxScrollOffset();
+    if (maxOffset <= 0) return;
+
+    this.scrollOffset += deltaY * this.config.scrollSpeed;
+    this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, maxOffset));
+    this.scrollContainer.y = -this.scrollOffset;
+  }
+
+  /**
+   * マウスホイールハンドラを解除
+   */
+  private removeWheelHandler(): void {
+    if (this.wheelHandler) {
+      this.scene.input?.off?.('wheel', this.wheelHandler);
+      this.wheelHandler = null;
+    }
+  }
+}

--- a/atelier-guild-rank/src/shared/components/index.ts
+++ b/atelier-guild-rank/src/shared/components/index.ts
@@ -19,6 +19,12 @@ export { FooterUI } from './FooterUI';
 export { HeaderUI, type IHeaderUIData } from './HeaderUI';
 // PhaseTabUI
 export { PhaseTabUI } from './PhaseTabUI';
+// ScrollableContainer
+export {
+  ScrollableContainer,
+  type ScrollableContainerConfig,
+  type ScrollMaskBounds,
+} from './ScrollableContainer';
 // RewardCardDialog: Phaser.Events.EventEmitter継承のため、バレルエクスポートから除外
 // 直接インポートを使用: import { RewardCardDialog } from '@shared/components/RewardCardDialog';
 // Sidebar

--- a/atelier-guild-rank/src/shared/presentation/ui/phases/QuestAcceptPhaseUI.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/phases/QuestAcceptPhaseUI.ts
@@ -16,6 +16,7 @@
  */
 
 import type { Quest } from '@domain/entities/Quest';
+import { ScrollableContainer } from '@shared/components/ScrollableContainer';
 import { MAIN_LAYOUT } from '@shared/constants';
 import { getSelectionIndexFromKey, isKeyForAction } from '@shared/constants/keybindings';
 import { GameEventType } from '@shared/types/events';
@@ -89,27 +90,11 @@ export class QuestAcceptPhaseUI extends BaseComponent {
   private focusedCardIndex = -1;
 
   // =============================================================================
-  // スクロール関連プロパティ（Issue #355）
+  // スクロール関連プロパティ（Issue #355 → Issue #368: ScrollableContainerに統合）
   // =============================================================================
 
-  /** カードスクロール用コンテナ */
-  private questCardScrollContainer: Phaser.GameObjects.Container | null = null;
-
-  /** マスク用Graphicsオブジェクト */
-  private cardAreaMaskGraphics: Phaser.GameObjects.Graphics | null = null;
-
-  /** 現在のスクロールオフセット（px） */
-  private scrollOffset = 0;
-
-  /** マウスホイールハンドラ参照 */
-  private wheelHandler:
-    | ((
-        pointer: Phaser.Input.Pointer,
-        gameObjects: Phaser.GameObjects.GameObject[],
-        deltaX: number,
-        deltaY: number,
-      ) => void)
-    | null = null;
+  /** スクロール可能なコンテナ（共通コンポーネント） */
+  private scrollableContainer: ScrollableContainer | null = null;
 
   // =============================================================================
   // 掲示板・訪問依頼管理（TASK-0117）
@@ -358,7 +343,7 @@ export class QuestAcceptPhaseUI extends BaseComponent {
     // Issue #355: スクロール位置をリセット
     this.resetScroll();
 
-    const targetContainer = this.questCardScrollContainer ?? this.container;
+    const targetContainer = this.scrollableContainer?.getScrollContainer() ?? this.container;
     for (let i = 0; i < quests.length; i++) {
       const quest = quests[i];
       const position = this.calculateCardPosition(i);
@@ -367,6 +352,9 @@ export class QuestAcceptPhaseUI extends BaseComponent {
       this.setupCardClickHandler(questCard, quest);
       this.questCards.push(questCard);
     }
+
+    // Issue #368: ScrollableContainerにコンテンツ高さを通知
+    this.scrollableContainer?.setContentHeight(this.getTotalCardContentHeight());
   }
 
   /**
@@ -450,9 +438,6 @@ export class QuestAcceptPhaseUI extends BaseComponent {
   public destroy(): void {
     // 【キーボードリスナー破棄】
     this.removeKeyboardListener();
-
-    // 【スクロールハンドラ破棄】Issue #355
-    this.removeScrollHandler();
 
     // 【カード破棄】: すべてのQuestCardUIを破棄
     this.destroyExistingCards();
@@ -681,110 +666,38 @@ export class QuestAcceptPhaseUI extends BaseComponent {
   }
 
   // =============================================================================
-  // Issue #355: スクロール機能
+  // Issue #355 → Issue #368: スクロール機能（ScrollableContainerに統合）
   // =============================================================================
 
   /**
-   * 【カードスクロールエリア作成】: マスク付きスクロールコンテナを作成
-   *
-   * Issue #355: フッター被り防止のため、カードエリアにクリッピングマスクと
-   * マウスホイールスクロールを追加する。
+   * 【カードスクロールエリア作成】: ScrollableContainerを使用してスクロール可能エリアを作成
    */
   private createCardScrollArea(): void {
-    // スクロール用サブコンテナ（カードはこの中に配置される）
-    this.questCardScrollContainer = this.scene.add.container(0, 0);
-    this.container.add(this.questCardScrollContainer);
-
-    // クリッピングマスクを適用
-    this.applyCardAreaMask();
-
-    // マウスホイールスクロールを設定
-    this.setupScrollHandler();
-  }
-
-  /**
-   * 【クリッピングマスク適用】: カードエリアの表示範囲をフッター上部までに制限
-   *
-   * GeometryMaskはワールド座標で動作するため、既知のレイアウト定数から計算する。
-   */
-  private applyCardAreaMask(): void {
-    if (!this.questCardScrollContainer) return;
-
     const gameWidth = this.scene.cameras?.main?.width ?? 1280;
     const gameHeight = this.scene.cameras?.main?.height ?? 720;
 
-    const maskX = MAIN_LAYOUT.SIDEBAR_WIDTH;
-    const maskY = MAIN_LAYOUT.HEADER_HEIGHT + QuestAcceptPhaseUI.CARD_AREA_OFFSET_Y;
-    const maskWidth = gameWidth - MAIN_LAYOUT.SIDEBAR_WIDTH;
-    const maskHeight =
-      gameHeight -
-      MAIN_LAYOUT.HEADER_HEIGHT -
-      MAIN_LAYOUT.FOOTER_HEIGHT -
-      QuestAcceptPhaseUI.CARD_AREA_OFFSET_Y;
-
-    try {
-      this.cardAreaMaskGraphics = this.scene.make.graphics({});
-      this.cardAreaMaskGraphics.fillStyle(0xffffff);
-      this.cardAreaMaskGraphics.fillRect(maskX, maskY, maskWidth, maskHeight);
-
-      const mask = this.cardAreaMaskGraphics.createGeometryMask();
-      this.questCardScrollContainer.setMask(mask);
-    } catch {
-      // make.graphicsが使用できない場合はマスクなしで動作
-    }
-  }
-
-  /**
-   * 【スクロールハンドラ設定】: マウスホイールでカードエリアをスクロール
-   */
-  private setupScrollHandler(): void {
-    this.wheelHandler = (
-      _pointer: Phaser.Input.Pointer,
-      _gameObjects: Phaser.GameObjects.GameObject[],
-      _deltaX: number,
-      deltaY: number,
-    ) => {
-      if (!this.container.visible) return;
-      this.applyScroll(deltaY);
-    };
-    this.scene.input?.on?.('wheel', this.wheelHandler);
-  }
-
-  /**
-   * 【スクロール適用】: deltaYに基づいてスクロールオフセットを更新
-   *
-   * @param deltaY - マウスホイールのdelta値
-   */
-  private applyScroll(deltaY: number): void {
-    if (!this.questCardScrollContainer) return;
-
-    const maxScroll = this.getMaxScrollOffset();
-    if (maxScroll <= 0) return;
-
-    this.scrollOffset = Math.min(
-      Math.max(this.scrollOffset + deltaY * QuestAcceptPhaseUI.SCROLL_SPEED, 0),
-      maxScroll,
-    );
-    this.questCardScrollContainer.y = -this.scrollOffset;
+    this.scrollableContainer = new ScrollableContainer(this.scene, this.container, {
+      maskBounds: {
+        x: MAIN_LAYOUT.SIDEBAR_WIDTH,
+        y: MAIN_LAYOUT.HEADER_HEIGHT + QuestAcceptPhaseUI.CARD_AREA_OFFSET_Y,
+        width: gameWidth - MAIN_LAYOUT.SIDEBAR_WIDTH,
+        height:
+          gameHeight -
+          MAIN_LAYOUT.HEADER_HEIGHT -
+          MAIN_LAYOUT.FOOTER_HEIGHT -
+          QuestAcceptPhaseUI.CARD_AREA_OFFSET_Y,
+      },
+      scrollSpeed: QuestAcceptPhaseUI.SCROLL_SPEED,
+      isScrollEnabled: () => this.container.visible,
+    });
+    this.scrollableContainer.create();
   }
 
   /**
    * 【スクロールリセット】: スクロール位置を先頭に戻す
    */
   private resetScroll(): void {
-    this.scrollOffset = 0;
-    if (this.questCardScrollContainer) {
-      this.questCardScrollContainer.y = 0;
-    }
-  }
-
-  /**
-   * 【最大スクロールオフセット計算】: コンテンツがカードエリアを超える分のpx値
-   */
-  private getMaxScrollOffset(): number {
-    const totalContentHeight = this.getTotalCardContentHeight();
-    const visibleHeight = this.getCardAreaVisibleHeight();
-    return Math.max(0, totalContentHeight - visibleHeight);
+    this.scrollableContainer?.resetScroll();
   }
 
   /**
@@ -801,37 +714,13 @@ export class QuestAcceptPhaseUI extends BaseComponent {
   }
 
   /**
-   * 【カードエリア可視高さ取得】: マスク範囲内で見える高さ
-   */
-  private getCardAreaVisibleHeight(): number {
-    const gameHeight = this.scene.cameras?.main?.height ?? 720;
-    return (
-      gameHeight -
-      MAIN_LAYOUT.HEADER_HEIGHT -
-      MAIN_LAYOUT.FOOTER_HEIGHT -
-      QuestAcceptPhaseUI.CARD_AREA_OFFSET_Y
-    );
-  }
-
-  /**
-   * 【スクロールハンドラ解除】
-   */
-  private removeScrollHandler(): void {
-    if (this.wheelHandler) {
-      this.scene.input?.off?.('wheel', this.wheelHandler);
-      this.wheelHandler = null;
-    }
-  }
-
-  /**
-   * 【スクロールエリア破棄】: マスクとスクロールコンテナを破棄
+   * 【スクロールエリア破棄】
    */
   private destroyCardScrollArea(): void {
-    if (this.cardAreaMaskGraphics) {
-      this.cardAreaMaskGraphics.destroy();
-      this.cardAreaMaskGraphics = null;
+    if (this.scrollableContainer) {
+      this.scrollableContainer.destroy();
+      this.scrollableContainer = null;
     }
-    this.questCardScrollContainer = null;
   }
 
   // =============================================================================

--- a/atelier-guild-rank/tests/unit/shared/components/scrollable-container.test.ts
+++ b/atelier-guild-rank/tests/unit/shared/components/scrollable-container.test.ts
@@ -1,0 +1,377 @@
+/**
+ * ScrollableContainer ユニットテスト
+ * Issue #368: スクロール機能の共通コンポーネント化
+ */
+
+import type { ScrollableContainerConfig } from '@shared/components/ScrollableContainer';
+import { ScrollableContainer } from '@shared/components/ScrollableContainer';
+import type { MockSceneResult } from '@test-mocks/phaser-mocks';
+import { createMockScene } from '@test-mocks/phaser-mocks';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('ScrollableContainer', () => {
+  let mockSceneResult: MockSceneResult;
+  let parentContainer: ReturnType<typeof createMockContainer>;
+  let defaultConfig: ScrollableContainerConfig;
+
+  function createMockContainer() {
+    return {
+      add: vi.fn().mockReturnThis(),
+      destroy: vi.fn(),
+      visible: true,
+      setVisible: vi.fn().mockReturnThis(),
+      setPosition: vi.fn().mockReturnThis(),
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSceneResult = createMockScene();
+    parentContainer = createMockContainer();
+
+    defaultConfig = {
+      maskBounds: { x: 200, y: 140, width: 1080, height: 460 },
+      scrollSpeed: 0.5,
+      isScrollEnabled: () => true,
+    };
+  });
+
+  describe('コンストラクタ', () => {
+    it('正常にインスタンスを作成できる', () => {
+      const scrollable = new ScrollableContainer(
+        mockSceneResult.scene,
+        parentContainer as unknown as Phaser.GameObjects.Container,
+        defaultConfig,
+      );
+      expect(scrollable).toBeInstanceOf(ScrollableContainer);
+    });
+
+    it('sceneがnullの場合エラーを投げる', () => {
+      expect(
+        () =>
+          new ScrollableContainer(
+            null as unknown as Phaser.Scene,
+            parentContainer as unknown as Phaser.GameObjects.Container,
+            defaultConfig,
+          ),
+      ).toThrow('ScrollableContainer: scene is required');
+    });
+
+    it('parentContainerがnullの場合エラーを投げる', () => {
+      expect(
+        () =>
+          new ScrollableContainer(
+            mockSceneResult.scene,
+            null as unknown as Phaser.GameObjects.Container,
+            defaultConfig,
+          ),
+      ).toThrow('ScrollableContainer: parentContainer is required');
+    });
+
+    it('maskBoundsがnullの場合エラーを投げる', () => {
+      expect(
+        () =>
+          new ScrollableContainer(
+            mockSceneResult.scene,
+            parentContainer as unknown as Phaser.GameObjects.Container,
+            { maskBounds: null } as unknown as ScrollableContainerConfig,
+          ),
+      ).toThrow('ScrollableContainer: maskBounds is required');
+    });
+
+    it('scrollSpeedのデフォルト値は0.5', () => {
+      const scrollable = new ScrollableContainer(
+        mockSceneResult.scene,
+        parentContainer as unknown as Phaser.GameObjects.Container,
+        { maskBounds: defaultConfig.maskBounds },
+      );
+      scrollable.create();
+      // デフォルト値が適用されていることを確認（直接アクセスできないのでスクロール動作で確認）
+      expect(scrollable).toBeInstanceOf(ScrollableContainer);
+    });
+  });
+
+  describe('create()', () => {
+    it('スクロールコンテナを作成して親コンテナに追加する', () => {
+      const scrollable = new ScrollableContainer(
+        mockSceneResult.scene,
+        parentContainer as unknown as Phaser.GameObjects.Container,
+        defaultConfig,
+      );
+      scrollable.create();
+
+      // scene.add.containerが呼ばれてスクロールコンテナが作成される
+      expect(mockSceneResult.scene.add.container).toHaveBeenCalledWith(0, 0);
+      // 親コンテナにaddされる
+      expect(parentContainer.add).toHaveBeenCalled();
+    });
+
+    it('getScrollContainer()でスクロールコンテナを取得できる', () => {
+      const scrollable = new ScrollableContainer(
+        mockSceneResult.scene,
+        parentContainer as unknown as Phaser.GameObjects.Container,
+        defaultConfig,
+      );
+      scrollable.create();
+
+      const container = scrollable.getScrollContainer();
+      expect(container).not.toBeNull();
+    });
+
+    it('マウスホイールハンドラが登録される', () => {
+      const scrollable = new ScrollableContainer(
+        mockSceneResult.scene,
+        parentContainer as unknown as Phaser.GameObjects.Container,
+        defaultConfig,
+      );
+
+      // scene.inputにonメソッドを追加
+      const mockInput = { on: vi.fn(), off: vi.fn() };
+      (mockSceneResult.scene as unknown as Record<string, unknown>).input = mockInput;
+
+      scrollable.create();
+
+      expect(mockInput.on).toHaveBeenCalledWith('wheel', expect.any(Function));
+    });
+  });
+
+  describe('create()前のgetScrollContainer()', () => {
+    it('create()前はnullを返す', () => {
+      const scrollable = new ScrollableContainer(
+        mockSceneResult.scene,
+        parentContainer as unknown as Phaser.GameObjects.Container,
+        defaultConfig,
+      );
+      expect(scrollable.getScrollContainer()).toBeNull();
+    });
+  });
+
+  describe('setContentHeight() / getMaxScrollOffset()', () => {
+    it('コンテンツ高さを設定できる', () => {
+      const scrollable = new ScrollableContainer(
+        mockSceneResult.scene,
+        parentContainer as unknown as Phaser.GameObjects.Container,
+        defaultConfig,
+      );
+      scrollable.create();
+      scrollable.setContentHeight(800);
+
+      // maskBounds.height = 460, contentHeight = 800
+      // maxOffset = 800 - 460 = 340
+      expect(scrollable.getMaxScrollOffset()).toBe(340);
+    });
+
+    it('コンテンツ高さが可視領域以下の場合、最大オフセットは0', () => {
+      const scrollable = new ScrollableContainer(
+        mockSceneResult.scene,
+        parentContainer as unknown as Phaser.GameObjects.Container,
+        defaultConfig,
+      );
+      scrollable.create();
+      scrollable.setContentHeight(200);
+
+      expect(scrollable.getMaxScrollOffset()).toBe(0);
+    });
+
+    it('コンテンツ高さが0の場合、最大オフセットは0', () => {
+      const scrollable = new ScrollableContainer(
+        mockSceneResult.scene,
+        parentContainer as unknown as Phaser.GameObjects.Container,
+        defaultConfig,
+      );
+      scrollable.create();
+      scrollable.setContentHeight(0);
+
+      expect(scrollable.getMaxScrollOffset()).toBe(0);
+    });
+  });
+
+  describe('resetScroll()', () => {
+    it('スクロールオフセットを0にリセットする', () => {
+      const scrollable = new ScrollableContainer(
+        mockSceneResult.scene,
+        parentContainer as unknown as Phaser.GameObjects.Container,
+        defaultConfig,
+      );
+      scrollable.create();
+
+      scrollable.resetScroll();
+
+      expect(scrollable.getScrollOffset()).toBe(0);
+    });
+  });
+
+  describe('getScrollOffset()', () => {
+    it('初期状態では0を返す', () => {
+      const scrollable = new ScrollableContainer(
+        mockSceneResult.scene,
+        parentContainer as unknown as Phaser.GameObjects.Container,
+        defaultConfig,
+      );
+      scrollable.create();
+
+      expect(scrollable.getScrollOffset()).toBe(0);
+    });
+  });
+
+  describe('destroy()', () => {
+    it('リソースが正しく破棄される', () => {
+      const mockInput = { on: vi.fn(), off: vi.fn() };
+      (mockSceneResult.scene as unknown as Record<string, unknown>).input = mockInput;
+
+      const scrollable = new ScrollableContainer(
+        mockSceneResult.scene,
+        parentContainer as unknown as Phaser.GameObjects.Container,
+        defaultConfig,
+      );
+      scrollable.create();
+      scrollable.destroy();
+
+      // ホイールハンドラが解除される
+      expect(mockInput.off).toHaveBeenCalledWith('wheel', expect.any(Function));
+
+      // スクロールコンテナがnullになる
+      expect(scrollable.getScrollContainer()).toBeNull();
+    });
+
+    it('destroy()後のresetScroll()はエラーにならない', () => {
+      const scrollable = new ScrollableContainer(
+        mockSceneResult.scene,
+        parentContainer as unknown as Phaser.GameObjects.Container,
+        defaultConfig,
+      );
+      scrollable.create();
+      scrollable.destroy();
+
+      // エラーが発生しないことを確認
+      expect(() => scrollable.resetScroll()).not.toThrow();
+    });
+  });
+
+  describe('isScrollEnabled', () => {
+    it('isScrollEnabledがfalseの場合、スクロールが無効になる', () => {
+      let isEnabled = true;
+      const config: ScrollableContainerConfig = {
+        ...defaultConfig,
+        isScrollEnabled: () => isEnabled,
+      };
+
+      const mockInput = {
+        on: vi.fn(),
+        off: vi.fn(),
+      };
+      (mockSceneResult.scene as unknown as Record<string, unknown>).input = mockInput;
+
+      const scrollable = new ScrollableContainer(
+        mockSceneResult.scene,
+        parentContainer as unknown as Phaser.GameObjects.Container,
+        config,
+      );
+      scrollable.create();
+      scrollable.setContentHeight(1000);
+
+      // ホイールハンドラを取得
+      const wheelHandler = mockInput.on.mock.calls[0]?.[1] as (
+        pointer: unknown,
+        gameObjects: unknown[],
+        deltaX: number,
+        deltaY: number,
+      ) => void;
+      expect(wheelHandler).toBeDefined();
+
+      // スクロール無効にする
+      isEnabled = false;
+      wheelHandler(null, [], 0, 100);
+
+      // スクロールオフセットは変わらない
+      expect(scrollable.getScrollOffset()).toBe(0);
+    });
+
+    it('isScrollEnabledがtrueの場合、スクロールが動作する', () => {
+      const mockInput = {
+        on: vi.fn(),
+        off: vi.fn(),
+      };
+      (mockSceneResult.scene as unknown as Record<string, unknown>).input = mockInput;
+
+      const scrollable = new ScrollableContainer(
+        mockSceneResult.scene,
+        parentContainer as unknown as Phaser.GameObjects.Container,
+        defaultConfig,
+      );
+      scrollable.create();
+      scrollable.setContentHeight(1000);
+
+      // ホイールハンドラを取得
+      const wheelHandler = mockInput.on.mock.calls[0]?.[1] as (
+        pointer: unknown,
+        gameObjects: unknown[],
+        deltaX: number,
+        deltaY: number,
+      ) => void;
+
+      // スクロールを実行
+      wheelHandler(null, [], 0, 100);
+
+      // スクロールオフセットが変わる（100 * 0.5 = 50）
+      expect(scrollable.getScrollOffset()).toBe(50);
+    });
+  });
+
+  describe('スクロール範囲制限', () => {
+    let mockInput: { on: ReturnType<typeof vi.fn>; off: ReturnType<typeof vi.fn> };
+    let scrollable: ScrollableContainer;
+    let wheelHandler: (
+      pointer: unknown,
+      gameObjects: unknown[],
+      deltaX: number,
+      deltaY: number,
+    ) => void;
+
+    beforeEach(() => {
+      mockInput = { on: vi.fn(), off: vi.fn() };
+      (mockSceneResult.scene as unknown as Record<string, unknown>).input = mockInput;
+
+      scrollable = new ScrollableContainer(
+        mockSceneResult.scene,
+        parentContainer as unknown as Phaser.GameObjects.Container,
+        defaultConfig,
+      );
+      scrollable.create();
+      scrollable.setContentHeight(800); // maxOffset = 800 - 460 = 340
+
+      wheelHandler = mockInput.on.mock.calls[0]?.[1] as typeof wheelHandler;
+    });
+
+    it('下方向にスクロールできる', () => {
+      wheelHandler(null, [], 0, 200);
+      // 200 * 0.5 = 100
+      expect(scrollable.getScrollOffset()).toBe(100);
+    });
+
+    it('上方向には0未満にならない', () => {
+      wheelHandler(null, [], 0, -200);
+      expect(scrollable.getScrollOffset()).toBe(0);
+    });
+
+    it('最大オフセットを超えてスクロールしない', () => {
+      // maxOffset = 340
+      wheelHandler(null, [], 0, 1000);
+      // 1000 * 0.5 = 500 → clamp to 340
+      expect(scrollable.getScrollOffset()).toBe(340);
+    });
+
+    it('連続スクロールが正しく累積する', () => {
+      wheelHandler(null, [], 0, 100); // 50
+      wheelHandler(null, [], 0, 100); // 100
+      wheelHandler(null, [], 0, 100); // 150
+      expect(scrollable.getScrollOffset()).toBe(150);
+    });
+
+    it('コンテンツ高さが可視領域以下の場合スクロールしない', () => {
+      scrollable.setContentHeight(200); // maxOffset = 0
+      wheelHandler(null, [], 0, 200);
+      expect(scrollable.getScrollOffset()).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- QuestAcceptPhaseUIとAlchemyPhaseUIで重複していたGeometryMask + マウスホイールスクロールのパターンを`ScrollableContainer`共通コンポーネントとして抽出
- 約200行の重複コードを削減し、DRYを実現
- 23件のユニットテストを追加（コンストラクタ検証、スクロール動作、範囲制限、リソース破棄）

## Changes
- **新規**: `src/shared/components/ScrollableContainer.ts` - スクロール共通コンポーネント
- **修正**: `src/shared/presentation/ui/phases/QuestAcceptPhaseUI.ts` - ScrollableContainer使用に置換
- **修正**: `src/features/alchemy/components/AlchemyPhaseUI.ts` - ScrollableContainer使用に置換
- **修正**: `src/shared/components/index.ts` - エクスポート追加
- **新規**: `tests/unit/shared/components/scrollable-container.test.ts` - ユニットテスト

## Test plan
- [x] ScrollableContainer ユニットテスト 23件全パス
- [x] 全ユニットテスト 2674件全パス（147ファイル）
- [x] TypeScript型チェック通過
- [x] Biomeリントチェック通過（変更ファイル）

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)