### PR TITLE
fix: 2回採取時に未選択素材が採取済みになる問題を修正

### DIFF
--- a/atelier-guild-rank/src/features/gathering/components/MaterialSlotUI.ts
+++ b/atelier-guild-rank/src/features/gathering/components/MaterialSlotUI.ts
@@ -155,6 +155,9 @@ export class MaterialSlotUI extends BaseComponent {
    * @param enabled - 有効/無効
    */
   setInteractive(enabled: boolean): void {
+    // リスナーの累積追加を防ぐため、状態変更時は常に既存リスナーを解除する
+    this.container.removeAllListeners();
+
     if (enabled && this.material && this.clickCallback) {
       this.container.setInteractive(
         new Phaser.Geom.Rectangle(
@@ -182,7 +185,6 @@ export class MaterialSlotUI extends BaseComponent {
       });
     } else {
       this.container.removeInteractive();
-      this.container.removeAllListeners();
     }
   }
 


### PR DESCRIPTION
## Summary
- `MaterialSlotUI.setInteractive(true)`呼出時に`pointerdown`リスナーが累積追加される問題を修正
- リスナー登録前に`removeAllListeners()`で既存リスナーを解除するようにし、1クリックで複数回選択処理が発生する問題を解消

Closes #410

## Test plan
- [ ] 2回採取時に選択した素材のみが採取済みになることを確認
- [ ] 未選択の素材が採取済みにならないことを確認
- [ ] 素材スロットのホバーエフェクトが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)