### PR TITLE
fix: 調合UIのイベントリスナー解除漏れを修正

### DIFF
--- a/atelier-guild-rank/src/features/alchemy/components/AlchemyPhaseUI.ts
+++ b/atelier-guild-rank/src/features/alchemy/components/AlchemyPhaseUI.ts
@@ -128,6 +128,9 @@ export class AlchemyPhaseUI extends BaseComponent {
   /** キーボードイベントハンドラ参照（Issue #135） */
   private keyboardHandler: ((event: { key: string }) => void) | null = null;
 
+  /** 調合ボタン背景の参照（Issue #426: リスナー解除用） */
+  private craftButtonBg: RexRoundRectangle | null = null;
+
   /** 現在のフォーカスインデックス（キーボードナビゲーション用） */
   private focusedRecipeIndex = 0;
 
@@ -512,7 +515,7 @@ export class AlchemyPhaseUI extends BaseComponent {
 
     this.craftButtonContainer = this.scene.add.container(buttonX, buttonY);
 
-    // ボタン背景
+    // ボタン背景（Issue #426: リスナー解除用に参照を保持）
     const bg = this.rexUI.add
       .roundRectangle({
         width: buttonWidth,
@@ -524,6 +527,7 @@ export class AlchemyPhaseUI extends BaseComponent {
     bg.on('pointerdown', () => {
       this.executeCraft();
     });
+    this.craftButtonBg = bg;
 
     // ボタンテキスト
     const buttonText = this.scene.make.text({
@@ -763,11 +767,8 @@ export class AlchemyPhaseUI extends BaseComponent {
     // スクロール位置をリセット（カード再作成前に実施）
     this.resetScroll();
 
-    // 既存のレシピカードを破棄（コンテナ破棄で子要素も一括破棄）
-    for (const item of this.recipeLabels) {
-      item.cardContainer.destroy(true);
-    }
-    this.recipeLabels = [];
+    // 既存のレシピカードを破棄（Issue #426: リスナー解除してからコンテナ破棄）
+    this.cleanupRecipeLabels();
 
     // 選択状態をリセット
     this.selectedRecipeId = null;
@@ -782,20 +783,44 @@ export class AlchemyPhaseUI extends BaseComponent {
 
   /**
    * コンポーネントを破棄
+   * Issue #426: リスナー解除漏れを修正
    */
   destroy(): void {
     this.removeKeyboardListener();
+    this.cleanupRecipeLabels();
+    this.cleanupCraftButton();
+    this.qualityPreviewText = null;
+    this.destroyScrollArea();
+    this.container.destroy();
+  }
+
+  /**
+   * レシピラベルのリスナーを解除してから破棄
+   * Issue #426: refresh()とdestroy()で共通利用
+   */
+  private cleanupRecipeLabels(): void {
     for (const item of this.recipeLabels) {
+      if (item.craftable) {
+        item.background.off('pointerdown');
+      }
       item.cardContainer.destroy(true);
     }
     this.recipeLabels = [];
+  }
+
+  /**
+   * 調合ボタンのリスナーを解除してから破棄
+   * Issue #426: destroy()でリスナー解除を確実に実施
+   */
+  private cleanupCraftButton(): void {
+    if (this.craftButtonBg) {
+      this.craftButtonBg.off('pointerdown');
+      this.craftButtonBg = null;
+    }
     if (this.craftButtonContainer) {
       this.craftButtonContainer.destroy(true);
       this.craftButtonContainer = null;
     }
-    this.qualityPreviewText = null;
-    this.destroyScrollArea();
-    this.container.destroy();
   }
 
   // =============================================================================

--- a/atelier-guild-rank/src/features/alchemy/components/RecipeListUI.ts
+++ b/atelier-guild-rank/src/features/alchemy/components/RecipeListUI.ts
@@ -264,9 +264,14 @@ export class RecipeListUI extends BaseComponent {
 
   /**
    * コンポーネントを破棄
+   * Issue #426: リスナー解除漏れを修正
    */
   destroy(): void {
     for (const item of this.labels) {
+      // pointerdownリスナーを解除してからラベルを破棄
+      if (typeof item.label.off === 'function') {
+        item.label.off('pointerdown');
+      }
       item.label.destroy();
     }
     this.labels = [];

--- a/atelier-guild-rank/tests/unit/presentation/ui/phases/alchemy-phase-ui.test.ts
+++ b/atelier-guild-rank/tests/unit/presentation/ui/phases/alchemy-phase-ui.test.ts
@@ -170,6 +170,7 @@ const createMockScene = (): { scene: MockScene; mockContainer: MockContainer } =
           setPosition: vi.fn().mockReturnThis(),
           setInteractive: vi.fn().mockReturnThis(),
           on: vi.fn().mockReturnThis(),
+          off: vi.fn().mockReturnThis(),
         }),
         label: vi.fn().mockReturnValue(mockLabel),
         scrollablePanel: vi.fn().mockReturnValue({


### PR DESCRIPTION
## Summary
- `AlchemyPhaseUI`のレシピカード・調合ボタンの`pointerdown`リスナーが`destroy()`や`refresh()`時に解除されていなかった問題を修正
- `RecipeListUI`のラベルの`pointerdown`リスナーが`destroy()`時に解除されていなかった問題を修正
- リスナー解除ロジックを`cleanupRecipeLabels()`と`cleanupCraftButton()`に共通化し、`refresh()`と`destroy()`の両方で確実に解除されるようにした

## Test plan
- [ ] `pnpm test -- --run` でユニットテストがパスすること
- [ ] `pnpm typecheck` で型エラーがないこと
- [ ] `pnpm lint` でリントエラーがないこと
- [ ] 調合フェーズでレシピ選択・調合を複数回繰り返してもメモリリークが発生しないこと
- [ ] 調合フェーズから他フェーズへの遷移後、不要なイベントリスナーが残らないこと

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)