### PR TITLE
test: リゾルバ注入時のユニットテストを追加

### DIFF
--- a/atelier-guild-rank/tests/unit/scenes/helpers/phase-manager-resolvers.test.ts
+++ b/atelier-guild-rank/tests/unit/scenes/helpers/phase-manager-resolvers.test.ts
@@ -1,0 +1,213 @@
+/**
+ * PhaseManager リゾルバ生成テスト
+ * Issue #428: リゾルバ注入時のユニットテスト追加
+ *
+ * @description
+ * PhaseManagerのcreateMaterialNameResolver()とcreateItemNameResolver()を検証する。
+ * MasterDataRepositoryの有無に応じた動作を確認する。
+ */
+
+import type { IMasterDataRepository } from '@domain/interfaces/master-data-repository.interface';
+import { Container, ServiceKeys } from '@shared/services/di/container';
+import { toItemId, toMaterialId } from '@shared/types/ids';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Phaser依存を排除するためのモック
+vi.mock('phaser', () => ({
+  default: {
+    Scene: class MockScene {},
+    GameObjects: {
+      Container: class MockContainer {},
+    },
+  },
+}));
+
+// PhaseManagerの依存モジュールをモック
+vi.mock('@domain/entities/Quest', () => ({
+  Quest: class MockQuest {},
+}));
+
+vi.mock('@presentation/ui/phases/QuestAcceptPhaseUI', () => ({
+  QuestAcceptPhaseUI: class MockQuestAcceptPhaseUI {},
+}));
+
+vi.mock('@presentation/ui/phases/DeliveryPhaseUI', () => ({
+  DeliveryPhaseUI: class MockDeliveryPhaseUI {},
+}));
+
+vi.mock('@features/alchemy', () => ({
+  AlchemyPhaseUI: class MockAlchemyPhaseUI {},
+}));
+
+vi.mock('@features/gathering', () => ({
+  GatheringPhaseUI: class MockGatheringPhaseUI {},
+  GATHERING_LOCATIONS: [],
+}));
+
+// PhaseManagerをインポート（モック設定後）
+import { PhaseManager } from '@scenes/helpers/PhaseManager';
+
+describe('PhaseManager リゾルバ生成', () => {
+  let container: ReturnType<typeof Container.getInstance>;
+
+  beforeEach(() => {
+    Container.reset();
+    container = Container.getInstance();
+  });
+
+  afterEach(() => {
+    Container.reset();
+  });
+
+  // テスト用のPhaseManagerインスタンスを作成するヘルパー
+  function createPhaseManager(): PhaseManager {
+    const mockScene = {} as unknown as import('phaser').Scene;
+    const mockContainer = {} as unknown as import('phaser').GameObjects.Container;
+    const mockQuestService = {
+      getActiveQuests: vi.fn().mockReturnValue([]),
+      acceptQuest: vi.fn(),
+    } as unknown as import('@features/quest').IQuestService;
+
+    return new PhaseManager(mockScene, mockContainer, mockQuestService);
+  }
+
+  describe('createMaterialNameResolver', () => {
+    it('MasterDataRepositoryが登録されていない場合、undefinedを返す', () => {
+      const phaseManager = createPhaseManager();
+
+      const resolver = phaseManager.createMaterialNameResolver();
+
+      expect(resolver).toBeUndefined();
+    });
+
+    it('MasterDataRepositoryが登録されている場合、リゾルバ関数を返す', () => {
+      const mockRepo: Partial<IMasterDataRepository> = {
+        getMaterialById: vi.fn(),
+      };
+      container.register(ServiceKeys.MasterDataRepository, mockRepo);
+
+      const phaseManager = createPhaseManager();
+      const resolver = phaseManager.createMaterialNameResolver();
+
+      expect(resolver).toBeTypeOf('function');
+    });
+
+    it('リゾルバが素材IDから日本語名を解決する', () => {
+      const mockRepo: Partial<IMasterDataRepository> = {
+        getMaterialById: vi.fn((id) => {
+          if (id === toMaterialId('mat_001')) {
+            return {
+              id: toMaterialId('mat_001'),
+              name: '薬草',
+              baseQuality: 50,
+              attributes: [],
+            };
+          }
+          return undefined;
+        }),
+      };
+      container.register(ServiceKeys.MasterDataRepository, mockRepo);
+
+      const phaseManager = createPhaseManager();
+      const resolver = phaseManager.createMaterialNameResolver();
+
+      expect(resolver).toBeDefined();
+      expect(resolver?.('mat_001')).toBe('薬草');
+    });
+
+    it('マスターデータに存在しない素材IDの場合、IDをそのまま返す', () => {
+      const mockRepo: Partial<IMasterDataRepository> = {
+        getMaterialById: vi.fn().mockReturnValue(undefined),
+      };
+      container.register(ServiceKeys.MasterDataRepository, mockRepo);
+
+      const phaseManager = createPhaseManager();
+      const resolver = phaseManager.createMaterialNameResolver();
+
+      expect(resolver).toBeDefined();
+      expect(resolver?.('unknown_mat')).toBe('unknown_mat');
+    });
+
+    it('リゾルバがtoMaterialIdで正しく型変換して呼び出す', () => {
+      const getMaterialById = vi.fn().mockReturnValue(undefined);
+      const mockRepo: Partial<IMasterDataRepository> = { getMaterialById };
+      container.register(ServiceKeys.MasterDataRepository, mockRepo);
+
+      const phaseManager = createPhaseManager();
+      const resolver = phaseManager.createMaterialNameResolver();
+      resolver?.('mat_test');
+
+      expect(getMaterialById).toHaveBeenCalledWith(toMaterialId('mat_test'));
+    });
+  });
+
+  describe('createItemNameResolver', () => {
+    it('MasterDataRepositoryが登録されていない場合、undefinedを返す', () => {
+      const phaseManager = createPhaseManager();
+
+      const resolver = phaseManager.createItemNameResolver();
+
+      expect(resolver).toBeUndefined();
+    });
+
+    it('MasterDataRepositoryが登録されている場合、リゾルバ関数を返す', () => {
+      const mockRepo: Partial<IMasterDataRepository> = {
+        getItemById: vi.fn(),
+      };
+      container.register(ServiceKeys.MasterDataRepository, mockRepo);
+
+      const phaseManager = createPhaseManager();
+      const resolver = phaseManager.createItemNameResolver();
+
+      expect(resolver).toBeTypeOf('function');
+    });
+
+    it('リゾルバがアイテムIDから日本語名を解決する', () => {
+      const mockRepo: Partial<IMasterDataRepository> = {
+        getItemById: vi.fn((id) => {
+          if (id === toItemId('item_001')) {
+            return {
+              id: toItemId('item_001'),
+              name: '癒しの軟膏',
+              category: 'MEDICINE',
+              effects: [],
+            };
+          }
+          return undefined;
+        }),
+      };
+      container.register(ServiceKeys.MasterDataRepository, mockRepo);
+
+      const phaseManager = createPhaseManager();
+      const resolver = phaseManager.createItemNameResolver();
+
+      expect(resolver).toBeDefined();
+      expect(resolver?.('item_001')).toBe('癒しの軟膏');
+    });
+
+    it('マスターデータに存在しないアイテムIDの場合、IDをそのまま返す', () => {
+      const mockRepo: Partial<IMasterDataRepository> = {
+        getItemById: vi.fn().mockReturnValue(undefined),
+      };
+      container.register(ServiceKeys.MasterDataRepository, mockRepo);
+
+      const phaseManager = createPhaseManager();
+      const resolver = phaseManager.createItemNameResolver();
+
+      expect(resolver).toBeDefined();
+      expect(resolver?.('unknown_item')).toBe('unknown_item');
+    });
+
+    it('リゾルバがtoItemIdで正しく型変換して呼び出す', () => {
+      const getItemById = vi.fn().mockReturnValue(undefined);
+      const mockRepo: Partial<IMasterDataRepository> = { getItemById };
+      container.register(ServiceKeys.MasterDataRepository, mockRepo);
+
+      const phaseManager = createPhaseManager();
+      const resolver = phaseManager.createItemNameResolver();
+      resolver?.('item_test');
+
+      expect(getItemById).toHaveBeenCalledWith(toItemId('item_test'));
+    });
+  });
+});

--- a/atelier-guild-rank/tests/unit/shared/utils/format-condition.test.ts
+++ b/atelier-guild-rank/tests/unit/shared/utils/format-condition.test.ts
@@ -1,0 +1,189 @@
+/**
+ * format-condition テスト
+ * Issue #428: リゾルバ注入時のユニットテスト追加
+ *
+ * @description
+ * formatCondition の各条件タイプとオプション動作を検証する。
+ */
+
+import { type FormatConditionInput, formatCondition } from '@shared/utils/format-condition';
+import { describe, expect, it } from 'vitest';
+
+describe('formatCondition', () => {
+  describe('条件タイプ別フォーマット', () => {
+    it('SPECIFIC: itemIdとリゾルバがある場合、解決された日本語名を使用する', () => {
+      const condition: FormatConditionInput = { type: 'SPECIFIC', itemId: 'item_001' };
+      const resolver = (id: string) => (id === 'item_001' ? '癒しの軟膏' : id);
+
+      const result = formatCondition(condition, { itemNameResolver: resolver });
+
+      expect(result).toBe('癒しの軟膏を納品');
+    });
+
+    it('SPECIFIC: itemIdがあるがリゾルバがない場合、itemIdをそのまま使用する', () => {
+      const condition: FormatConditionInput = { type: 'SPECIFIC', itemId: 'item_001' };
+
+      const result = formatCondition(condition);
+
+      expect(result).toBe('item_001を納品');
+    });
+
+    it('SPECIFIC: itemIdがない場合、「指定品」を使用する', () => {
+      const condition: FormatConditionInput = { type: 'SPECIFIC' };
+
+      const result = formatCondition(condition);
+
+      expect(result).toBe('指定品を納品');
+    });
+
+    it('CATEGORY: カテゴリ名を使用する', () => {
+      const condition: FormatConditionInput = { type: 'CATEGORY', category: '薬品' };
+
+      const result = formatCondition(condition);
+
+      expect(result).toBe('薬品の品を納品');
+    });
+
+    it('CATEGORY: カテゴリがない場合、デフォルト値を使用する', () => {
+      const condition: FormatConditionInput = { type: 'CATEGORY' };
+
+      const result = formatCondition(condition);
+
+      expect(result).toBe('カテゴリの品を納品');
+    });
+
+    it('QUALITY: 品質閾値を表示する', () => {
+      const condition: FormatConditionInput = { type: 'QUALITY', minQuality: 'B' };
+
+      const result = formatCondition(condition);
+
+      expect(result).toBe('品質B以上');
+    });
+
+    it('QUALITY: minQualityがない場合、デフォルト値Dを使用する', () => {
+      const condition: FormatConditionInput = { type: 'QUALITY' };
+
+      const result = formatCondition(condition);
+
+      expect(result).toBe('品質D以上');
+    });
+
+    it('QUANTITY: 数量を表示する', () => {
+      const condition: FormatConditionInput = { type: 'QUANTITY', quantity: 3 };
+
+      const result = formatCondition(condition);
+
+      expect(result).toBe('3個納品');
+    });
+
+    it('QUANTITY: quantityがない場合、デフォルト値1を使用する', () => {
+      const condition: FormatConditionInput = { type: 'QUANTITY' };
+
+      const result = formatCondition(condition);
+
+      expect(result).toBe('1個納品');
+    });
+
+    it('ATTRIBUTE: 固定テキストを返す', () => {
+      const condition: FormatConditionInput = { type: 'ATTRIBUTE' };
+
+      const result = formatCondition(condition);
+
+      expect(result).toBe('特定属性が必要');
+    });
+
+    it('EFFECT: 固定テキストを返す', () => {
+      const condition: FormatConditionInput = { type: 'EFFECT' };
+
+      const result = formatCondition(condition);
+
+      expect(result).toBe('特定効果が必要');
+    });
+
+    it('MATERIAL: 固定テキストを返す', () => {
+      const condition: FormatConditionInput = { type: 'MATERIAL' };
+
+      const result = formatCondition(condition);
+
+      expect(result).toBe('レア素材を使用');
+    });
+
+    it('COMPOUND: 固定テキストを返す', () => {
+      const condition: FormatConditionInput = { type: 'COMPOUND' };
+
+      const result = formatCondition(condition);
+
+      expect(result).toBe('複合条件');
+    });
+
+    it('未知の条件タイプの場合、タイプ文字列をそのまま返す', () => {
+      const condition: FormatConditionInput = { type: 'UNKNOWN_TYPE' };
+
+      const result = formatCondition(condition);
+
+      expect(result).toBe('UNKNOWN_TYPE');
+    });
+  });
+
+  describe('withPrefixオプション', () => {
+    it('withPrefix=trueの場合、「条件: 」プレフィックスが付与される', () => {
+      const condition: FormatConditionInput = { type: 'QUANTITY', quantity: 5 };
+
+      const result = formatCondition(condition, { withPrefix: true });
+
+      expect(result).toBe('条件: 5個納品');
+    });
+
+    it('withPrefix=falseの場合、プレフィックスは付与されない', () => {
+      const condition: FormatConditionInput = { type: 'QUANTITY', quantity: 5 };
+
+      const result = formatCondition(condition, { withPrefix: false });
+
+      expect(result).toBe('5個納品');
+    });
+
+    it('withPrefixが未指定の場合、プレフィックスは付与されない', () => {
+      const condition: FormatConditionInput = { type: 'QUANTITY', quantity: 5 };
+
+      const result = formatCondition(condition);
+
+      expect(result).toBe('5個納品');
+    });
+
+    it('withPrefix=trueとitemNameResolverを組み合わせて使用できる', () => {
+      const condition: FormatConditionInput = { type: 'SPECIFIC', itemId: 'item_002' };
+      const resolver = (id: string) => (id === 'item_002' ? '火の結晶' : id);
+
+      const result = formatCondition(condition, {
+        itemNameResolver: resolver,
+        withPrefix: true,
+      });
+
+      expect(result).toBe('条件: 火の結晶を納品');
+    });
+  });
+
+  describe('itemNameResolver', () => {
+    it('リゾルバが名前を解決できない場合、itemIdがフォールバックとして使用される', () => {
+      const condition: FormatConditionInput = { type: 'SPECIFIC', itemId: 'unknown_item' };
+      // リゾルバがそのまま返す場合（マスターデータに存在しない場合のシミュレーション）
+      const resolver = (id: string) => id;
+
+      const result = formatCondition(condition, { itemNameResolver: resolver });
+
+      expect(result).toBe('unknown_itemを納品');
+    });
+
+    it('SPECIFIC以外の条件タイプではリゾルバは使用されない', () => {
+      let resolverCalled = false;
+      const resolver = (id: string) => {
+        resolverCalled = true;
+        return id;
+      };
+
+      formatCondition({ type: 'QUANTITY', quantity: 3 }, { itemNameResolver: resolver });
+
+      expect(resolverCalled).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- PhaseManagerの`createMaterialNameResolver()`/`createItemNameResolver()`のユニットテストを追加（10テスト）
- 共通ユーティリティ`formatCondition()`のユニットテストを追加（20テスト）
- MasterDataRepositoryの有無に応じたリゾルバ生成動作、各条件タイプのフォーマット、withPrefixオプションを検証

Closes #428

## Test plan
- [x] `pnpm test -- --run` - 全2736テストがパス（新規30テスト含む）
- [x] `pnpm typecheck` - 型エラーなし
- [x] `pnpm lint` - 新規ファイルにリントエラーなし
- [x] PhaseManager: MasterDataRepository未登録時にundefinedが返ることを確認
- [x] PhaseManager: MasterDataRepository登録時に正しい日本語名が返ることを確認
- [x] formatCondition: 全8条件タイプのフォーマットを確認
- [x] formatCondition: withPrefixオプションの動作を確認
- [x] formatCondition: itemNameResolverの有無によるフォールバック動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)