### PR TITLE
fix: 依頼フェーズで受注済み依頼の詳細を確認可能にする

### DIFF
--- a/atelier-guild-rank/src/scenes/helpers/PhaseManager.ts
+++ b/atelier-guild-rank/src/scenes/helpers/PhaseManager.ts
@@ -274,6 +274,9 @@ export class PhaseManager {
     }
 
     // フェーズ固有の初期化
+    if (phase === GamePhase.QUEST_ACCEPT) {
+      this.initializeQuestAcceptPhase();
+    }
     if (phase === GamePhase.GATHERING) {
       this.initializeGatheringSession();
     }
@@ -301,6 +304,18 @@ export class PhaseManager {
   // ===========================================================================
   // フェーズ固有の初期化・終了処理
   // ===========================================================================
+
+  /**
+   * 依頼受注フェーズを初期化
+   * Issue #431: 受注済み依頼をメインコンテンツエリアに表示
+   */
+  private initializeQuestAcceptPhase(): void {
+    const questAcceptUI = this.phaseUIs.get(GamePhase.QUEST_ACCEPT);
+    if (questAcceptUI && 'updateAcceptedQuests' in questAcceptUI) {
+      const activeQuests = this.questService.getActiveQuests();
+      (questAcceptUI as QuestAcceptPhaseUI).updateAcceptedQuests(activeQuests);
+    }
+  }
 
   /**
    * 採取フェーズを初期化（場所選択ステージ）
@@ -445,6 +460,11 @@ export class PhaseManager {
       const questAcceptUI = this.phaseUIs.get(GamePhase.QUEST_ACCEPT);
       if (questAcceptUI && 'removeAcceptedQuest' in questAcceptUI) {
         (questAcceptUI as QuestAcceptPhaseUI).removeAcceptedQuest(event.quest.id);
+      }
+
+      // Issue #431: 受注済み依頼リストをメインコンテンツエリアに表示更新
+      if (questAcceptUI && 'updateAcceptedQuests' in questAcceptUI) {
+        (questAcceptUI as QuestAcceptPhaseUI).updateAcceptedQuests(activeQuests);
       }
     } catch (error) {
       console.error('Failed to accept quest:', error);

--- a/atelier-guild-rank/src/shared/presentation/ui/phases/QuestAcceptPhaseUI.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/phases/QuestAcceptPhaseUI.ts
@@ -15,11 +15,12 @@
  * ```
  */
 
-import type { Quest } from '@domain/entities/Quest';
+import { Quest } from '@domain/entities/Quest';
 import { ScrollableContainer } from '@shared/components/ScrollableContainer';
 import { MAIN_LAYOUT } from '@shared/constants';
 import { getSelectionIndexFromKey, isKeyForAction } from '@shared/constants/keybindings';
 import { GameEventType } from '@shared/types/events';
+import type { IActiveQuest } from '@shared/types/quests';
 import type Phaser from 'phaser';
 import type { RexScrollablePanel } from '../../types/rexui';
 import { BaseComponent } from '../components/BaseComponent';
@@ -119,6 +120,19 @@ export class QuestAcceptPhaseUI extends BaseComponent {
   private itemNameResolver?: (itemId: string) => string;
 
   // =============================================================================
+  // 受注済み依頼表示（Issue #431）
+  // =============================================================================
+
+  /** 受注済み依頼カードリスト */
+  private acceptedQuestCards: QuestCardUI[] = [];
+
+  /** 受注済み依頼セクションタイトル */
+  private acceptedSectionTitle: Phaser.GameObjects.Text | null = null;
+
+  /** 受注済み依頼セクション区切り線 */
+  private acceptedSectionDivider: Phaser.GameObjects.Rectangle | null = null;
+
+  // =============================================================================
   // レイアウト定数
   // =============================================================================
 
@@ -153,6 +167,15 @@ export class QuestAcceptPhaseUI extends BaseComponent {
   private static readonly TITLE_FONT_SIZE = '24px';
   private static readonly TITLE_COLOR = '#000000';
   private static readonly TITLE_TEXT = '📋 本日の依頼';
+
+  /**
+   * 【受注済みセクション定数】: 受注済み依頼の表示レイアウト（Issue #431）
+   */
+  private static readonly ACCEPTED_SECTION_TITLE = '📌 受注済み依頼';
+  private static readonly ACCEPTED_SECTION_FONT_SIZE = '20px';
+  private static readonly ACCEPTED_SECTION_COLOR = '#333333';
+  private static readonly ACCEPTED_CARD_START_X = 200;
+  private static readonly ACCEPTED_CARD_SPACING_X = 300;
 
   /**
    * 【コンストラクタ】: 依頼受注フェーズUIを初期化
@@ -458,6 +481,10 @@ export class QuestAcceptPhaseUI extends BaseComponent {
     // 【受注済みリスト破棄】
     this.destroyAcceptedList();
 
+    // 【受注済み依頼カード破棄】Issue #431
+    this.destroyAcceptedQuestCards();
+    this.destroyAcceptedSectionHeader();
+
     // 【タイトルテキスト破棄】
     this.destroyTitleText();
 
@@ -677,6 +704,188 @@ export class QuestAcceptPhaseUI extends BaseComponent {
    */
   public canAcceptMore(): boolean {
     return this._acceptedCount < QuestAcceptPhaseUI.QUEST_ACCEPT_LIMIT;
+  }
+
+  // =============================================================================
+  // Issue #431: 受注済み依頼表示
+  // =============================================================================
+
+  /**
+   * 【受注済み依頼表示更新】: 受注済み依頼をカード形式でメインコンテンツエリアに表示
+   *
+   * 【設計意図】:
+   * - 受注済み依頼の詳細（必要素材、報酬、期限等）をカード形式で確認可能にする
+   * - 新規依頼リストの下に「受注済み依頼」セクションとして表示
+   * - IActiveQuestからQuestエンティティを復元してQuestCardUIで表示
+   *
+   * @param activeQuests - 受注済み依頼リスト
+   */
+  public updateAcceptedQuests(activeQuests: IActiveQuest[]): void {
+    // 既存の受注済みカードを破棄
+    this.destroyAcceptedQuestCards();
+
+    if (!activeQuests || activeQuests.length === 0) {
+      this.destroyAcceptedSectionHeader();
+      return;
+    }
+
+    const targetContainer = this.scrollableContainer?.getScrollContainer() ?? this.container;
+
+    // 受注済みセクションのY位置を計算（新規依頼カードの下）
+    const acceptedSectionY = this.calculateAcceptedSectionY();
+
+    // セクションタイトルを作成
+    this.createAcceptedSectionHeader(targetContainer, acceptedSectionY);
+
+    // 受注済み依頼カードを横一列で配置
+    const cardStartY = acceptedSectionY + 40;
+    for (let i = 0; i < activeQuests.length; i++) {
+      const activeQuest = activeQuests[i];
+      const quest = new Quest(activeQuest.quest, activeQuest.client);
+      const x =
+        QuestAcceptPhaseUI.ACCEPTED_CARD_START_X + i * QuestAcceptPhaseUI.ACCEPTED_CARD_SPACING_X;
+
+      const questCard = new QuestCardUI(this.scene, {
+        quest,
+        x,
+        y: cardStartY,
+        interactive: true,
+        itemNameResolver: this.itemNameResolver,
+      });
+      targetContainer.add(questCard.getContainer());
+
+      // クリックで詳細モーダルを開く（受注ボタンなし、閲覧のみ）
+      const background = questCard.getBackground();
+      if (background?.on) {
+        background.on('pointerdown', () => {
+          this.openAcceptedQuestDetailModal(quest, activeQuest.remainingDays);
+        });
+      }
+
+      this.acceptedQuestCards.push(questCard);
+    }
+
+    // スクロールコンテンツ高さを更新
+    this.scrollableContainer?.setContentHeight(this.getTotalContentHeight());
+  }
+
+  /**
+   * 【受注済み依頼詳細モーダルを開く】: 受注済み依頼の詳細を閲覧専用モーダルで表示
+   *
+   * 【設計意図】:
+   * - 受注済み依頼は受注ボタンを表示せず、閲覧のみ可能にする
+   * - 残り日数の情報を確認できるようにする
+   *
+   * @param quest - 依頼エンティティ
+   * @param remainingDays - 残り日数
+   */
+  private openAcceptedQuestDetailModal(quest: Quest, remainingDays: number): void {
+    if (this.currentModal) {
+      return;
+    }
+
+    // 残り日数を反映したQuestデータを作成
+    const questWithRemainingDays = new Quest(
+      { ...quest.data, deadline: remainingDays },
+      quest.client,
+    );
+
+    this.currentModal = new QuestDetailModal(this.scene, {
+      quest: questWithRemainingDays,
+      onAccept: () => {
+        // 受注済みの場合は受注ボタンを押しても閉じるだけ
+        this.closeQuestDetailModal();
+      },
+      onClose: () => {
+        this.closeQuestDetailModal();
+      },
+      itemNameResolver: this.itemNameResolver,
+    });
+    this.currentModal.create();
+  }
+
+  /**
+   * 【受注済みセクションのY位置を計算】: 新規依頼カードの下の位置を返す
+   */
+  private calculateAcceptedSectionY(): number {
+    if (this.questCards.length === 0) {
+      return QuestAcceptPhaseUI.GRID_START_Y;
+    }
+    const rows = Math.ceil(this.questCards.length / QuestAcceptPhaseUI.GRID_COLUMNS);
+    return QuestAcceptPhaseUI.GRID_START_Y + rows * QuestAcceptPhaseUI.GRID_SPACING_Y + 20;
+  }
+
+  /**
+   * 【受注済みセクションヘッダー作成】: タイトルと区切り線を作成
+   */
+  private createAcceptedSectionHeader(
+    targetContainer: Phaser.GameObjects.Container,
+    sectionY: number,
+  ): void {
+    this.destroyAcceptedSectionHeader();
+
+    // 区切り線
+    this.acceptedSectionDivider = this.scene.add.rectangle(440, sectionY - 15, 700, 2, 0xcccccc);
+    targetContainer.add(this.acceptedSectionDivider);
+
+    // セクションタイトル
+    this.acceptedSectionTitle = this.scene.add.text(
+      440,
+      sectionY,
+      QuestAcceptPhaseUI.ACCEPTED_SECTION_TITLE,
+      {
+        fontSize: QuestAcceptPhaseUI.ACCEPTED_SECTION_FONT_SIZE,
+        color: QuestAcceptPhaseUI.ACCEPTED_SECTION_COLOR,
+        fontStyle: 'bold',
+      },
+    );
+    this.acceptedSectionTitle.setOrigin(0.5, 0);
+    targetContainer.add(this.acceptedSectionTitle);
+  }
+
+  /**
+   * 【受注済みセクションヘッダー破棄】
+   */
+  private destroyAcceptedSectionHeader(): void {
+    if (this.acceptedSectionTitle) {
+      this.acceptedSectionTitle.destroy();
+      this.acceptedSectionTitle = null;
+    }
+    if (this.acceptedSectionDivider) {
+      this.acceptedSectionDivider.destroy();
+      this.acceptedSectionDivider = null;
+    }
+  }
+
+  /**
+   * 【受注済み依頼カード破棄】: 受注済み依頼のカードを全て破棄
+   */
+  private destroyAcceptedQuestCards(): void {
+    for (const card of this.acceptedQuestCards) {
+      if (card?.destroy) {
+        card.destroy();
+      }
+    }
+    this.acceptedQuestCards = [];
+  }
+
+  /**
+   * 【全コンテンツ高さ取得】: 新規依頼 + 受注済み依頼を含む総高さ
+   */
+  private getTotalContentHeight(): number {
+    const baseHeight = this.getTotalCardContentHeight();
+    if (this.acceptedQuestCards.length === 0) {
+      return baseHeight;
+    }
+    // 受注済みセクション: タイトル(40) + カード(180/2=90) + マージン(40)
+    return this.calculateAcceptedSectionY() + 40 + QuestAcceptPhaseUI.CARD_HEIGHT;
+  }
+
+  /**
+   * 【受注済み依頼カード数取得】: テスト用アクセサ
+   */
+  public getAcceptedQuestCount(): number {
+    return this.acceptedQuestCards.length;
   }
 
   // =============================================================================

--- a/atelier-guild-rank/tests/unit/presentation/ui/phases/QuestAcceptPhaseUI-accepted-quests.test.ts
+++ b/atelier-guild-rank/tests/unit/presentation/ui/phases/QuestAcceptPhaseUI-accepted-quests.test.ts
@@ -1,0 +1,366 @@
+/**
+ * QuestAcceptPhaseUI 受注済み依頼表示テスト
+ * Issue #431: 依頼フェーズで受注済み依頼の内容が確認できない
+ *
+ * @description
+ * QuestAcceptPhaseUIの受注済み依頼表示機能を検証する。
+ * updateAcceptedQuests()による受注済み依頼カードの表示・更新・破棄を確認。
+ */
+
+import type { Quest } from '@domain/entities/Quest';
+import type { IActiveQuest } from '@shared/types/quests';
+import type Phaser from 'phaser';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// =============================================================================
+// モック定義
+// =============================================================================
+
+vi.mock('phaser', () => ({
+  default: {
+    Scene: class MockScene {},
+    GameObjects: {
+      Container: class {},
+      Text: class {},
+      Rectangle: class {},
+    },
+  },
+}));
+
+vi.mock('@shared/constants/keybindings', () => ({
+  getSelectionIndexFromKey: vi.fn().mockReturnValue(null),
+  isKeyForAction: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@presentation/ui/theme', () => ({
+  Colors: {
+    PRIMARY: 0x4a90d9,
+    BACKGROUND: 0x333333,
+    TEXT: '#ffffff',
+    BORDER: 0x888888,
+    ACCENT: 0xff9900,
+    background: {
+      parchment: 0xf5e6c8,
+      dark: 0x333333,
+    },
+    border: {
+      quest: 0xc4a35a,
+    },
+    text: {
+      primary: '#000000',
+      secondary: '#666666',
+      light: '#ffffff',
+    },
+  },
+}));
+
+vi.mock('@presentation/ui/components/QuestCardUI', () => ({
+  QuestCardUI: class MockQuestCardUI {
+    private mockContainer = {
+      setVisible: vi.fn().mockReturnThis(),
+      setPosition: vi.fn().mockReturnThis(),
+      setDepth: vi.fn().mockReturnThis(),
+      setAlpha: vi.fn().mockReturnThis(),
+      setScale: vi.fn().mockReturnThis(),
+      add: vi.fn().mockReturnThis(),
+      destroy: vi.fn(),
+      name: '',
+      x: 0,
+      y: 0,
+      visible: true,
+    };
+    background = { on: vi.fn(), off: vi.fn() };
+    create() {}
+    destroy() {}
+    getContainer() {
+      return this.mockContainer;
+    }
+    getBackground() {
+      return this.background;
+    }
+    setSelected() {}
+  },
+}));
+
+vi.mock('@presentation/ui/components/QuestDetailModal', () => ({
+  QuestDetailModal: class MockQuestDetailModal {
+    create() {}
+    destroy() {}
+    show() {}
+    hide() {}
+  },
+}));
+
+// =============================================================================
+// モック作成ヘルパー
+// =============================================================================
+
+const createMockContainer = () => ({
+  setVisible: vi.fn().mockReturnThis(),
+  setPosition: vi.fn().mockReturnThis(),
+  setDepth: vi.fn().mockReturnThis(),
+  setAlpha: vi.fn().mockReturnThis(),
+  setScale: vi.fn().mockReturnThis(),
+  setMask: vi.fn().mockReturnThis(),
+  add: vi.fn().mockReturnThis(),
+  destroy: vi.fn(),
+  bringToTop: vi.fn().mockReturnThis(),
+  name: '',
+  x: 0,
+  y: 0,
+  visible: true,
+});
+
+const createMockText = () => ({
+  setText: vi.fn().mockReturnThis(),
+  setOrigin: vi.fn().mockReturnThis(),
+  setStyle: vi.fn().mockReturnThis(),
+  setColor: vi.fn().mockReturnThis(),
+  setFontSize: vi.fn().mockReturnThis(),
+  setFontStyle: vi.fn().mockReturnThis(),
+  destroy: vi.fn(),
+  text: '',
+});
+
+const createMockRectangle = () => ({
+  setFillStyle: vi.fn().mockReturnThis(),
+  setStrokeStyle: vi.fn().mockReturnThis(),
+  setOrigin: vi.fn().mockReturnThis(),
+  setInteractive: vi.fn().mockReturnThis(),
+  disableInteractive: vi.fn().mockReturnThis(),
+  setAlpha: vi.fn().mockReturnThis(),
+  on: vi.fn().mockReturnThis(),
+  off: vi.fn().mockReturnThis(),
+  destroy: vi.fn(),
+});
+
+function createMockScene(): Phaser.Scene {
+  return {
+    add: {
+      container: vi.fn().mockImplementation(() => createMockContainer()),
+      text: vi.fn().mockImplementation(() => createMockText()),
+      rectangle: vi.fn().mockImplementation(() => createMockRectangle()),
+      graphics: vi.fn().mockReturnValue({
+        fillStyle: vi.fn().mockReturnThis(),
+        fillRect: vi.fn().mockReturnThis(),
+        destroy: vi.fn(),
+      }),
+    },
+    make: {
+      text: vi.fn().mockImplementation(() => createMockText()),
+      container: vi.fn().mockImplementation(() => createMockContainer()),
+      graphics: vi.fn().mockReturnValue({
+        fillStyle: vi.fn().mockReturnThis(),
+        fillRect: vi.fn().mockReturnThis(),
+        clear: vi.fn().mockReturnThis(),
+        createGeometryMask: vi.fn().mockReturnValue({}),
+        destroy: vi.fn(),
+      }),
+    },
+    data: {
+      get: vi.fn().mockReturnValue({
+        emit: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
+        once: vi.fn(),
+      }),
+      set: vi.fn(),
+    },
+    input: {
+      on: vi.fn(),
+      off: vi.fn(),
+      keyboard: { on: vi.fn(), off: vi.fn() },
+    },
+    rexUI: {
+      add: {
+        label: vi.fn().mockReturnValue({
+          layout: vi.fn(),
+          setInteractive: vi.fn().mockReturnThis(),
+          on: vi.fn().mockReturnThis(),
+          destroy: vi.fn(),
+          setText: vi.fn().mockReturnThis(),
+        }),
+        roundRectangle: vi.fn().mockReturnValue({
+          setFillStyle: vi.fn().mockReturnThis(),
+          destroy: vi.fn(),
+        }),
+        sizer: vi.fn().mockReturnValue({
+          layout: vi.fn(),
+          add: vi.fn().mockReturnThis(),
+          destroy: vi.fn(),
+        }),
+      },
+    },
+    cameras: {
+      main: { centerX: 640, centerY: 360, width: 1280, height: 720 },
+    },
+    tweens: {
+      add: vi.fn().mockReturnValue({ stop: vi.fn() }),
+    },
+  } as unknown as Phaser.Scene;
+}
+
+function createMockActiveQuest(id: string, clientName: string, remainingDays = 3): IActiveQuest {
+  return {
+    quest: {
+      id,
+      clientId: `client-${id}`,
+      condition: { type: 'QUANTITY', quantity: 1 },
+      contribution: 50,
+      gold: 100,
+      deadline: 5,
+      difficulty: 'normal',
+      flavorText: `${clientName}からの依頼`,
+    },
+    client: {
+      id: `client-${id}`,
+      name: clientName,
+      type: 'VILLAGER',
+      contributionMultiplier: 1.0,
+      goldMultiplier: 1.0,
+      deadlineModifier: 0,
+      preferredQuestTypes: ['QUANTITY'],
+      unlockRank: 'G',
+    },
+    remainingDays,
+    acceptedDay: 1,
+  } as IActiveQuest;
+}
+
+function createMockQuest(id: string, clientName = '依頼者'): Quest {
+  return {
+    data: {
+      id,
+      clientId: `client-${id}`,
+      condition: { type: 'QUANTITY', targetId: 'item-1', quantity: 1 },
+      contribution: 10,
+      gold: 100,
+      deadline: 3,
+      difficulty: 'E',
+      flavorText: 'テスト依頼',
+    },
+    client: {
+      id: `client-${id}`,
+      name: clientName,
+      type: 'VILLAGER',
+      contributionMultiplier: 1.0,
+      goldMultiplier: 1.0,
+      deadlineModifier: 0,
+      preferredQuestTypes: ['QUANTITY'],
+      unlockRank: 'G',
+    },
+    canDeliver: vi.fn().mockReturnValue(false),
+    calculateContribution: vi.fn().mockReturnValue(10),
+    calculateGold: vi.fn().mockReturnValue(100),
+  } as unknown as Quest;
+}
+
+// =============================================================================
+// テスト
+// =============================================================================
+
+describe('QuestAcceptPhaseUI - 受注済み依頼表示（Issue #431）', () => {
+  let mockScene: Phaser.Scene;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockScene = createMockScene();
+  });
+
+  // ===========================================================================
+  // テストケース1: 受注済み依頼の表示
+  // ===========================================================================
+
+  describe('受注済み依頼の表示', () => {
+    it('T-0431-01: updateAcceptedQuestsで受注済み依頼が表示される', async () => {
+      const { QuestAcceptPhaseUI } = await import('@presentation/ui/phases/QuestAcceptPhaseUI');
+      const phaseUI = new QuestAcceptPhaseUI(mockScene);
+
+      const activeQuests = [
+        createMockActiveQuest('quest-1', '村人A', 3),
+        createMockActiveQuest('quest-2', '商人B', 2),
+      ];
+
+      phaseUI.updateAcceptedQuests(activeQuests);
+
+      expect(phaseUI.getAcceptedQuestCount()).toBe(2);
+    });
+
+    it('T-0431-02: 受注済み依頼が0件の場合、カードが表示されない', async () => {
+      const { QuestAcceptPhaseUI } = await import('@presentation/ui/phases/QuestAcceptPhaseUI');
+      const phaseUI = new QuestAcceptPhaseUI(mockScene);
+
+      phaseUI.updateAcceptedQuests([]);
+
+      expect(phaseUI.getAcceptedQuestCount()).toBe(0);
+    });
+
+    it('T-0431-03: updateAcceptedQuestsを複数回呼ぶと前回の表示が置き換わる', async () => {
+      const { QuestAcceptPhaseUI } = await import('@presentation/ui/phases/QuestAcceptPhaseUI');
+      const phaseUI = new QuestAcceptPhaseUI(mockScene);
+
+      // 最初に2件表示
+      phaseUI.updateAcceptedQuests([
+        createMockActiveQuest('quest-1', '村人A'),
+        createMockActiveQuest('quest-2', '商人B'),
+      ]);
+      expect(phaseUI.getAcceptedQuestCount()).toBe(2);
+
+      // 1件に更新
+      phaseUI.updateAcceptedQuests([createMockActiveQuest('quest-1', '村人A')]);
+      expect(phaseUI.getAcceptedQuestCount()).toBe(1);
+    });
+
+    it('T-0431-04: null/undefinedを渡してもエラーにならない', async () => {
+      const { QuestAcceptPhaseUI } = await import('@presentation/ui/phases/QuestAcceptPhaseUI');
+      const phaseUI = new QuestAcceptPhaseUI(mockScene);
+
+      // null相当
+      phaseUI.updateAcceptedQuests(null as unknown as IActiveQuest[]);
+      expect(phaseUI.getAcceptedQuestCount()).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // テストケース2: 新規依頼と受注済み依頼の共存
+  // ===========================================================================
+
+  describe('新規依頼と受注済み依頼の共存', () => {
+    it('T-0431-05: 新規依頼と受注済み依頼が両方表示される', async () => {
+      const { QuestAcceptPhaseUI } = await import('@presentation/ui/phases/QuestAcceptPhaseUI');
+      const phaseUI = new QuestAcceptPhaseUI(mockScene);
+
+      // 新規依頼を設定
+      const boardQuests = [
+        createMockQuest('board-1', '掲示板依頼者1'),
+        createMockQuest('board-2', '掲示板依頼者2'),
+      ];
+      phaseUI.updateBoardQuests(boardQuests);
+
+      // 受注済み依頼を設定
+      const activeQuests = [createMockActiveQuest('active-1', '受注済み依頼者1')];
+      phaseUI.updateAcceptedQuests(activeQuests);
+
+      expect(phaseUI.getDisplayedQuestCount()).toBe(2);
+      expect(phaseUI.getAcceptedQuestCount()).toBe(1);
+    });
+  });
+
+  // ===========================================================================
+  // テストケース3: destroy時のクリーンアップ
+  // ===========================================================================
+
+  describe('destroy時のクリーンアップ', () => {
+    it('T-0431-06: destroy()で受注済み依頼カードが破棄される', async () => {
+      const { QuestAcceptPhaseUI } = await import('@presentation/ui/phases/QuestAcceptPhaseUI');
+      const phaseUI = new QuestAcceptPhaseUI(mockScene);
+
+      phaseUI.updateAcceptedQuests([createMockActiveQuest('quest-1', '村人A')]);
+      expect(phaseUI.getAcceptedQuestCount()).toBe(1);
+
+      phaseUI.destroy();
+
+      expect(phaseUI.getAcceptedQuestCount()).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- QuestAcceptPhaseUIに`updateAcceptedQuests()`メソッドを追加し、受注済み依頼をカード形式でメインコンテンツエリアに表示
- PhaseManagerの`handleQuestAccepted()`で受注済みリストの表示を更新
- PhaseManagerの`showPhase()`でQUEST_ACCEPTフェーズ表示時に受注済み依頼を初期表示

## Test plan
- [x] 受注済み依頼がカード形式で表示されること（T-0431-01）
- [x] 受注済み0件の場合カードが表示されないこと（T-0431-02）
- [x] 複数回更新で前回の表示が置き換わること（T-0431-03）
- [x] null/undefinedを渡してもエラーにならないこと（T-0431-04）
- [x] 新規依頼と受注済み依頼が両方表示されること（T-0431-05）
- [x] destroy()で受注済みカードが破棄されること（T-0431-06）
- [x] 全ユニットテスト通過（151ファイル, 2712テスト）
- [x] 型チェック通過
- [x] リントチェック通過（変更ファイルのみ）

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)