### PR TITLE
fix: 採取地クリック時のisGatheringCard未定義エラーを修正

### DIFF
--- a/atelier-guild-rank/src/features/gathering/components/GatheringPhaseUI.ts
+++ b/atelier-guild-rank/src/features/gathering/components/GatheringPhaseUI.ts
@@ -16,11 +16,11 @@
  */
 
 import type { MaterialInstance } from '@domain/entities/MaterialInstance';
+import type { IDeckService } from '@domain/interfaces/deck-service.interface';
 import type {
   DraftSession,
   IGatheringService,
 } from '@domain/interfaces/gathering-service.interface';
-import type { Card } from '@features/deck/types/card';
 import { Button } from '@presentation/ui/components/Button';
 import { THEME } from '@presentation/ui/theme';
 import { BaseComponent } from '@shared/components';
@@ -110,6 +110,7 @@ export class GatheringPhaseUI extends BaseComponent {
   constructor(
     scene: Phaser.Scene,
     private gatheringService: IGatheringService,
+    private deckService?: IDeckService,
     onEnd?: () => void,
   ) {
     // Issue #137: 親コンテナに追加されるため、シーンには直接追加しない
@@ -490,14 +491,15 @@ export class GatheringPhaseUI extends BaseComponent {
    * @param result - 場所選択結果
    */
   handleLocationSelected(result: ILocationSelectResult): void {
-    // ドラフト採取セッションを開始
-    // cardIdからCardオブジェクトを取得する処理は上位層が担当
-    // ここではサービスに直接委譲
-    // TODO(TASK-0114): startDraftGatheringの引数型をcardId直接受け取りに拡張する
-    // 暫定: cardIdのみで仮のCardオブジェクトを構築（上位層でCard取得を行うべき）
-    const draftSession = this.gatheringService.startDraftGathering({
-      id: result.cardId,
-    } as unknown as Card);
+    // 手札からcardIdに一致するCardオブジェクトを取得
+    const card = this.deckService?.getHand().find((c) => c.id === result.cardId);
+
+    if (!card) {
+      console.warn('GatheringPhaseUI: Card not found in hand for cardId:', result.cardId);
+      return;
+    }
+
+    const draftSession = this.gatheringService.startDraftGathering(card);
 
     if (!draftSession) {
       console.warn(

--- a/atelier-guild-rank/src/scenes/helpers/PhaseManager.ts
+++ b/atelier-guild-rank/src/scenes/helpers/PhaseManager.ts
@@ -106,8 +106,12 @@ export class PhaseManager {
     if (container.has(ServiceKeys.GatheringService)) {
       gatheringService = container.resolve<IGatheringService>(ServiceKeys.GatheringService);
     }
+    let deckService: IDeckService | undefined;
+    if (container.has(ServiceKeys.DeckService)) {
+      deckService = container.resolve<IDeckService>(ServiceKeys.DeckService);
+    }
     if (gatheringService) {
-      const gatheringUI = new GatheringPhaseUI(this.scene, gatheringService);
+      const gatheringUI = new GatheringPhaseUI(this.scene, gatheringService, deckService);
       gatheringUI.create();
       this.contentContainer.add(gatheringUI.getContainer());
       this.phaseUIs.set(GamePhase.GATHERING, gatheringUI);

--- a/atelier-guild-rank/tests/integration/free-phase-navigation/gathering-two-stage.test.ts
+++ b/atelier-guild-rank/tests/integration/free-phase-navigation/gathering-two-stage.test.ts
@@ -9,6 +9,7 @@
  * @信頼性レベル 🔵 REQ-002, EDGE-103, 設計文書architecture.mdより
  */
 
+import type { IDeckService } from '@domain/interfaces/deck-service.interface';
 import type { IGatheringService } from '@domain/interfaces/gathering-service.interface';
 import type { IGatheringLocation, ILocationSelectResult } from '@features/gathering';
 import {
@@ -78,6 +79,24 @@ const createMockGatheringService = (): IGatheringService =>
     canGather: vi.fn(() => true),
     calculateGatheringCost: vi.fn(() => ({ actionPointCost: 1, extraDays: 0 })),
   }) as unknown as IGatheringService;
+
+/**
+ * モックDeckServiceの作成
+ * 手札に採取カードを含むモック
+ */
+const createMockDeckService = (...cardIds: string[]): IDeckService =>
+  ({
+    getHand: vi.fn(() =>
+      cardIds.map((id) => ({
+        id: toCardId(id),
+        master: { type: 'GATHERING', name: id },
+        isGatheringCard: () => true,
+        isRecipeCard: () => false,
+        isEnhancementCard: () => false,
+      })),
+    ),
+    getHandSize: vi.fn(() => cardIds.length),
+  }) as unknown as IDeckService;
 
 // =============================================================================
 // テスト
@@ -267,7 +286,11 @@ describe('採取2段階化 統合テスト（TASK-0120）', () => {
       const mockGatheringService = createMockGatheringService();
 
       const { GatheringPhaseUI } = await import('@features/gathering/components/GatheringPhaseUI');
-      const phaseUI = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const phaseUI = new GatheringPhaseUI(
+        mockScene,
+        mockGatheringService,
+        createMockDeckService('gathering-forest', 'gathering-mine'),
+      );
 
       expect(phaseUI.getCurrentStage()).toBe(GatheringStage.LOCATION_SELECT);
     });
@@ -280,7 +303,11 @@ describe('採取2段階化 統合テスト（TASK-0120）', () => {
       const mockGatheringService = createMockGatheringService();
 
       const { GatheringPhaseUI } = await import('@features/gathering/components/GatheringPhaseUI');
-      const phaseUI = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const phaseUI = new GatheringPhaseUI(
+        mockScene,
+        mockGatheringService,
+        createMockDeckService('gathering-forest', 'gathering-mine'),
+      );
       phaseUI.create();
       phaseUI.show();
 
@@ -295,7 +322,11 @@ describe('採取2段階化 統合テスト（TASK-0120）', () => {
       const mockGatheringService = createMockGatheringService();
 
       const { GatheringPhaseUI } = await import('@features/gathering/components/GatheringPhaseUI');
-      const phaseUI = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const phaseUI = new GatheringPhaseUI(
+        mockScene,
+        mockGatheringService,
+        createMockDeckService('gathering-forest', 'gathering-mine'),
+      );
       phaseUI.create();
       phaseUI.show();
 
@@ -319,7 +350,11 @@ describe('採取2段階化 統合テスト（TASK-0120）', () => {
       const mockGatheringService = createMockGatheringService();
 
       const { GatheringPhaseUI } = await import('@features/gathering/components/GatheringPhaseUI');
-      const phaseUI = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const phaseUI = new GatheringPhaseUI(
+        mockScene,
+        mockGatheringService,
+        createMockDeckService('gathering-forest', 'gathering-mine'),
+      );
       phaseUI.create();
       phaseUI.show();
 
@@ -346,7 +381,11 @@ describe('採取2段階化 統合テスト（TASK-0120）', () => {
       const mockGatheringService = createMockGatheringService();
 
       const { GatheringPhaseUI } = await import('@features/gathering/components/GatheringPhaseUI');
-      const phaseUI = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const phaseUI = new GatheringPhaseUI(
+        mockScene,
+        mockGatheringService,
+        createMockDeckService('gathering-forest', 'gathering-mine'),
+      );
       phaseUI.create();
       phaseUI.show();
 
@@ -373,7 +412,11 @@ describe('採取2段階化 統合テスト（TASK-0120）', () => {
       const mockGatheringService = createMockGatheringService();
 
       const { GatheringPhaseUI } = await import('@features/gathering/components/GatheringPhaseUI');
-      const phaseUI = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const phaseUI = new GatheringPhaseUI(
+        mockScene,
+        mockGatheringService,
+        createMockDeckService('gathering-forest', 'gathering-mine'),
+      );
       phaseUI.create();
 
       const onConfirm = vi.fn();
@@ -394,7 +437,11 @@ describe('採取2段階化 統合テスト（TASK-0120）', () => {
       const mockGatheringService = createMockGatheringService();
 
       const { GatheringPhaseUI } = await import('@features/gathering/components/GatheringPhaseUI');
-      const phaseUI = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const phaseUI = new GatheringPhaseUI(
+        mockScene,
+        mockGatheringService,
+        createMockDeckService('gathering-forest', 'gathering-mine'),
+      );
       phaseUI.create();
       phaseUI.show();
 
@@ -423,7 +470,11 @@ describe('採取2段階化 統合テスト（TASK-0120）', () => {
       const mockGatheringService = createMockGatheringService();
 
       const { GatheringPhaseUI } = await import('@features/gathering/components/GatheringPhaseUI');
-      const phaseUI = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const phaseUI = new GatheringPhaseUI(
+        mockScene,
+        mockGatheringService,
+        createMockDeckService('gathering-forest', 'gathering-mine'),
+      );
       phaseUI.create();
       phaseUI.show();
 
@@ -454,7 +505,11 @@ describe('採取2段階化 統合テスト（TASK-0120）', () => {
       const mockGatheringService = createMockGatheringService();
 
       const { GatheringPhaseUI } = await import('@features/gathering/components/GatheringPhaseUI');
-      const phaseUI = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const phaseUI = new GatheringPhaseUI(
+        mockScene,
+        mockGatheringService,
+        createMockDeckService('gathering-forest', 'gathering-mine'),
+      );
       phaseUI.create();
       phaseUI.show();
 
@@ -544,7 +599,11 @@ describe('採取2段階化 統合テスト（TASK-0120）', () => {
       const mockGatheringService = createMockGatheringService();
 
       const { GatheringPhaseUI } = await import('@features/gathering/components/GatheringPhaseUI');
-      const phaseUI = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const phaseUI = new GatheringPhaseUI(
+        mockScene,
+        mockGatheringService,
+        createMockDeckService('gathering_nearby_forest'),
+      );
       phaseUI.create();
       phaseUI.show();
 
@@ -569,7 +628,11 @@ describe('採取2段階化 統合テスト（TASK-0120）', () => {
       const mockGatheringService = createMockGatheringService();
 
       const { GatheringPhaseUI } = await import('@features/gathering/components/GatheringPhaseUI');
-      const phaseUI = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const phaseUI = new GatheringPhaseUI(
+        mockScene,
+        mockGatheringService,
+        createMockDeckService('gathering_nearby_forest', 'gathering_mountain_trail'),
+      );
       phaseUI.create();
       phaseUI.show();
 

--- a/atelier-guild-rank/tests/unit/features/gathering/components/GatheringPhaseUI.test.ts
+++ b/atelier-guild-rank/tests/unit/features/gathering/components/GatheringPhaseUI.test.ts
@@ -8,6 +8,7 @@
  * @信頼性レベル 🔵 REQ-002・architecture.md・dataflow.md セクション4に基づく
  */
 
+import type { IDeckService } from '@domain/interfaces/deck-service.interface';
 import type { IGatheringService } from '@domain/interfaces/gathering-service.interface';
 import type { IGatheringLocation } from '@features/gathering';
 import { GATHERING_LOCATIONS, GatheringStage } from '@features/gathering';
@@ -164,6 +165,33 @@ function createMockGatheringService(): IGatheringService {
   } as unknown as IGatheringService;
 }
 
+function createMockDeckService(): IDeckService {
+  return {
+    getHand: vi.fn().mockReturnValue([
+      {
+        id: toCardId('gathering-forest'),
+        master: { type: 'GATHERING', name: '近くの森' },
+        isGatheringCard: () => true,
+        isRecipeCard: () => false,
+        isEnhancementCard: () => false,
+      },
+    ]),
+    getHandSize: vi.fn().mockReturnValue(1),
+    getDeckSize: vi.fn().mockReturnValue(15),
+    getDiscardSize: vi.fn().mockReturnValue(0),
+    drawHand: vi.fn(),
+    discardHand: vi.fn().mockReturnValue([]),
+    playCard: vi.fn(),
+    addCard: vi.fn(),
+    removeCard: vi.fn(),
+    initialize: vi.fn(),
+    reset: vi.fn(),
+    shuffleDeck: vi.fn(),
+    getDeck: vi.fn().mockReturnValue([]),
+    getDiscard: vi.fn().mockReturnValue([]),
+  } as unknown as IDeckService;
+}
+
 // =============================================================================
 // テスト
 // =============================================================================
@@ -171,11 +199,13 @@ function createMockGatheringService(): IGatheringService {
 describe('GatheringPhaseUI 変更（TASK-0114）', () => {
   let mockScene: Phaser.Scene;
   let mockGatheringService: IGatheringService;
+  let mockDeckService: IDeckService;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockScene = createMockScene();
     mockGatheringService = createMockGatheringService();
+    mockDeckService = createMockDeckService();
   });
 
   // ===========================================================================
@@ -187,7 +217,7 @@ describe('GatheringPhaseUI 変更（TASK-0114）', () => {
       // 【テスト目的】: 採取フェーズ進入時にLocationSelectUIが表示される
       // 🔵 dataflow.md セクション4.2に基づく
 
-      const ui = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const ui = new GatheringPhaseUI(mockScene, mockGatheringService, mockDeckService);
       ui.create();
       ui.show();
 
@@ -195,7 +225,7 @@ describe('GatheringPhaseUI 変更（TASK-0114）', () => {
     });
 
     it('create()直後はステージが未設定（nullまたはLOCATION_SELECT）', () => {
-      const ui = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const ui = new GatheringPhaseUI(mockScene, mockGatheringService, mockDeckService);
       ui.create();
 
       // show()前でもgetCurrentStage()は呼べる
@@ -213,7 +243,7 @@ describe('GatheringPhaseUI 変更（TASK-0114）', () => {
       // 【テスト目的】: LocationSelectUIで場所を選択するとドラフト採取セッションが開始される
       // 🔵 dataflow.md セクション4.2に基づく
 
-      const ui = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const ui = new GatheringPhaseUI(mockScene, mockGatheringService, mockDeckService);
       ui.create();
       ui.show();
 
@@ -228,7 +258,7 @@ describe('GatheringPhaseUI 変更（TASK-0114）', () => {
     });
 
     it('場所選択後にGatheringServiceのstartDraftGatheringが呼ばれる', () => {
-      const ui = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const ui = new GatheringPhaseUI(mockScene, mockGatheringService, mockDeckService);
       ui.create();
       ui.show();
 
@@ -248,7 +278,7 @@ describe('GatheringPhaseUI 変更（TASK-0114）', () => {
 
   describe('アクティブセッション判定', () => {
     it('show()直後はアクティブセッションなし', () => {
-      const ui = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const ui = new GatheringPhaseUI(mockScene, mockGatheringService, mockDeckService);
       ui.create();
       ui.show();
 
@@ -256,7 +286,7 @@ describe('GatheringPhaseUI 変更（TASK-0114）', () => {
     });
 
     it('場所選択後はアクティブセッションあり', () => {
-      const ui = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const ui = new GatheringPhaseUI(mockScene, mockGatheringService, mockDeckService);
       ui.create();
       ui.show();
 
@@ -279,7 +309,7 @@ describe('GatheringPhaseUI 変更（TASK-0114）', () => {
       // 【テスト目的】: ドラフトセッション進行中にフェーズ切り替えが要求されると確認が必要
       // 🟡 EDGE-001・REQ-001-03・design-interview.md D3から妥当な推測
 
-      const ui = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const ui = new GatheringPhaseUI(mockScene, mockGatheringService, mockDeckService);
       ui.create();
       ui.show();
 
@@ -303,7 +333,7 @@ describe('GatheringPhaseUI 変更（TASK-0114）', () => {
     });
 
     it('アクティブセッションなしの場合、requestLeavePhase()は即座にonConfirmを呼ぶ', () => {
-      const ui = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const ui = new GatheringPhaseUI(mockScene, mockGatheringService, mockDeckService);
       ui.create();
       ui.show();
 
@@ -317,7 +347,7 @@ describe('GatheringPhaseUI 変更（TASK-0114）', () => {
     });
 
     it('confirmLeavePhase()でonConfirmが発火しセッションが破棄される', () => {
-      const ui = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const ui = new GatheringPhaseUI(mockScene, mockGatheringService, mockDeckService);
       ui.create();
       ui.show();
 
@@ -341,7 +371,7 @@ describe('GatheringPhaseUI 変更（TASK-0114）', () => {
     });
 
     it('cancelLeavePhase()でonCancelが発火しセッションが維持される', () => {
-      const ui = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const ui = new GatheringPhaseUI(mockScene, mockGatheringService, mockDeckService);
       ui.create();
       ui.show();
 
@@ -371,7 +401,7 @@ describe('GatheringPhaseUI 変更（TASK-0114）', () => {
 
   describe('セッション破棄', () => {
     it('discardSession()でLOCATION_SELECTに戻る', () => {
-      const ui = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const ui = new GatheringPhaseUI(mockScene, mockGatheringService, mockDeckService);
       ui.create();
       ui.show();
 
@@ -398,7 +428,7 @@ describe('GatheringPhaseUI 変更（TASK-0114）', () => {
 
   describe('場所データ設定（Issue #354）', () => {
     it('setAvailableLocations()で場所データが設定される', () => {
-      const ui = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const ui = new GatheringPhaseUI(mockScene, mockGatheringService, mockDeckService);
       ui.create();
 
       const locations: IGatheringLocation[] = GATHERING_LOCATIONS.map((loc) => ({
@@ -411,7 +441,7 @@ describe('GatheringPhaseUI 変更（TASK-0114）', () => {
     });
 
     it('show()後にsetAvailableLocations()を呼んでもエラーにならない', () => {
-      const ui = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const ui = new GatheringPhaseUI(mockScene, mockGatheringService, mockDeckService);
       ui.create();
       ui.show();
 
@@ -424,7 +454,7 @@ describe('GatheringPhaseUI 変更（TASK-0114）', () => {
     });
 
     it('setAvailableLocations()後にshow()でLocationSelectUIに場所が反映される', () => {
-      const ui = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const ui = new GatheringPhaseUI(mockScene, mockGatheringService, mockDeckService);
       ui.create();
 
       const locations: IGatheringLocation[] = GATHERING_LOCATIONS.map((loc) => ({
@@ -440,7 +470,7 @@ describe('GatheringPhaseUI 変更（TASK-0114）', () => {
     });
 
     it('discardSession()後に再度show()しても場所データが維持される', () => {
-      const ui = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const ui = new GatheringPhaseUI(mockScene, mockGatheringService, mockDeckService);
       ui.create();
 
       const locations: IGatheringLocation[] = GATHERING_LOCATIONS.map((loc) => ({
@@ -470,7 +500,7 @@ describe('GatheringPhaseUI 変更（TASK-0114）', () => {
 
   describe('destroy', () => {
     it('destroy()でリソースが解放される', () => {
-      const ui = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const ui = new GatheringPhaseUI(mockScene, mockGatheringService, mockDeckService);
       ui.create();
       ui.show();
 
@@ -478,7 +508,7 @@ describe('GatheringPhaseUI 変更（TASK-0114）', () => {
     });
 
     it('セッション進行中にdestroy()してもエラーにならない', () => {
-      const ui = new GatheringPhaseUI(mockScene, mockGatheringService);
+      const ui = new GatheringPhaseUI(mockScene, mockGatheringService, mockDeckService);
       ui.create();
       ui.show();
 


### PR DESCRIPTION
## Summary
- 採取フェーズで採取地をクリックした際に `card.isGatheringCard is not a function` エラーが発生する問題を修正
- `GatheringPhaseUI.handleLocationSelected()` でプレーンオブジェクトの代わりに `DeckService.getHand()` から正しい `Card` オブジェクトを取得するように変更
- `PhaseManager` から `DeckService` を `GatheringPhaseUI` に注入

## Test plan
- [x] 型チェック（tsc --noEmit）パス
- [x] ユニットテスト 2685件パス（0件失敗）
- [x] リントチェック（変更ファイルのみ）パス
- [ ] 実機で採取地クリック→ドラフト採取セッション開始を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)