### PR TITLE
feat: フェーズ遷移自動化を実装 (#471)

### DIFF
--- a/atelier-guild-rank/src/scenes/MainScene.ts
+++ b/atelier-guild-rank/src/scenes/MainScene.ts
@@ -275,11 +275,7 @@ export class MainScene extends Phaser.Scene {
       height: PHASE_RAIL_HEIGHT,
       current: this.stateManager.getState().currentPhase,
       onPhaseClick: (phase) => {
-        // IMainSceneGameFlowManager には switchPhase が無いため、
-        // PhaseTabUI と同じく IGameFlowManager 経由で呼び出す
-        const realGFM = this
-          .gameFlowManager as unknown as import('@shared/services/game-flow/game-flow-manager.interface').IGameFlowManager;
-        realGFM.switchPhase({ targetPhase: phase as GamePhase }).catch(() => {
+        this.gameFlowManager.switchPhase({ targetPhase: phase as GamePhase }).catch(() => {
           // フェーズ切り替え失敗時は何もしない（PHASE_CHANGEDイベントが発行されないため状態は変わらない）
         });
       },
@@ -487,9 +483,7 @@ export class MainScene extends Phaser.Scene {
     const currentPhase = this.stateManager.getState().currentPhase;
     if (currentPhase !== GamePhase.QUEST_ACCEPT) return;
 
-    const realGFM = this
-      .gameFlowManager as unknown as import('@shared/services/game-flow/game-flow-manager.interface').IGameFlowManager;
-    realGFM.switchPhase({ targetPhase: GamePhase.GATHERING }).catch(() => {
+    this.gameFlowManager.switchPhase({ targetPhase: GamePhase.GATHERING }).catch(() => {
       // 遷移失敗時は何もしない（採取セッション中など）
     });
   }

--- a/atelier-guild-rank/src/scenes/MainScene.ts
+++ b/atelier-guild-rank/src/scenes/MainScene.ts
@@ -27,6 +27,7 @@ import {
   createQuestServiceAdapter,
 } from '@shared/services/delivery-phase-adapters';
 import { Container, ServiceKeys } from '@shared/services/di/container';
+import { getPhaseConditionText } from '@shared/services/game-flow/phase-condition-text';
 import { GamePhase } from '@shared/types/common';
 import type { GameEndStats, IPhaseChangedEvent } from '@shared/types/events';
 import { GameEventType } from '@shared/types/events';
@@ -221,6 +222,9 @@ export class MainScene extends Phaser.Scene {
 
     // サイドバーの初期更新
     this.phaseManager.updateSidebar(this.sidebarUI);
+
+    // Issue #471: 到達条件テキストの初期設定
+    this.updatePhaseConditionText(initialPhase);
   }
 
   // ===========================================================================
@@ -360,6 +364,8 @@ export class MainScene extends Phaser.Scene {
         this.updateHeader();
         // Issue #458 Phase 4 A: PhaseRailのアクティブタブを更新
         this.phaseRail.setCurrent(busEvent.payload.newPhase);
+        // Issue #471: 到達条件テキストを更新
+        this.updatePhaseConditionText(busEvent.payload.newPhase);
       }),
     );
 
@@ -378,6 +384,8 @@ export class MainScene extends Phaser.Scene {
     this.unsubscribeHandlers.push(
       this.eventBus.on<{ quest: IQuest }>(GameEventType.QUEST_ACCEPTED, (busEvent) => {
         this.phaseManager.handleQuestAccepted(busEvent.payload, this.sidebarUI);
+        // Issue #471: 受注後にGATHERINGフェーズへ自動遷移
+        this.autoTransitionToGathering();
       }),
     );
 
@@ -465,6 +473,34 @@ export class MainScene extends Phaser.Scene {
    */
   private handleGameCleared(condition: GameEndCondition): void {
     this.scene.start('GameClearScene', { stats: this.buildGameEndStats(condition) });
+  }
+
+  // ===========================================================================
+  // フェーズ遷移自動化 (Issue #471)
+  // ===========================================================================
+
+  /**
+   * 受注後にGATHERINGフェーズへ自動遷移する
+   * 現在QUEST_ACCEPTフェーズの場合のみ遷移する
+   */
+  private autoTransitionToGathering(): void {
+    const currentPhase = this.stateManager.getState().currentPhase;
+    if (currentPhase !== GamePhase.QUEST_ACCEPT) return;
+
+    const realGFM = this
+      .gameFlowManager as unknown as import('@shared/services/game-flow/game-flow-manager.interface').IGameFlowManager;
+    realGFM.switchPhase({ targetPhase: GamePhase.GATHERING }).catch(() => {
+      // 遷移失敗時は何もしない（採取セッション中など）
+    });
+  }
+
+  /**
+   * 到達条件テキストを更新する
+   */
+  private updatePhaseConditionText(phase: GamePhase): void {
+    const hasActiveQuests = this.questService.getActiveQuests().length > 0;
+    const conditionText = getPhaseConditionText(phase, hasActiveQuests);
+    this.phaseRail.setConditionText(conditionText);
   }
 
   // ===========================================================================

--- a/atelier-guild-rank/src/scenes/types/main-scene-types.ts
+++ b/atelier-guild-rank/src/scenes/types/main-scene-types.ts
@@ -9,6 +9,7 @@
 
 import type { EventHandler } from '@shared/services';
 import type { GamePhase, GuildRank } from '@shared/types/common';
+import type { IPhaseSwitchRequest, IPhaseSwitchResult } from '@shared/types/phase-switch';
 
 // =============================================================================
 // サービスインターフェース（依存注入用）
@@ -51,6 +52,8 @@ export interface IMainSceneGameFlowManager {
   startDay(): void;
   endDay(): void;
   skipPhase(): void;
+  /** Issue #471: フェーズ自由切り替え */
+  switchPhase(request: IPhaseSwitchRequest): Promise<IPhaseSwitchResult>;
 }
 
 /**

--- a/atelier-guild-rank/src/shared/presentation/ui/components/composite/PhaseRail.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/components/composite/PhaseRail.ts
@@ -100,6 +100,10 @@ export class PhaseRail extends BaseComponent {
   private notificationText: Phaser.GameObjects.Text | null = null;
   private notificationTimer: Phaser.Time.TimerEvent | null = null;
 
+  // Issue #471: 到達条件テキスト
+  private conditionTextObj: Phaser.GameObjects.Text | null = null;
+  private _conditionText = '';
+
   constructor(scene: Phaser.Scene, x: number, y: number, options: PhaseRailOptions = {}) {
     super(scene, x, y, options);
     this.phases = options.phases ?? VALID_GAME_PHASES;
@@ -189,6 +193,25 @@ export class PhaseRail extends BaseComponent {
       this.tabTexts.push(text);
     }
 
+    // Issue #471: 到達条件テキスト（タブ下部に小さく表示）
+    this.conditionTextObj = this.scene.make.text({
+      x: this.width / 2,
+      y: this.height + 6,
+      text: this._conditionText,
+      style: {
+        fontSize: '11px',
+        color: '#9CA3AF',
+        fontStyle: 'normal',
+      },
+      add: false,
+    });
+    if (this.conditionTextObj.setOrigin) this.conditionTextObj.setOrigin(0.5, 0);
+    if (this.conditionTextObj.setName) this.conditionTextObj.setName('PhaseRail.conditionText');
+    if (this.conditionTextObj.setVisible) {
+      this.conditionTextObj.setVisible(this._conditionText.length > 0);
+    }
+    this.container.add(this.conditionTextObj);
+
     this.container.setDepth(DesignTokens.zIndex.phaseRail);
   }
 
@@ -233,6 +256,24 @@ export class PhaseRail extends BaseComponent {
   /** タブが無効化されているかを取得 */
   isTabsDisabled(): boolean {
     return this.tabsDisabled;
+  }
+
+  /**
+   * 到達条件テキストを設定する（Issue #471）
+   * PhaseRail 下部に次フェーズへの到達条件をテキスト表示する。
+   */
+  setConditionText(text: string): this {
+    this._conditionText = text;
+    if (this.conditionTextObj) {
+      if (this.conditionTextObj.setText) this.conditionTextObj.setText(text);
+      if (this.conditionTextObj.setVisible) this.conditionTextObj.setVisible(text.length > 0);
+    }
+    return this;
+  }
+
+  /** 到達条件テキストを取得 */
+  getConditionText(): string {
+    return this._conditionText;
   }
 
   /** タブ数を取得 */

--- a/atelier-guild-rank/src/shared/services/game-flow/index.ts
+++ b/atelier-guild-rank/src/shared/services/game-flow/index.ts
@@ -7,3 +7,4 @@
 
 export { GameFlowManager } from './game-flow-manager';
 export type { GameEndCondition, IGameFlowManager } from './game-flow-manager.interface';
+export { getPhaseConditionText } from './phase-condition-text';

--- a/atelier-guild-rank/src/shared/services/game-flow/phase-condition-text.ts
+++ b/atelier-guild-rank/src/shared/services/game-flow/phase-condition-text.ts
@@ -1,0 +1,35 @@
+/**
+ * phase-condition-text.ts
+ * Issue #471: フェーズ遷移の到達条件テキストを決定する純粋関数
+ *
+ * Functional Core: 副作用なし、入力のみに依存
+ */
+
+import type { GamePhase } from '@shared/types/common';
+
+/**
+ * 現在のフェーズと状態から、次フェーズへの到達条件テキストを返す
+ *
+ * @param currentPhase - 現在のフェーズ
+ * @param hasActiveQuests - 受注中の依頼があるか
+ * @returns 到達条件テキスト（条件なしの場合は空文字）
+ */
+export function getPhaseConditionText(
+  currentPhase: GamePhase | string,
+  hasActiveQuests: boolean,
+): string {
+  switch (currentPhase) {
+    case 'QUEST_ACCEPT':
+      return hasActiveQuests
+        ? '→ 依頼を受注済み。採取に進めます'
+        : '→ 依頼を受注すると採取に進めます';
+    case 'GATHERING':
+      return '→ 素材を集めたら調合に進めます';
+    case 'ALCHEMY':
+      return '→ アイテムを調合したら納品に進めます';
+    case 'DELIVERY':
+      return '';
+    default:
+      return '';
+  }
+}

--- a/atelier-guild-rank/tests/unit/scenes/main-scene-header-update.test.ts
+++ b/atelier-guild-rank/tests/unit/scenes/main-scene-header-update.test.ts
@@ -340,6 +340,7 @@ const createMockGameFlowManager = () => ({
   startDay: vi.fn(),
   endDay: vi.fn(),
   skipPhase: vi.fn(),
+  switchPhase: vi.fn().mockResolvedValue({ success: true }),
 });
 
 const createMockEventBus = () => {
@@ -527,6 +528,55 @@ describe('MainSceneヘッダー更新（Issue #443）', () => {
         (call: unknown[]) => call[0] === GameEventType.GATHERING_ENDED,
       );
       expect(gatheringEndedCalls.length).toBe(1);
+    });
+  });
+
+  // ===========================================================================
+  // Issue #471: 受注後のGATHERING自動遷移
+  // ===========================================================================
+
+  describe('QUEST_ACCEPTEDイベントでGATHERINGへ自動遷移（Issue #471）', () => {
+    it('QUEST_ACCEPT中に受注するとswitchPhase(GATHERING)が呼ばれる', async () => {
+      const { mockEventBus, mockGameFlowManager } = await createAndInitMainScene();
+      mockGameFlowManager.switchPhase.mockClear();
+
+      // QUEST_ACCEPTEDイベントを発行
+      mockEventBus.emit(GameEventType.QUEST_ACCEPTED, {
+        quest: { id: 'q1', name: 'テスト依頼' },
+      });
+
+      // switchPhase(GATHERING)が呼ばれることを確認
+      expect(mockGameFlowManager.switchPhase).toHaveBeenCalledWith({
+        targetPhase: GamePhase.GATHERING,
+      });
+    });
+
+    it('GATHERING中に受注してもswitchPhaseは呼ばれない', async () => {
+      const { mockEventBus, mockStateManager, mockGameFlowManager } =
+        await createAndInitMainScene();
+      mockGameFlowManager.switchPhase.mockClear();
+
+      // 現在フェーズをGATHERINGに変更
+      mockStateManager.getState.mockReturnValue({
+        currentRank: GuildRank.E,
+        promotionGauge: 35,
+        remainingDays: 25,
+        currentDay: 6,
+        currentPhase: GamePhase.GATHERING,
+        gold: 500,
+        actionPoints: 3,
+        comboCount: 0,
+        rankHp: 100,
+        isPromotionTest: false,
+      });
+
+      // QUEST_ACCEPTEDイベントを発行
+      mockEventBus.emit(GameEventType.QUEST_ACCEPTED, {
+        quest: { id: 'q1', name: 'テスト依頼' },
+      });
+
+      // switchPhaseは呼ばれないことを確認
+      expect(mockGameFlowManager.switchPhase).not.toHaveBeenCalled();
     });
   });
 });

--- a/atelier-guild-rank/tests/unit/scenes/main-scene-header-update.test.ts
+++ b/atelier-guild-rank/tests/unit/scenes/main-scene-header-update.test.ts
@@ -102,6 +102,7 @@ vi.mock('@presentation/ui/components/composite', () => ({
     create() {}
     setCurrent = vi.fn();
     setTabsDisabled = vi.fn();
+    setConditionText = vi.fn();
     destroy() {}
   },
   ContextPanel: class MockContextPanel {

--- a/atelier-guild-rank/tests/unit/shared/presentation/ui/components/composite/PhaseRail-transition.test.ts
+++ b/atelier-guild-rank/tests/unit/shared/presentation/ui/components/composite/PhaseRail-transition.test.ts
@@ -1,0 +1,68 @@
+/**
+ * PhaseRail - フェーズ遷移自動化関連テスト
+ * Issue #471: PhaseRail の到達条件テキスト表示・逆行対応
+ */
+import { PhaseRail } from '@shared/presentation/ui/components/composite/PhaseRail';
+import type Phaser from 'phaser';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createComponentMockScene } from '../test-helpers';
+
+describe('PhaseRail - フェーズ遷移自動化', () => {
+  let scene: Phaser.Scene;
+
+  beforeEach(() => {
+    scene = createComponentMockScene();
+  });
+
+  describe('到達条件テキスト', () => {
+    it('setConditionText でテキストが設定される', () => {
+      const rail = new PhaseRail(scene, 0, 0);
+      rail.create();
+
+      rail.setConditionText('依頼を受注すると採取に進めます');
+      expect(rail.getConditionText()).toBe('依頼を受注すると採取に進めます');
+    });
+
+    it('setConditionText で空文字を設定するとテキストがクリアされる', () => {
+      const rail = new PhaseRail(scene, 0, 0);
+      rail.create();
+
+      rail.setConditionText('テスト条件');
+      rail.setConditionText('');
+      expect(rail.getConditionText()).toBe('');
+    });
+
+    it('create 前に setConditionText を呼んでもエラーにならない', () => {
+      const rail = new PhaseRail(scene, 0, 0);
+      expect(() => rail.setConditionText('テスト')).not.toThrow();
+    });
+  });
+
+  describe('逆行（前フェーズへの遷移）', () => {
+    it('onPhaseClick コールバックはどのフェーズからでも呼ばれる', () => {
+      const clickHandler = vi.fn();
+      const rail = new PhaseRail(scene, 0, 0, {
+        current: 'ALCHEMY',
+        onPhaseClick: clickHandler,
+      });
+      rail.create();
+
+      // QUEST_ACCEPT（前方向）へのクリックが通る
+      rail.simulateTabClick('QUEST_ACCEPT');
+      expect(clickHandler).toHaveBeenCalledWith('QUEST_ACCEPT');
+    });
+
+    it('採取セッション中は逆行もブロックされる', () => {
+      const clickHandler = vi.fn();
+      const rail = new PhaseRail(scene, 0, 0, {
+        current: 'GATHERING',
+        onPhaseClick: clickHandler,
+      });
+      rail.create();
+      rail.setTabsDisabled(true);
+
+      rail.simulateTabClick('QUEST_ACCEPT');
+      expect(clickHandler).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/atelier-guild-rank/tests/unit/shared/services/game-flow/phase-condition-text.test.ts
+++ b/atelier-guild-rank/tests/unit/shared/services/game-flow/phase-condition-text.test.ts
@@ -1,0 +1,42 @@
+/**
+ * phase-condition-text テスト
+ * Issue #471: フェーズ到達条件テキストの純粋関数テスト
+ */
+import { getPhaseConditionText } from '@shared/services/game-flow/phase-condition-text';
+import { describe, expect, it } from 'vitest';
+
+describe('getPhaseConditionText', () => {
+  describe('正常系', () => {
+    it('QUEST_ACCEPT で受注なしの場合、受注を促すテキストを返す', () => {
+      const text = getPhaseConditionText('QUEST_ACCEPT', false);
+      expect(text).toBe('→ 依頼を受注すると採取に進めます');
+    });
+
+    it('QUEST_ACCEPT で受注済みの場合、採取に進めるテキストを返す', () => {
+      const text = getPhaseConditionText('QUEST_ACCEPT', true);
+      expect(text).toBe('→ 依頼を受注済み。採取に進めます');
+    });
+
+    it('GATHERING の場合、調合への条件テキストを返す', () => {
+      const text = getPhaseConditionText('GATHERING', false);
+      expect(text).toBe('→ 素材を集めたら調合に進めます');
+    });
+
+    it('ALCHEMY の場合、納品への条件テキストを返す', () => {
+      const text = getPhaseConditionText('ALCHEMY', false);
+      expect(text).toBe('→ アイテムを調合したら納品に進めます');
+    });
+
+    it('DELIVERY の場合、空文字を返す', () => {
+      const text = getPhaseConditionText('DELIVERY', false);
+      expect(text).toBe('');
+    });
+  });
+
+  describe('異常系', () => {
+    it('未知のフェーズの場合、空文字を返す', () => {
+      const text = getPhaseConditionText('UNKNOWN_PHASE', false);
+      expect(text).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- QUEST_ACCEPT で依頼を受注すると自動で GATHERING フェーズへ遷移
- PhaseRail 下部に次フェーズへの到達条件テキストを表示（フェーズ変更時に自動更新）
- PhaseRail は既に全方向の自由遷移に対応済み（逆行＝状態保持で前フェーズに戻れる）
- 到達条件テキスト判定の純粋関数 `getPhaseConditionText()` を新設（テスト付き）

## Test plan
- [x] `pnpm test -- --run` 全2883テスト pass
- [x] `pnpm typecheck` pass
- [x] `pnpm lint` pass（既存の1件のみ）
- [ ] 手動確認: 依頼受注後にGATHERINGへ自動遷移すること
- [ ] 手動確認: PhaseRail下部に到達条件テキストが表示されること
- [ ] 手動確認: PhaseRailタブクリックで前フェーズに戻れること

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)