### PR TITLE
fix: 採取フェーズの追加AP表示と残り選択回数の重なりを修正

### DIFF
--- a/atelier-guild-rank/src/features/gathering/components/GatheringPhaseUI.ts
+++ b/atelier-guild-rank/src/features/gathering/components/GatheringPhaseUI.ts
@@ -193,7 +193,7 @@ export class GatheringPhaseUI extends BaseComponent {
     this.extraApCostText = this.scene.make
       .text({
         x: GATHERING_LAYOUT.CONTENT_CENTER_X,
-        y: 85,
+        y: 100,
         text: '',
         style: {
           fontSize: `${THEME.sizes.small}px`,


### PR DESCRIPTION
## Summary
- 採取フェーズの追加APコスト表示（y=85）と残り選択回数テキスト（y=60, 16px）が近すぎて重なる問題を修正
- 追加AP表示のY座標を85から100に変更し、十分な間隔を確保

Closes #433

## Test plan
- [ ] 採取フェーズで場所を選択し、採取セッションを開始する
- [ ] 残り選択回数と追加AP表示が重ならず明瞭に読めることを確認
- [ ] presentationCount超過時に追加AP表示が正しい位置に表示されることを確認
- [ ] ユニットテスト全パス（150件）、型チェック・リントチェックOK

🤖 Generated with [Claude Code](https://claude.com/claude-code)