### PR TITLE
feat: ランク詳細 SlidePanel を新規実装 (#475)

### DIFF
--- a/atelier-guild-rank/src/features/rank/components/RankDetailUI.ts
+++ b/atelier-guild-rank/src/features/rank/components/RankDetailUI.ts
@@ -1,0 +1,364 @@
+/**
+ * RankDetailUI コンポーネント（SlidePanel 合成版）
+ *
+ * Issue #475: ランク詳細 SlidePanel を新規実装
+ *
+ * ランクの詳細情報（必要貢献度、日数制限、特殊ルール、昇格ボーナス）を
+ * スライドパネルで表示する。
+ *
+ * 内部実装は `shared/presentation/ui/components/composite/SlidePanel` を合成し、
+ * パネル本体の枠線・背景・開閉アニメーションは SlidePanel に委譲する。
+ * オーバーレイ（画面全体の半透明背景・クリックで閉じる）および ESC キーは
+ * このクラスで管理する。
+ */
+
+import { BaseComponent } from '@shared/components';
+import { PROMOTION_BONUS_BASE } from '@shared/constants';
+import { SlidePanel } from '@shared/presentation/ui/components/composite/SlidePanel';
+import { Colors, DesignTokens, RANK_COLORS, THEME } from '@shared/theme';
+import type { IGuildRankMaster } from '@shared/types/master-data';
+import type Phaser from 'phaser';
+import { getNextRank, getRankOrder } from '../services/rank-operations';
+
+// =============================================================================
+// 定数
+// =============================================================================
+
+/** SlidePanel サイズ */
+const PANEL_WIDTH = 320;
+const PANEL_HEIGHT = 440;
+
+/** オーバーレイ */
+const OVERLAY_COLOR = 0x000000;
+const OVERLAY_ALPHA = 0.7;
+const OVERLAY_DEPTH = 900;
+const OPEN_OVERLAY_DURATION = 200;
+
+/** テキスト配置（SlidePanel 左上基準） */
+const TEXT_LEFT = 20;
+const TEXT_RIGHT_MARGIN = 20;
+const NAME_Y = 24;
+const CONTRIBUTION_LABEL_Y = 68;
+const CONTRIBUTION_VALUE_Y = 92;
+const DAYLIMIT_Y = 124;
+const RULES_LABEL_Y = 164;
+const RULES_START_Y = 192;
+const RULES_LINE_HEIGHT = 24;
+const BONUS_OFFSET_Y = 16;
+const CLOSE_BUTTON_BOTTOM_MARGIN = 40;
+
+/** フォントサイズ */
+const FONT_SIZE_TITLE = `${THEME.sizes.large}px`;
+const FONT_SIZE_BODY = `${THEME.sizes.medium}px`;
+const FONT_SIZE_SMALL = `${THEME.sizes.small}px`;
+
+/** ボタン色 */
+const CLOSE_BUTTON_BG_COLOR = '#9e9e9e';
+
+// =============================================================================
+// 型定義
+// =============================================================================
+
+/** RankDetailUI の設定 */
+export interface RankDetailUIConfig {
+  /** 表示するランクのマスターデータ */
+  rankMaster: IGuildRankMaster;
+  /** 現在の累積貢献度 */
+  currentContribution: number;
+  /** 閉じる時のコールバック */
+  onClose?: () => void;
+}
+
+// =============================================================================
+// コンポーネント
+// =============================================================================
+
+/**
+ * ランク詳細スライドパネル
+ *
+ * 選択されたランクの詳細情報をスライドパネルで表示する。
+ */
+export class RankDetailUI extends BaseComponent {
+  private config: RankDetailUIConfig;
+
+  /** オーバーレイ（背景の暗いエリア、クリックで閉じる） */
+  private overlay!: Phaser.GameObjects.Rectangle;
+
+  /** スライドパネル本体（SlidePanel composite） */
+  private slidePanel!: SlidePanel;
+
+  /** SlidePanel の内部コンテンツコンテナ */
+  private panelContent!: Phaser.GameObjects.Container;
+
+  /** ESC キー（パネルを閉じるショートカット） */
+  private escKey: Phaser.Input.Keyboard.Key | null = null;
+
+  /** アニメーション中フラグ（二重操作防止用） */
+  private animating = false;
+
+  /** 破棄済みフラグ */
+  private isDestroyed = false;
+
+  constructor(scene: Phaser.Scene, config: RankDetailUIConfig) {
+    if (!config) {
+      throw new Error('config is required');
+    }
+
+    const centerX = scene.cameras?.main?.width ? scene.cameras.main.width / 2 : 640;
+    const centerY = scene.cameras?.main?.height ? scene.cameras.main.height / 2 : 360;
+
+    super(scene, centerX, centerY);
+    this.config = config;
+  }
+
+  /** UI を作成して開くアニメーションを再生する */
+  create(): void {
+    this.createOverlay();
+    this.createSlidePanel();
+    this.createDetailContent(this.config.rankMaster);
+    this.createCloseButton();
+    this.setupEscKey();
+    this.playOpenAnimation();
+  }
+
+  /** リソース解放 */
+  destroy(): void {
+    this.isDestroyed = true;
+
+    // Tween キャンセル
+    if (this.overlay && this.scene.tweens?.killTweensOf) {
+      this.scene.tweens.killTweensOf(this.overlay);
+    }
+    if (this.panelContent && this.scene.tweens?.killTweensOf) {
+      this.scene.tweens.killTweensOf(this.panelContent);
+    }
+
+    // ESC キーリスナー解除
+    if (this.escKey) {
+      this.escKey.off('down');
+      if (this.scene.input?.keyboard) {
+        this.scene.input.keyboard.removeKey('ESC');
+      }
+      this.escKey = null;
+    }
+
+    // オーバーレイ破棄
+    if (this.overlay) {
+      this.overlay.off('pointerdown');
+      this.overlay.destroy();
+    }
+
+    // SlidePanel の tween/bg 参照のみクリアし、container の破棄は親に任せる
+    if (this.slidePanel) {
+      this.slidePanel.destroy(false);
+    }
+
+    // コンテナ破棄（panelContent を含む全子要素を連鎖破棄）
+    if (this.container) {
+      this.container.destroy(true);
+    }
+  }
+
+  /** パネルを閉じる */
+  close(): void {
+    if (this.isDestroyed) return;
+    if (this.animating) return;
+
+    this.animating = true;
+
+    // open tween が進行中の場合にも安全なよう、overlay の tween を先にキャンセルする
+    if (this.scene.tweens?.killTweensOf) {
+      this.scene.tweens.killTweensOf(this.overlay);
+    }
+
+    // overlay と SlidePanel のフェードアウトを同じ duration で同期させる
+    const closeDuration = DesignTokens.motion.duration.base;
+
+    this.scene.tweens.add({
+      targets: this.overlay,
+      alpha: 0,
+      duration: closeDuration,
+      ease: 'Linear',
+      onComplete: () => {
+        if (this.isDestroyed) return;
+        this.animating = false;
+        this.config.onClose?.();
+      },
+    });
+
+    // SlidePanel 側も同じ duration でフェードアウト
+    this.slidePanel.close({ animate: true });
+  }
+
+  // ===========================================================================
+  // private
+  // ===========================================================================
+
+  private createOverlay(): void {
+    const width = this.scene.cameras?.main?.width || 1280;
+    const height = this.scene.cameras?.main?.height || 720;
+
+    this.overlay = this.scene.add.rectangle(0, 0, width, height, OVERLAY_COLOR, 0);
+    this.overlay.setOrigin(0.5);
+
+    this.overlay.setDepth(OVERLAY_DEPTH);
+    this.overlay.setInteractive();
+    this.overlay.on('pointerdown', () => this.close());
+    this.container.add(this.overlay);
+  }
+
+  private createSlidePanel(): void {
+    const cameraWidth = this.scene.cameras?.main?.width || 1280;
+    const cameraHeight = this.scene.cameras?.main?.height || 720;
+    const panelX = cameraWidth - PANEL_WIDTH - 20;
+    const panelY = (cameraHeight - PANEL_HEIGHT) / 2;
+
+    this.slidePanel = new SlidePanel(
+      this.scene,
+      panelX - this.container.x,
+      panelY - this.container.y,
+      {
+        width: PANEL_WIDTH,
+        height: PANEL_HEIGHT,
+        addToScene: false,
+      },
+    );
+    this.slidePanel.create();
+    this.panelContent = this.slidePanel.getContentContainer();
+    this.container.add(this.panelContent);
+  }
+
+  private createDetailContent(rankMaster: IGuildRankMaster): void {
+    const contentWidth = PANEL_WIDTH - TEXT_LEFT - TEXT_RIGHT_MARGIN;
+    const rankColor = RANK_COLORS[rankMaster.id] ?? Colors.text.primary;
+    const rankColorHex = `#${rankColor.toString(16).padStart(6, '0')}`;
+
+    // ランク名
+    const nameText = this.scene.add.text(TEXT_LEFT, NAME_Y, rankMaster.name, {
+      fontSize: FONT_SIZE_TITLE,
+      color: rankColorHex,
+      fontStyle: 'bold',
+      padding: { top: 4 },
+    });
+    this.panelContent.add(nameText);
+
+    // 貢献度ラベル
+    const contribLabel = this.scene.add.text(TEXT_LEFT, CONTRIBUTION_LABEL_Y, '貢献度:', {
+      fontSize: FONT_SIZE_SMALL,
+      color: '#888888',
+    });
+    this.panelContent.add(contribLabel);
+
+    // 貢献度値（現在 / 必要）
+    const contribStr = `${this.config.currentContribution} / ${rankMaster.requiredContribution}`;
+    const contribText = this.scene.add.text(TEXT_LEFT, CONTRIBUTION_VALUE_Y, contribStr, {
+      fontSize: FONT_SIZE_BODY,
+      color: '#cccccc',
+      padding: { top: 4 },
+    });
+    this.panelContent.add(contribText);
+
+    // 日数制限
+    const dayLimitStr = `日数制限: ${rankMaster.dayLimit}日`;
+    const dayLimitText = this.scene.add.text(TEXT_LEFT, DAYLIMIT_Y, dayLimitStr, {
+      fontSize: FONT_SIZE_BODY,
+      color: '#cccccc',
+      padding: { top: 4 },
+    });
+    this.panelContent.add(dayLimitText);
+
+    // 特殊ルールラベル
+    const rulesLabel = this.scene.add.text(TEXT_LEFT, RULES_LABEL_Y, '特殊ルール:', {
+      fontSize: FONT_SIZE_SMALL,
+      color: '#888888',
+    });
+    this.panelContent.add(rulesLabel);
+
+    // 特殊ルールリスト
+    let rulesEndY = RULES_START_Y;
+    if (rankMaster.specialRules.length === 0) {
+      const noneText = this.scene.add.text(TEXT_LEFT, RULES_START_Y, 'なし', {
+        fontSize: FONT_SIZE_SMALL,
+        color: '#aaaaaa',
+      });
+      this.panelContent.add(noneText);
+      rulesEndY = RULES_START_Y + RULES_LINE_HEIGHT;
+    } else {
+      for (let i = 0; i < rankMaster.specialRules.length; i++) {
+        const rule = rankMaster.specialRules[i];
+        if (!rule) continue;
+        const lineY = RULES_START_Y + i * RULES_LINE_HEIGHT;
+        const ruleText = this.scene.add.text(TEXT_LEFT, lineY, rule.description, {
+          fontSize: FONT_SIZE_SMALL,
+          color: '#aaaaaa',
+          wordWrap: { width: contentWidth },
+        });
+        this.panelContent.add(ruleText);
+        rulesEndY = lineY + RULES_LINE_HEIGHT;
+      }
+    }
+
+    // 昇格ボーナス
+    const nextRank = getNextRank(rankMaster.id);
+    if (nextRank) {
+      const bonusGold = PROMOTION_BONUS_BASE * (getRankOrder(nextRank) + 1);
+      const bonusLabelY = rulesEndY + BONUS_OFFSET_Y;
+      const accentColor = `#${Colors.text.accent.toString(16).padStart(6, '0')}`;
+      const bonusText = this.scene.add.text(TEXT_LEFT, bonusLabelY, `昇格ボーナス: ${bonusGold}G`, {
+        fontSize: FONT_SIZE_BODY,
+        color: accentColor,
+        padding: { top: 4 },
+      });
+      this.panelContent.add(bonusText);
+    }
+  }
+
+  private createCloseButton(): void {
+    const closeBtn = this.scene.add.text(
+      PANEL_WIDTH / 2,
+      PANEL_HEIGHT - CLOSE_BUTTON_BOTTOM_MARGIN,
+      '閉じる',
+      {
+        fontSize: FONT_SIZE_BODY,
+        color: '#ffffff',
+        backgroundColor: CLOSE_BUTTON_BG_COLOR,
+        padding: { x: 16, y: 8 },
+      },
+    );
+    closeBtn.setOrigin(0.5);
+    closeBtn.setInteractive({ useHandCursor: true });
+    closeBtn.on('pointerdown', () => this.close());
+
+    this.panelContent.add(closeBtn);
+  }
+
+  private setupEscKey(): void {
+    if (this.scene.input?.keyboard) {
+      this.escKey = this.scene.input.keyboard.addKey('ESC');
+      this.escKey.on('down', () => this.handleEscKey());
+    }
+  }
+
+  private handleEscKey(): void {
+    if (this.animating) return;
+    this.close();
+  }
+
+  private playOpenAnimation(): void {
+    this.scene.tweens.add({
+      targets: this.overlay,
+      alpha: OVERLAY_ALPHA,
+      duration: OPEN_OVERLAY_DURATION,
+      ease: 'Linear',
+    });
+
+    this.slidePanel.open();
+  }
+}
+
+/**
+ * 新しい命名エイリアス: Issue #475 以降は `RankDetailSlidePanel` を推奨する。
+ * 既存コードとの後方互換のため `RankDetailUI` も引き続きエクスポートする。
+ */
+export { RankDetailUI as RankDetailSlidePanel };
+export type { RankDetailUIConfig as RankDetailSlidePanelConfig };

--- a/atelier-guild-rank/src/features/rank/components/RankDetailUI.ts
+++ b/atelier-guild-rank/src/features/rank/components/RankDetailUI.ts
@@ -125,12 +125,14 @@ export class RankDetailUI extends BaseComponent {
   destroy(): void {
     this.isDestroyed = true;
 
-    // Tween キャンセル
-    if (this.overlay && this.scene.tweens?.killTweensOf) {
-      this.scene.tweens.killTweensOf(this.overlay);
-    }
-    if (this.panelContent && this.scene.tweens?.killTweensOf) {
-      this.scene.tweens.killTweensOf(this.panelContent);
+    // Tween キャンセル（SlidePanel 内の Tween も含めて確実に停止する）
+    if (this.scene.tweens?.killTweensOf) {
+      if (this.overlay) {
+        this.scene.tweens.killTweensOf(this.overlay);
+      }
+      if (this.panelContent) {
+        this.scene.tweens.killTweensOf(this.panelContent);
+      }
     }
 
     // ESC キーリスナー解除

--- a/atelier-guild-rank/src/features/rank/components/index.ts
+++ b/atelier-guild-rank/src/features/rank/components/index.ts
@@ -9,6 +9,11 @@ export type { PromotionDialogConfig } from './PromotionDialog';
 export { PromotionDialog } from './PromotionDialog';
 export type { RankBadgeConfig } from './RankBadge';
 export { RankBadge } from './RankBadge';
+export type {
+  RankDetailSlidePanelConfig,
+  RankDetailUIConfig,
+} from './RankDetailUI';
+export { RankDetailSlidePanel, RankDetailUI } from './RankDetailUI';
 export type { RankProgressBarConfig } from './RankProgressBar';
 export { RankProgressBar } from './RankProgressBar';
 export type { DisplayRule, SpecialRuleDisplayConfig } from './SpecialRuleDisplay';

--- a/atelier-guild-rank/src/features/rank/index.ts
+++ b/atelier-guild-rank/src/features/rank/index.ts
@@ -70,7 +70,16 @@ export type {
   DisplayRule,
   PromotionDialogConfig,
   RankBadgeConfig,
+  RankDetailSlidePanelConfig,
+  RankDetailUIConfig,
   RankProgressBarConfig,
   SpecialRuleDisplayConfig,
 } from './components';
-export { PromotionDialog, RankBadge, RankProgressBar, SpecialRuleDisplay } from './components';
+export {
+  PromotionDialog,
+  RankBadge,
+  RankDetailSlidePanel,
+  RankDetailUI,
+  RankProgressBar,
+  SpecialRuleDisplay,
+} from './components';

--- a/atelier-guild-rank/tests/unit/features/rank/components/RankDetailUI.test.ts
+++ b/atelier-guild-rank/tests/unit/features/rank/components/RankDetailUI.test.ts
@@ -1,0 +1,452 @@
+/**
+ * RankDetailUI コンポーネントテスト
+ * Issue #475: ランク詳細 SlidePanel を新規実装
+ */
+
+import { RankDetailUI, type RankDetailUIConfig } from '@features/rank/components/RankDetailUI';
+import type { GuildRank } from '@shared/types';
+import type { IGuildRankMaster, ISpecialRule } from '@shared/types/master-data';
+import type Phaser from 'phaser';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// =============================================================================
+// モックヘルパー
+// =============================================================================
+
+function createMockRankMaster(
+  rank: GuildRank,
+  options: {
+    name?: string;
+    requiredContribution?: number;
+    dayLimit?: number;
+    specialRules?: ISpecialRule[];
+  } = {},
+): IGuildRankMaster {
+  return {
+    id: rank,
+    name: options.name ?? `${rank}ランク`,
+    requiredContribution: options.requiredContribution ?? 100,
+    dayLimit: options.dayLimit ?? 30,
+    specialRules: options.specialRules ?? [],
+    promotionTest: null,
+    unlockedGatheringCards: [],
+    unlockedRecipeCards: [],
+  };
+}
+
+function createMockScene(): Phaser.Scene {
+  const mockContainer = {
+    setPosition: vi.fn().mockReturnThis(),
+    setVisible: vi.fn().mockReturnThis(),
+    setAlpha: vi.fn().mockReturnThis(),
+    setDepth: vi.fn().mockReturnThis(),
+    add: vi.fn().mockReturnThis(),
+    remove: vi.fn().mockReturnThis(),
+    destroy: vi.fn(),
+    x: 640,
+    y: 360,
+  };
+
+  const mockText = {
+    setOrigin: vi.fn().mockReturnThis(),
+    setWordWrapWidth: vi.fn().mockReturnThis(),
+    setText: vi.fn().mockReturnThis(),
+    setInteractive: vi.fn().mockReturnThis(),
+    on: vi.fn().mockReturnThis(),
+    off: vi.fn().mockReturnThis(),
+    destroy: vi.fn(),
+  };
+
+  const mockTween = {
+    stop: vi.fn(),
+  };
+
+  const scene = {
+    add: {
+      container: vi.fn().mockReturnValue(mockContainer),
+      rectangle: vi.fn().mockReturnValue({
+        setOrigin: vi.fn().mockReturnThis(),
+        setStrokeStyle: vi.fn().mockReturnThis(),
+        setFillStyle: vi.fn().mockReturnThis(),
+        setInteractive: vi.fn().mockReturnThis(),
+        setDepth: vi.fn().mockReturnThis(),
+        on: vi.fn().mockReturnThis(),
+        off: vi.fn().mockReturnThis(),
+        destroy: vi.fn(),
+      }),
+      text: vi.fn().mockReturnValue(mockText),
+    },
+    make: {
+      text: vi.fn().mockReturnValue(mockText),
+    },
+    cameras: {
+      main: { width: 1280, height: 720 },
+    },
+    children: {
+      remove: vi.fn(),
+    },
+    tweens: {
+      add: vi.fn().mockReturnValue(mockTween),
+      killTweensOf: vi.fn(),
+    },
+    input: {
+      keyboard: {
+        addKey: vi.fn().mockReturnValue({
+          on: vi.fn().mockReturnThis(),
+          off: vi.fn().mockReturnThis(),
+        }),
+        removeKey: vi.fn(),
+      },
+    },
+    rexUI: undefined,
+  } as unknown as Phaser.Scene;
+
+  return scene;
+}
+
+// =============================================================================
+// テスト
+// =============================================================================
+
+describe('RankDetailUI', () => {
+  let mockScene: Phaser.Scene;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockScene = createMockScene();
+  });
+
+  describe('コンストラクタ', () => {
+    it('正しい設定でインスタンスを生成できる', () => {
+      const config: RankDetailUIConfig = {
+        rankMaster: createMockRankMaster('D'),
+        currentContribution: 50,
+        onClose: vi.fn(),
+      };
+
+      const ui = new RankDetailUI(mockScene, config);
+      expect(ui).toBeDefined();
+    });
+
+    it('configがnullの場合エラーを投げる', () => {
+      expect(() => new RankDetailUI(mockScene, null as unknown as RankDetailUIConfig)).toThrow(
+        'config is required',
+      );
+    });
+  });
+
+  describe('create', () => {
+    it('create()でオーバーレイが作成される', () => {
+      const config: RankDetailUIConfig = {
+        rankMaster: createMockRankMaster('D'),
+        currentContribution: 50,
+        onClose: vi.fn(),
+      };
+
+      const ui = new RankDetailUI(mockScene, config);
+      ui.create();
+
+      expect(mockScene.add.rectangle).toHaveBeenCalled();
+    });
+
+    it('create()でランク名が表示される', () => {
+      const config: RankDetailUIConfig = {
+        rankMaster: createMockRankMaster('C', { name: 'Cランク' }),
+        currentContribution: 80,
+        onClose: vi.fn(),
+      };
+
+      const ui = new RankDetailUI(mockScene, config);
+      ui.create();
+
+      const textCalls = (mockScene.add.text as ReturnType<typeof vi.fn>).mock.calls;
+      const nameCall = textCalls.find(
+        (call: unknown[]) => typeof call[2] === 'string' && (call[2] as string).includes('Cランク'),
+      );
+      expect(nameCall).toBeDefined();
+    });
+
+    it('必要貢献度が表示される', () => {
+      const config: RankDetailUIConfig = {
+        rankMaster: createMockRankMaster('D', { requiredContribution: 200 }),
+        currentContribution: 80,
+        onClose: vi.fn(),
+      };
+
+      const ui = new RankDetailUI(mockScene, config);
+      ui.create();
+
+      const textCalls = (mockScene.add.text as ReturnType<typeof vi.fn>).mock.calls;
+      const contribCall = textCalls.find(
+        (call: unknown[]) => typeof call[2] === 'string' && (call[2] as string).includes('200'),
+      );
+      expect(contribCall).toBeDefined();
+    });
+
+    it('現在の貢献度が表示される', () => {
+      const config: RankDetailUIConfig = {
+        rankMaster: createMockRankMaster('D', { requiredContribution: 200 }),
+        currentContribution: 80,
+        onClose: vi.fn(),
+      };
+
+      const ui = new RankDetailUI(mockScene, config);
+      ui.create();
+
+      const textCalls = (mockScene.add.text as ReturnType<typeof vi.fn>).mock.calls;
+      const currentCall = textCalls.find(
+        (call: unknown[]) => typeof call[2] === 'string' && (call[2] as string).includes('80'),
+      );
+      expect(currentCall).toBeDefined();
+    });
+
+    it('日数制限が表示される', () => {
+      const config: RankDetailUIConfig = {
+        rankMaster: createMockRankMaster('D', { dayLimit: 25 }),
+        currentContribution: 50,
+        onClose: vi.fn(),
+      };
+
+      const ui = new RankDetailUI(mockScene, config);
+      ui.create();
+
+      const textCalls = (mockScene.add.text as ReturnType<typeof vi.fn>).mock.calls;
+      const dayCall = textCalls.find(
+        (call: unknown[]) => typeof call[2] === 'string' && (call[2] as string).includes('25'),
+      );
+      expect(dayCall).toBeDefined();
+    });
+
+    it('特殊ルールが表示される', () => {
+      const config: RankDetailUIConfig = {
+        rankMaster: createMockRankMaster('C', {
+          specialRules: [{ type: 'QUEST_LIMIT', description: '同時受注数: 2件まで', value: 2 }],
+        }),
+        currentContribution: 50,
+        onClose: vi.fn(),
+      };
+
+      const ui = new RankDetailUI(mockScene, config);
+      ui.create();
+
+      const textCalls = (mockScene.add.text as ReturnType<typeof vi.fn>).mock.calls;
+      const ruleCall = textCalls.find(
+        (call: unknown[]) =>
+          typeof call[2] === 'string' && (call[2] as string).includes('同時受注数: 2件まで'),
+      );
+      expect(ruleCall).toBeDefined();
+    });
+
+    it('特殊ルールが無い場合は「なし」が表示される', () => {
+      const config: RankDetailUIConfig = {
+        rankMaster: createMockRankMaster('E', { specialRules: [] }),
+        currentContribution: 50,
+        onClose: vi.fn(),
+      };
+
+      const ui = new RankDetailUI(mockScene, config);
+      ui.create();
+
+      const textCalls = (mockScene.add.text as ReturnType<typeof vi.fn>).mock.calls;
+      const noneCall = textCalls.find(
+        (call: unknown[]) => typeof call[2] === 'string' && (call[2] as string) === 'なし',
+      );
+      expect(noneCall).toBeDefined();
+    });
+
+    it('昇格ボーナスが表示される', () => {
+      const config: RankDetailUIConfig = {
+        rankMaster: createMockRankMaster('D'),
+        currentContribution: 50,
+        onClose: vi.fn(),
+      };
+
+      const ui = new RankDetailUI(mockScene, config);
+      ui.create();
+
+      const textCalls = (mockScene.add.text as ReturnType<typeof vi.fn>).mock.calls;
+      const bonusCall = textCalls.find(
+        (call: unknown[]) =>
+          typeof call[2] === 'string' && (call[2] as string).includes('昇格ボーナス'),
+      );
+      expect(bonusCall).toBeDefined();
+    });
+
+    it('ESCキーリスナーが登録される', () => {
+      const config: RankDetailUIConfig = {
+        rankMaster: createMockRankMaster('D'),
+        currentContribution: 50,
+        onClose: vi.fn(),
+      };
+
+      const ui = new RankDetailUI(mockScene, config);
+      ui.create();
+
+      expect(mockScene.input.keyboard?.addKey).toHaveBeenCalledWith('ESC');
+    });
+
+    it('閉じるボタンが作成される', () => {
+      const config: RankDetailUIConfig = {
+        rankMaster: createMockRankMaster('D'),
+        currentContribution: 50,
+        onClose: vi.fn(),
+      };
+
+      const ui = new RankDetailUI(mockScene, config);
+      ui.create();
+
+      const textCalls = (mockScene.add.text as ReturnType<typeof vi.fn>).mock.calls;
+      const closeCall = textCalls.find(
+        (call: unknown[]) => typeof call[2] === 'string' && (call[2] as string).includes('閉じる'),
+      );
+      expect(closeCall).toBeDefined();
+    });
+
+    it('開くアニメーションが再生される', () => {
+      const config: RankDetailUIConfig = {
+        rankMaster: createMockRankMaster('D'),
+        currentContribution: 50,
+        onClose: vi.fn(),
+      };
+
+      const ui = new RankDetailUI(mockScene, config);
+      ui.create();
+
+      expect(mockScene.tweens.add).toHaveBeenCalled();
+    });
+  });
+
+  describe('close', () => {
+    it('close()でアニメーションが実行される', () => {
+      const onClose = vi.fn();
+      const config: RankDetailUIConfig = {
+        rankMaster: createMockRankMaster('D'),
+        currentContribution: 50,
+        onClose,
+      };
+
+      const ui = new RankDetailUI(mockScene, config);
+      ui.create();
+
+      (mockScene.tweens.add as ReturnType<typeof vi.fn>).mockClear();
+
+      ui.close();
+
+      expect(mockScene.tweens.add).toHaveBeenCalled();
+    });
+
+    it('close()のonCompleteでonCloseコールバックが呼ばれる', () => {
+      const onClose = vi.fn();
+      const config: RankDetailUIConfig = {
+        rankMaster: createMockRankMaster('D'),
+        currentContribution: 50,
+        onClose,
+      };
+
+      const ui = new RankDetailUI(mockScene, config);
+      ui.create();
+
+      (mockScene.tweens.add as ReturnType<typeof vi.fn>).mockImplementation(
+        (tweenConfig: { onComplete?: () => void }) => {
+          tweenConfig.onComplete?.();
+          return { stop: vi.fn() };
+        },
+      );
+
+      ui.close();
+
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it('destroy後にclose()のonCompleteが実行されてもonCloseは呼ばれない', () => {
+      const onClose = vi.fn();
+      const config: RankDetailUIConfig = {
+        rankMaster: createMockRankMaster('D'),
+        currentContribution: 50,
+        onClose,
+      };
+
+      const ui = new RankDetailUI(mockScene, config);
+      ui.create();
+
+      let capturedOnComplete: (() => void) | undefined;
+      (mockScene.tweens.add as ReturnType<typeof vi.fn>).mockImplementation(
+        (tweenConfig: { onComplete?: () => void }) => {
+          capturedOnComplete = tweenConfig.onComplete;
+          return { stop: vi.fn() };
+        },
+      );
+
+      ui.close();
+      ui.destroy();
+
+      capturedOnComplete?.();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('アニメーション中にclose()を重複呼びしても1回だけ実行される', () => {
+      const config: RankDetailUIConfig = {
+        rankMaster: createMockRankMaster('D'),
+        currentContribution: 50,
+        onClose: vi.fn(),
+      };
+
+      const ui = new RankDetailUI(mockScene, config);
+      ui.create();
+
+      (mockScene.tweens.add as ReturnType<typeof vi.fn>).mockClear();
+
+      ui.close();
+
+      const callCountAfterFirstClose = (mockScene.tweens.add as ReturnType<typeof vi.fn>).mock.calls
+        .length;
+
+      ui.close(); // 2回目は無視されるべき
+
+      expect((mockScene.tweens.add as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
+        callCountAfterFirstClose,
+      );
+    });
+  });
+
+  describe('destroy', () => {
+    it('destroy()でリソースが解放される', () => {
+      const config: RankDetailUIConfig = {
+        rankMaster: createMockRankMaster('D'),
+        currentContribution: 50,
+        onClose: vi.fn(),
+      };
+
+      const ui = new RankDetailUI(mockScene, config);
+      ui.create();
+
+      expect(() => ui.destroy()).not.toThrow();
+    });
+
+    it('create()前にdestroy()を呼んでもエラーにならない', () => {
+      const config: RankDetailUIConfig = {
+        rankMaster: createMockRankMaster('D'),
+        currentContribution: 50,
+        onClose: vi.fn(),
+      };
+
+      const ui = new RankDetailUI(mockScene, config);
+
+      expect(() => ui.destroy()).not.toThrow();
+    });
+
+    it('ESCキーリスナーが解除される', () => {
+      const config: RankDetailUIConfig = {
+        rankMaster: createMockRankMaster('D'),
+        currentContribution: 50,
+        onClose: vi.fn(),
+      };
+
+      const ui = new RankDetailUI(mockScene, config);
+      ui.create();
+      ui.destroy();
+
+      expect(mockScene.input.keyboard?.removeKey).toHaveBeenCalledWith('ESC');
+    });
+  });
+});

--- a/atelier-guild-rank/tests/unit/features/rank/components/RankDetailUI.test.ts
+++ b/atelier-guild-rank/tests/unit/features/rank/components/RankDetailUI.test.ts
@@ -3,7 +3,7 @@
  * Issue #475: ランク詳細 SlidePanel を新規実装
  */
 
-import { RankDetailUI, type RankDetailUIConfig } from '@features/rank/components/RankDetailUI';
+import { RankDetailUI, type RankDetailUIConfig } from '@features/rank';
 import type { GuildRank } from '@shared/types';
 import type { IGuildRankMaster, ISpecialRule } from '@shared/types/master-data';
 import type Phaser from 'phaser';


### PR DESCRIPTION
## Summary
- `RankDetailSlidePanel` を SlidePanel ベースで新規作成（ランク名、必要貢献度、日数制限、特殊ルール、昇格ボーナスを表示）
- 既存の `MaterialDetailUI` / `RecipeDetailUI` と同じ合成パターンで実装
- ユニットテスト20件を追加（コンストラクタ、create、close、destroy）

## Test plan
- [x] `pnpm test -- --run` パス（2872テスト全パス）
- [x] `pnpm typecheck` パス
- [x] `pnpm lint` パス（既存の警告のみ）
- [ ] ランク詳細パネルが正しく表示される（ビジュアル確認）

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)