### PR TITLE
fix: GameObjectにname設定を追加しデバッグ性を向上

### DIFF
--- a/atelier-guild-rank/src/shared/components/FooterUI.ts
+++ b/atelier-guild-rank/src/shared/components/FooterUI.ts
@@ -149,7 +149,7 @@ export class FooterUI extends BaseComponent {
       FOOTER_LAYOUT.HEIGHT,
       FOOTER_COLORS.BACKGROUND,
       0.95,
-    );
+    ).setName('FooterUI.backgroundPanel');
     this.container.add(this._backgroundPanel);
 
     // 上部ボーダーライン
@@ -161,7 +161,7 @@ export class FooterUI extends BaseComponent {
       2,
       FOOTER_COLORS.BORDER,
       1,
-    );
+    ).setName('FooterUI.borderLine');
     this.container.add(borderLine);
 
     // PhaseTabUIを作成・統合
@@ -189,7 +189,7 @@ export class FooterUI extends BaseComponent {
         FOOTER_LAYOUT.CARD_HEIGHT,
         FOOTER_COLORS.CARD_PLACEHOLDER,
         0.5,
-      );
+      ).setName(`FooterUI.cardPlaceholder${i}`);
       placeholder.setStrokeStyle(2, FOOTER_COLORS.CARD_PLACEHOLDER_BORDER);
       this.container.add(placeholder);
       this._handDisplayArea.push(placeholder);

--- a/atelier-guild-rank/src/shared/components/HeaderUI.ts
+++ b/atelier-guild-rank/src/shared/components/HeaderUI.ts
@@ -198,7 +198,7 @@ export class HeaderUI extends BaseComponent {
       HEADER_LAYOUT.HEIGHT,
       COLORS.BACKGROUND,
       0.95,
-    );
+    ).setName('HeaderUI.backgroundPanel');
     this.container.add(this._backgroundPanel);
 
     // 下部ボーダーライン
@@ -210,7 +210,7 @@ export class HeaderUI extends BaseComponent {
       2,
       COLORS.BORDER,
       1,
-    );
+    ).setName('HeaderUI.borderLine');
     this.container.add(borderLine);
 
     // ランクラベルを生成

--- a/atelier-guild-rank/src/shared/components/PhaseTabUI.ts
+++ b/atelier-guild-rank/src/shared/components/PhaseTabUI.ts
@@ -212,7 +212,7 @@ export class PhaseTabUI extends BaseComponent {
         TAB_LAYOUT.TAB_WIDTH,
         TAB_LAYOUT.TAB_HEIGHT,
         isActive ? TAB_COLORS.ACTIVE : TAB_COLORS.INACTIVE,
-      );
+      ).setName(`PhaseTabUI.tabBg${i}`);
       bg.setInteractive({ useHandCursor: true });
       bg.on('pointerdown', () => this.handleTabClick(phase));
       this.container.add(bg);
@@ -231,6 +231,7 @@ export class PhaseTabUI extends BaseComponent {
         },
         add: false,
       });
+      text.setName(`PhaseTabUI.tabText${i}`);
       this.container.add(text);
       this._tabTexts.push(text);
     }
@@ -249,7 +250,7 @@ export class PhaseTabUI extends BaseComponent {
       TAB_LAYOUT.END_DAY_WIDTH,
       TAB_LAYOUT.END_DAY_HEIGHT,
       TAB_COLORS.END_DAY_BUTTON,
-    );
+    ).setName('PhaseTabUI.endDayBg');
     this._endDayBackground.setInteractive({ useHandCursor: true });
     this._endDayBackground.on('pointerover', () => {
       this._endDayBackground?.setFillStyle(TAB_COLORS.END_DAY_BUTTON_HOVER);
@@ -267,6 +268,7 @@ export class PhaseTabUI extends BaseComponent {
       style: { fontSize: '14px', color: '#FFFFFF', fontStyle: 'bold' },
       add: false,
     });
+    this._endDayText.setName('PhaseTabUI.endDayText');
     this.container.add(this._endDayText);
 
     // 休憩ボタン
@@ -280,7 +282,7 @@ export class PhaseTabUI extends BaseComponent {
       TAB_LAYOUT.REST_WIDTH,
       TAB_LAYOUT.REST_HEIGHT,
       TAB_COLORS.REST_BUTTON,
-    );
+    ).setName('PhaseTabUI.restBg');
     this._restBackground.setInteractive({ useHandCursor: true });
     this._restBackground.on('pointerover', () => {
       this._restBackground?.setFillStyle(TAB_COLORS.REST_BUTTON_HOVER);
@@ -298,6 +300,7 @@ export class PhaseTabUI extends BaseComponent {
       style: { fontSize: '14px', color: '#FFFFFF', fontStyle: 'bold' },
       add: false,
     });
+    this._restText.setName('PhaseTabUI.restText');
     this.container.add(this._restText);
 
     // PHASE_CHANGEDイベントの購読

--- a/atelier-guild-rank/src/shared/components/SidebarUI.ts
+++ b/atelier-guild-rank/src/shared/components/SidebarUI.ts
@@ -220,25 +220,29 @@ export class SidebarUI extends BaseComponent {
    */
   create(): void {
     // 背景パネルを生成（半透明のダークグレー）
-    this._backgroundPanel = this.scene.add.rectangle(
-      SIDEBAR_LAYOUT.WIDTH / 2,
-      SIDEBAR_LAYOUT.HEIGHT / 2,
-      SIDEBAR_LAYOUT.WIDTH,
-      SIDEBAR_LAYOUT.HEIGHT,
-      COLORS.BACKGROUND,
-      0.95,
-    );
+    this._backgroundPanel = this.scene.add
+      .rectangle(
+        SIDEBAR_LAYOUT.WIDTH / 2,
+        SIDEBAR_LAYOUT.HEIGHT / 2,
+        SIDEBAR_LAYOUT.WIDTH,
+        SIDEBAR_LAYOUT.HEIGHT,
+        COLORS.BACKGROUND,
+        0.95,
+      )
+      .setName('SidebarUI.backgroundPanel');
     this.container.add(this._backgroundPanel);
 
     // 右側ボーダーライン
-    const borderLine = this.scene.add.rectangle(
-      SIDEBAR_LAYOUT.WIDTH - 1,
-      SIDEBAR_LAYOUT.HEIGHT / 2,
-      2,
-      SIDEBAR_LAYOUT.HEIGHT,
-      COLORS.BORDER,
-      1,
-    );
+    const borderLine = this.scene.add
+      .rectangle(
+        SIDEBAR_LAYOUT.WIDTH - 1,
+        SIDEBAR_LAYOUT.HEIGHT / 2,
+        2,
+        SIDEBAR_LAYOUT.HEIGHT,
+        COLORS.BORDER,
+        1,
+      )
+      .setName('SidebarUI.borderLine');
     this.container.add(borderLine);
 
     let currentY = SIDEBAR_LAYOUT.PADDING;
@@ -252,6 +256,7 @@ export class SidebarUI extends BaseComponent {
       COLORS.SECTION_HEADER,
       0.8,
     );
+    questsHeaderBg.setName('SidebarUI.questsHeaderBg');
     questsHeaderBg.setInteractive({ useHandCursor: true });
     questsHeaderBg.on('pointerover', () => questsHeaderBg.setFillStyle(0x4b5563, 0.9));
     questsHeaderBg.on('pointerout', () => questsHeaderBg.setFillStyle(COLORS.SECTION_HEADER, 0.8));
@@ -292,6 +297,7 @@ export class SidebarUI extends BaseComponent {
       COLORS.SECTION_HEADER,
       0.8,
     );
+    materialsHeaderBg.setName('SidebarUI.materialsHeaderBg');
     materialsHeaderBg.setInteractive({ useHandCursor: true });
     materialsHeaderBg.on('pointerover', () => materialsHeaderBg.setFillStyle(0x4b5563, 0.9));
     materialsHeaderBg.on('pointerout', () =>
@@ -333,6 +339,7 @@ export class SidebarUI extends BaseComponent {
       COLORS.SECTION_HEADER,
       0.8,
     );
+    craftedItemsHeaderBg.setName('SidebarUI.craftedItemsHeaderBg');
     craftedItemsHeaderBg.setInteractive({ useHandCursor: true });
     craftedItemsHeaderBg.on('pointerover', () => craftedItemsHeaderBg.setFillStyle(0x4b5563, 0.9));
     craftedItemsHeaderBg.on('pointerout', () =>
@@ -382,6 +389,7 @@ export class SidebarUI extends BaseComponent {
       36,
       COLORS.ACCENT,
     );
+    this._shopButtonBackground.setName('SidebarUI.shopButtonBg');
     this._shopButtonBackground.setInteractive({ useHandCursor: true });
     this._shopButtonBackground.on('pointerover', () => {
       this._shopButtonBackground?.setFillStyle(COLORS.ACCENT_HOVER);

--- a/atelier-guild-rank/tests/mocks/phaser-mocks.ts
+++ b/atelier-guild-rank/tests/mocks/phaser-mocks.ts
@@ -62,6 +62,7 @@ export interface MockPhaserText {
   setPosition: ReturnType<typeof vi.fn>;
   setInteractive: ReturnType<typeof vi.fn>;
   setWordWrapWidth: ReturnType<typeof vi.fn>;
+  setName: ReturnType<typeof vi.fn>;
   on: ReturnType<typeof vi.fn>;
   destroy: ReturnType<typeof vi.fn>;
   text: string;
@@ -96,6 +97,7 @@ export interface MockPhaserRectangle {
   disableInteractive: ReturnType<typeof vi.fn>;
   setAlpha: ReturnType<typeof vi.fn>;
   setDepth: ReturnType<typeof vi.fn>;
+  setName: ReturnType<typeof vi.fn>;
   on: ReturnType<typeof vi.fn>;
   destroy: ReturnType<typeof vi.fn>;
 }
@@ -209,6 +211,7 @@ export const createMockText = (): MockPhaserText => ({
   setPosition: vi.fn().mockReturnThis(),
   setInteractive: vi.fn().mockReturnThis(),
   setWordWrapWidth: vi.fn().mockReturnThis(),
+  setName: vi.fn().mockReturnThis(),
   on: vi.fn().mockReturnThis(),
   destroy: vi.fn(),
   text: '',
@@ -243,6 +246,7 @@ export const createMockRectangle = (): MockPhaserRectangle => ({
   disableInteractive: vi.fn().mockReturnThis(),
   setAlpha: vi.fn().mockReturnThis(),
   setDepth: vi.fn().mockReturnThis(),
+  setName: vi.fn().mockReturnThis(),
   on: vi.fn().mockReturnThis(),
   destroy: vi.fn(),
 });

--- a/atelier-guild-rank/tests/setup.ts
+++ b/atelier-guild-rank/tests/setup.ts
@@ -15,6 +15,7 @@ const createMockGameObjectBase = () => ({
   removeAllListeners: vi.fn().mockReturnThis(),
   setData: vi.fn().mockReturnThis(),
   setBlendMode: vi.fn().mockReturnThis(),
+  setName: vi.fn().mockReturnThis(),
   on: vi.fn().mockReturnThis(),
   off: vi.fn().mockReturnThis(),
   destroy: vi.fn(),
@@ -37,6 +38,7 @@ class MockRectangle {
   removeAllListeners = vi.fn().mockReturnValue(this);
   setData = vi.fn().mockReturnValue(this);
   setBlendMode = vi.fn().mockReturnValue(this);
+  setName = vi.fn().mockReturnValue(this);
   on = vi.fn().mockReturnValue(this);
   off = vi.fn().mockReturnValue(this);
   destroy = vi.fn();

--- a/atelier-guild-rank/tests/unit/presentation/main-scene.test.ts
+++ b/atelier-guild-rank/tests/unit/presentation/main-scene.test.ts
@@ -34,7 +34,9 @@ vi.mock('phaser', () => {
       Scene: class MockScene {},
       GameObjects: {
         Container: class MockContainer {},
-        Text: class MockText {},
+        Text: class MockText {
+          setName = vi.fn().mockReturnThis();
+        },
         Graphics: class MockGraphics {
           fillStyle = vi.fn().mockReturnThis();
           fillRect = vi.fn().mockReturnThis();
@@ -55,6 +57,7 @@ vi.mock('phaser', () => {
           setInteractive = vi.fn().mockReturnThis();
           disableInteractive = vi.fn().mockReturnThis();
           setAlpha = vi.fn().mockReturnThis();
+          setName = vi.fn().mockReturnThis();
           on = vi.fn().mockReturnThis();
           destroy = vi.fn();
         },
@@ -135,6 +138,7 @@ const createMockText = () => ({
   setStyle: vi.fn().mockReturnThis(),
   setColor: vi.fn().mockReturnThis(),
   setFontSize: vi.fn().mockReturnThis(),
+  setName: vi.fn().mockReturnThis(),
   destroy: vi.fn(),
   text: '',
 });
@@ -224,6 +228,7 @@ const createMockScene = () => {
           setInteractive: vi.fn().mockReturnThis(),
           disableInteractive: vi.fn().mockReturnThis(),
           setAlpha: vi.fn().mockReturnThis(),
+          setName: vi.fn().mockReturnThis(),
           on: vi.fn().mockReturnThis(),
           destroy: vi.fn(),
         }),

--- a/atelier-guild-rank/tests/unit/presentation/scenes/main-scene-game-end.test.ts
+++ b/atelier-guild-rank/tests/unit/presentation/scenes/main-scene-game-end.test.ts
@@ -28,7 +28,9 @@ vi.mock('phaser', () => ({
     Scene: class MockScene {},
     GameObjects: {
       Container: class MockContainer {},
-      Text: class MockText {},
+      Text: class MockText {
+        setName = vi.fn().mockReturnThis();
+      },
       Graphics: class MockGraphics {
         fillStyle = vi.fn().mockReturnThis();
         fillRect = vi.fn().mockReturnThis();
@@ -49,6 +51,7 @@ vi.mock('phaser', () => ({
         setInteractive = vi.fn().mockReturnThis();
         disableInteractive = vi.fn().mockReturnThis();
         setAlpha = vi.fn().mockReturnThis();
+        setName = vi.fn().mockReturnThis();
         on = vi.fn().mockReturnThis();
         destroy = vi.fn();
       },

--- a/atelier-guild-rank/tests/unit/presentation/ui/components/footer-ui-visual.test.ts
+++ b/atelier-guild-rank/tests/unit/presentation/ui/components/footer-ui-visual.test.ts
@@ -26,6 +26,7 @@ interface MockText {
   setColor: ReturnType<typeof vi.fn>;
   setAlpha: ReturnType<typeof vi.fn>;
   setPosition: ReturnType<typeof vi.fn>;
+  setName: ReturnType<typeof vi.fn>;
   destroy: ReturnType<typeof vi.fn>;
   text: string;
 }
@@ -34,6 +35,7 @@ interface MockRectangle {
   setFillStyle: ReturnType<typeof vi.fn>;
   setStrokeStyle: ReturnType<typeof vi.fn>;
   setInteractive: ReturnType<typeof vi.fn>;
+  setName: ReturnType<typeof vi.fn>;
   on: ReturnType<typeof vi.fn>;
   destroy: ReturnType<typeof vi.fn>;
 }
@@ -95,6 +97,7 @@ const createMockScene = (): {
       setFillStyle: vi.fn().mockReturnThis(),
       setStrokeStyle: vi.fn().mockReturnThis(),
       setInteractive: vi.fn().mockReturnThis(),
+      setName: vi.fn().mockReturnThis(),
       on: vi.fn().mockReturnThis(),
       destroy: vi.fn(),
     };
@@ -115,6 +118,7 @@ const createMockScene = (): {
           setColor: vi.fn().mockReturnThis(),
           setAlpha: vi.fn().mockReturnThis(),
           setPosition: vi.fn().mockReturnThis(),
+          setName: vi.fn().mockReturnThis(),
           destroy: vi.fn(),
           text: '',
         };

--- a/atelier-guild-rank/tests/unit/presentation/ui/components/header-ui-visual.test.ts
+++ b/atelier-guild-rank/tests/unit/presentation/ui/components/header-ui-visual.test.ts
@@ -66,6 +66,7 @@ interface MockRectangle {
   setFillStyle: ReturnType<typeof vi.fn>;
   setStrokeStyle: ReturnType<typeof vi.fn>;
   setInteractive: ReturnType<typeof vi.fn>;
+  setName: ReturnType<typeof vi.fn>;
   on: ReturnType<typeof vi.fn>;
   destroy: ReturnType<typeof vi.fn>;
 }
@@ -136,6 +137,7 @@ const createMockScene = (): {
     setFillStyle: vi.fn().mockReturnThis(),
     setStrokeStyle: vi.fn().mockReturnThis(),
     setInteractive: vi.fn().mockReturnThis(),
+    setName: vi.fn().mockReturnThis(),
     on: vi.fn().mockReturnThis(),
     destroy: vi.fn(),
   };

--- a/atelier-guild-rank/tests/unit/presentation/ui/components/sidebar-ui-visual.test.ts
+++ b/atelier-guild-rank/tests/unit/presentation/ui/components/sidebar-ui-visual.test.ts
@@ -46,6 +46,7 @@ interface MockRectangle {
   setFillStyle: ReturnType<typeof vi.fn>;
   setStrokeStyle: ReturnType<typeof vi.fn>;
   setInteractive: ReturnType<typeof vi.fn>;
+  setName: ReturnType<typeof vi.fn>;
   on: ReturnType<typeof vi.fn>;
   destroy: ReturnType<typeof vi.fn>;
 }
@@ -116,6 +117,7 @@ const createMockScene = (): {
     setFillStyle: vi.fn().mockReturnThis(),
     setStrokeStyle: vi.fn().mockReturnThis(),
     setInteractive: vi.fn().mockReturnThis(),
+    setName: vi.fn().mockReturnThis(),
     on: vi.fn().mockReturnThis(),
     destroy: vi.fn(),
   };

--- a/atelier-guild-rank/tests/unit/shared/components/phase-tab-ui.test.ts
+++ b/atelier-guild-rank/tests/unit/shared/components/phase-tab-ui.test.ts
@@ -32,6 +32,7 @@ interface MockText {
   setColor: ReturnType<typeof vi.fn>;
   setAlpha: ReturnType<typeof vi.fn>;
   setPosition: ReturnType<typeof vi.fn>;
+  setName: ReturnType<typeof vi.fn>;
   destroy: ReturnType<typeof vi.fn>;
   text: string;
 }
@@ -40,6 +41,7 @@ interface MockRectangle {
   setFillStyle: ReturnType<typeof vi.fn>;
   setStrokeStyle: ReturnType<typeof vi.fn>;
   setInteractive: ReturnType<typeof vi.fn>;
+  setName: ReturnType<typeof vi.fn>;
   on: ReturnType<typeof vi.fn>;
   destroy: ReturnType<typeof vi.fn>;
 }
@@ -102,6 +104,7 @@ const createMockScene = (): {
       setFillStyle: vi.fn().mockReturnThis(),
       setStrokeStyle: vi.fn().mockReturnThis(),
       setInteractive: vi.fn().mockReturnThis(),
+      setName: vi.fn().mockReturnThis(),
       on: vi.fn().mockReturnThis(),
       destroy: vi.fn(),
     };
@@ -122,6 +125,7 @@ const createMockScene = (): {
           setColor: vi.fn().mockReturnThis(),
           setAlpha: vi.fn().mockReturnThis(),
           setPosition: vi.fn().mockReturnThis(),
+          setName: vi.fn().mockReturnThis(),
           destroy: vi.fn(),
           text: '',
         };


### PR DESCRIPTION
## Summary
- FooterUI/PhaseTabUI/HeaderUI/SidebarUIの全GameObjectに`setName()`で意味のある名前を設定
- 命名パターン: `"コンポーネント名.役割"` (例: `FooterUI.backgroundPanel`, `PhaseTabUI.tabBg0`)
- テストモック(setup.ts, phaser-mocks.ts, 各テストファイル)に`setName`メソッドを追加

Closes #376

## Test plan
- [x] 型チェック: パス
- [x] リント: パス（既存のe2e警告のみ）
- [x] 全147テストファイル、2685テスト: パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)