### PR TITLE
chore: PostToolUseフックにBiome自動lint fixを追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -134,7 +134,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "filepath=$(node -e \"const a=JSON.parse(process.env.ARGUMENTS||'{}');console.log(a.file_path||'');\") && if [ -n \"$filepath\" ] && echo \"$filepath\" | grep -qE \"[.](ts|tsx)$\"; then cd atelier-guild-rank && npx biome check --write --no-errors-on-unmatched \"$filepath\" 2>/dev/null || true; fi",
+            "command": "filepath=$(node -e \"const a=JSON.parse(process.env.ARGUMENTS||'{}');console.log(a.file_path||'');\") && if [ -n \"$filepath\" ] && echo \"$filepath\" | grep -qE \"[.](ts|tsx)$\" && echo \"$filepath\" | grep -q \"atelier-guild-rank\"; then cd atelier-guild-rank && npx biome check --write --no-errors-on-unmatched \"$filepath\" 2>/dev/null || true; fi",
             "timeout": 30,
             "statusMessage": "Running Biome lint fix..."
           }


### PR DESCRIPTION
## Summary
- Claude CodeのPostToolUseフックにBiome自動lint fixを追加
- Write/Editツール使用後に`.ts`/`.tsx`ファイルに対してBiome checkを自動実行
- lint修正のための追加コミット（`style: format code`等）を削減

Closes #380

## Test plan
- [ ] `.claude/settings.json`にhooksセクションが正しく追加されている
- [ ] TypeScriptファイル編集後にBiome lint fixが自動実行される
- [ ] 既存のLefthook pre-commitフックと競合しない
- [ ] フック実行が30秒以内に完了する
- [ ] エラー発生時に静かに失敗し開発体験を阻害しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)