### PR TITLE
fix: 採取フェーズのテキスト色を改善してコントラストを確保

### DIFF
--- a/atelier-guild-rank/src/features/gathering/components/LocationSelectUI.ts
+++ b/atelier-guild-rank/src/features/gathering/components/LocationSelectUI.ts
@@ -360,7 +360,7 @@ export class LocationSelectUI extends BaseComponent {
       text: '採取地マップ',
       style: {
         fontSize: `${THEME.sizes.large}px`,
-        color: '#FFFFFF',
+        color: `#${Colors.text.primary.toString(16).padStart(6, '0')}`,
         fontStyle: 'bold',
         fontFamily: THEME.fonts.primary,
       },
@@ -401,7 +401,7 @@ export class LocationSelectUI extends BaseComponent {
       text: location.name,
       style: {
         fontSize: `${THEME.sizes.medium}px`,
-        color: '#FFFFFF',
+        color: `#${Colors.text.primary.toString(16).padStart(6, '0')}`,
         fontStyle: 'bold',
         fontFamily: THEME.fonts.primary,
       },
@@ -433,7 +433,7 @@ export class LocationSelectUI extends BaseComponent {
       text: materialsStr,
       style: {
         fontSize: `${MAP_LAYOUT.MATERIAL_FONT_SIZE}px`,
-        color: '#CCCCCC',
+        color: `#${Colors.text.secondary.toString(16).padStart(6, '0')}`,
         fontFamily: THEME.fonts.primary,
       },
       add: false,


### PR DESCRIPTION
## Summary
- 採取地マップUIのテキスト色がベージュ系背景色(`Colors.background.secondary` = `0xede3d0`)と近く視認性が低い問題を修正
- タイトル・場所名テキスト色を `'#FFFFFF'`(白) → `Colors.text.primary`(`#333333`) に変更
- 素材プレビューテキスト色を `'#CCCCCC'` → `Colors.text.secondary`(`#666666`) に変更
- ハードコードされた色値をTHEMEの定数に統一

## Test plan
- [x] ユニットテスト全パス (147ファイル, 2685テスト)
- [x] 型チェックパス
- [x] リントチェックパス (既存警告のみ、新規エラーなし)
- [ ] 採取フェーズの場所選択画面でテキストが読みやすいことを目視確認

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)