### PR TITLE
feat: Toast通知導入（納品成功・ゴールド変動・AP不足）

### DIFF
--- a/atelier-guild-rank/src/scenes/MainScene.ts
+++ b/atelier-guild-rank/src/scenes/MainScene.ts
@@ -21,6 +21,11 @@ import { SidebarUI } from '@presentation/ui/components/SidebarUI';
 import { MAIN_LAYOUT } from '@shared/constants';
 import type { GameEndCondition } from '@shared/services';
 import {
+  formatApInsufficientMessage,
+  formatDeliverySuccessMessage,
+  formatGoldChangedMessage,
+} from '@shared/services';
+import {
   createContributionCalculatorAdapter,
   createDeckServiceAdapter,
   createInventoryServiceAdapter,
@@ -28,17 +33,13 @@ import {
 } from '@shared/services/delivery-phase-adapters';
 import { Container, ServiceKeys } from '@shared/services/di/container';
 import { getPhaseConditionText } from '@shared/services/game-flow/phase-condition-text';
-import {
-  formatApInsufficientMessage,
-  formatDeliverySuccessMessage,
-  formatGoldChangedMessage,
-} from '@shared/services/toast-message-formatter';
 import { GamePhase } from '@shared/types/common';
 import type {
   GameEndStats,
   IApInsufficientEvent,
   IGoldChangedEvent,
   IPhaseChangedEvent,
+  IQuestCompletedEvent,
 } from '@shared/types/events';
 import { GameEventType } from '@shared/types/events';
 import type { IQuest } from '@shared/types/quests';
@@ -420,20 +421,16 @@ export class MainScene extends Phaser.Scene {
 
     // Issue #472: 納品成功 Toast
     this.unsubscribeHandlers.push(
-      this.eventBus.on<{ quest: IQuest; gold: number; contribution: number }>(
-        GameEventType.QUEST_COMPLETED,
-        (busEvent) => {
-          const msg = formatDeliverySuccessMessage(
-            busEvent.payload.gold,
-            busEvent.payload.contribution,
-          );
-          this.toast.show(msg);
-          this.updateHeader();
-        },
-      ),
+      this.eventBus.on<IQuestCompletedEvent>(GameEventType.QUEST_COMPLETED, (busEvent) => {
+        const msg = formatDeliverySuccessMessage(
+          busEvent.payload.gold,
+          busEvent.payload.contribution,
+        );
+        this.toast.show(msg);
+      }),
     );
 
-    // Issue #472: ゴールド変動 Toast
+    // Issue #472: ゴールド変動 Toast（ヘッダー更新も兼ねる）
     this.unsubscribeHandlers.push(
       this.eventBus.on<IGoldChangedEvent>(GameEventType.GOLD_CHANGED, (busEvent) => {
         const msg = formatGoldChangedMessage(busEvent.payload.delta);

--- a/atelier-guild-rank/src/scenes/MainScene.ts
+++ b/atelier-guild-rank/src/scenes/MainScene.ts
@@ -15,7 +15,7 @@
 
 import { GatheringPhaseUI } from '@features/gathering';
 import type { IQuestService } from '@features/quest';
-import { ContextPanel, HUDBar, PhaseRail } from '@presentation/ui/components/composite';
+import { ContextPanel, HUDBar, PhaseRail, Toast } from '@presentation/ui/components/composite';
 import { FooterUI } from '@presentation/ui/components/FooterUI';
 import { SidebarUI } from '@presentation/ui/components/SidebarUI';
 import { MAIN_LAYOUT } from '@shared/constants';
@@ -28,8 +28,18 @@ import {
 } from '@shared/services/delivery-phase-adapters';
 import { Container, ServiceKeys } from '@shared/services/di/container';
 import { getPhaseConditionText } from '@shared/services/game-flow/phase-condition-text';
+import {
+  formatApInsufficientMessage,
+  formatDeliverySuccessMessage,
+  formatGoldChangedMessage,
+} from '@shared/services/toast-message-formatter';
 import { GamePhase } from '@shared/types/common';
-import type { GameEndStats, IPhaseChangedEvent } from '@shared/types/events';
+import type {
+  GameEndStats,
+  IApInsufficientEvent,
+  IGoldChangedEvent,
+  IPhaseChangedEvent,
+} from '@shared/types/events';
 import { GameEventType } from '@shared/types/events';
 import type { IQuest } from '@shared/types/quests';
 import Phaser from 'phaser';
@@ -111,6 +121,9 @@ export class MainScene extends Phaser.Scene {
 
   /** フッターUI */
   private footerUI!: FooterUI;
+
+  /** Toast通知 (Issue #472) */
+  private toast!: Toast;
 
   /** コンテンツコンテナ（各フェーズUIの親コンテナとして使用） */
   private _contentContainer!: Phaser.GameObjects.Container;
@@ -326,6 +339,12 @@ export class MainScene extends Phaser.Scene {
     // （将来的にはFooterUI本体のリファクタリングで除去予定）
     const phaseTabUI = this.footerUI.getPhaseTabUI();
     phaseTabUI?.getContainer().setVisible(false);
+
+    // Issue #472: Toast通知（右上配置）
+    const toastX = screenWidth - 160;
+    const toastY = LAYOUT.HEADER_HEIGHT + PHASE_RAIL_HEIGHT + 16;
+    this.toast = new Toast(this, toastX, toastY);
+    this.toast.create();
   }
 
   /**
@@ -399,6 +418,37 @@ export class MainScene extends Phaser.Scene {
       }),
     );
 
+    // Issue #472: 納品成功 Toast
+    this.unsubscribeHandlers.push(
+      this.eventBus.on<{ quest: IQuest; gold: number; contribution: number }>(
+        GameEventType.QUEST_COMPLETED,
+        (busEvent) => {
+          const msg = formatDeliverySuccessMessage(
+            busEvent.payload.gold,
+            busEvent.payload.contribution,
+          );
+          this.toast.show(msg);
+          this.updateHeader();
+        },
+      ),
+    );
+
+    // Issue #472: ゴールド変動 Toast
+    this.unsubscribeHandlers.push(
+      this.eventBus.on<IGoldChangedEvent>(GameEventType.GOLD_CHANGED, (busEvent) => {
+        const msg = formatGoldChangedMessage(busEvent.payload.delta);
+        if (msg) this.toast.show(msg);
+        this.updateHeader();
+      }),
+    );
+
+    // Issue #472: AP不足 Toast
+    this.unsubscribeHandlers.push(
+      this.eventBus.on<IApInsufficientEvent>(GameEventType.AP_INSUFFICIENT, () => {
+        this.toast.show(formatApInsufficientMessage());
+      }),
+    );
+
     // Issue #361: ゲーム終了イベントの購読
     this.unsubscribeHandlers.push(
       this.eventBus.on<GameEndCondition>(GameEventType.GAME_OVER, (busEvent) => {
@@ -423,6 +473,7 @@ export class MainScene extends Phaser.Scene {
     }
     this.unsubscribeHandlers = [];
 
+    this.toast?.destroy();
     this.phaseManager?.destroy();
   }
 

--- a/atelier-guild-rank/src/shared/presentation/ui/components/composite/Toast.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/components/composite/Toast.ts
@@ -55,6 +55,18 @@ export class Toast extends BaseComponent {
     if (message !== undefined) {
       this.message = message;
       this.text?.setText(message);
+      // Issue #472: メッセージ長に応じて背景サイズを再計算
+      if (this.bg && this.text) {
+        const w = Math.max(
+          44,
+          (this.text.width || this.message.length * 12) + DesignTokens.spacing.md * 2,
+        );
+        const h = Math.max(
+          44,
+          (this.text.height || DesignTokens.sizes.medium) + DesignTokens.spacing.sm * 2,
+        );
+        this.bg.setSize(w, h);
+      }
     }
     this.container.setVisible(true);
     this.timer?.remove();

--- a/atelier-guild-rank/src/shared/services/index.ts
+++ b/atelier-guild-rank/src/shared/services/index.ts
@@ -48,3 +48,9 @@ export {
   StateManager,
   VALID_PHASE_TRANSITIONS,
 } from './state-manager';
+// Toast Message Formatter (Issue #472)
+export {
+  formatApInsufficientMessage,
+  formatDeliverySuccessMessage,
+  formatGoldChangedMessage,
+} from './toast-message-formatter';

--- a/atelier-guild-rank/src/shared/services/state-manager/StateManager.ts
+++ b/atelier-guild-rank/src/shared/services/state-manager/StateManager.ts
@@ -150,6 +150,11 @@ export class StateManager implements IStateManager {
     }
 
     if (this.state.actionPoints < amount) {
+      // Issue #472: AP不足イベントを発行
+      this.eventBus.emit(GameEventType.AP_INSUFFICIENT, {
+        required: amount,
+        current: this.state.actionPoints,
+      });
       return false;
     }
 
@@ -173,10 +178,18 @@ export class StateManager implements IStateManager {
       throw new DomainError(ErrorCodes.INVALID_OPERATION, 'Amount must be positive');
     }
 
+    const previousAmount = this.state.gold;
     this.state = {
       ...this.state,
       gold: this.state.gold + amount,
     };
+
+    // Issue #472: ゴールド変動イベントを発行
+    this.eventBus.emit(GameEventType.GOLD_CHANGED, {
+      previousAmount,
+      newAmount: this.state.gold,
+      delta: amount,
+    });
   }
 
   /**
@@ -196,10 +209,18 @@ export class StateManager implements IStateManager {
       return false;
     }
 
+    const previousAmount = this.state.gold;
     this.state = {
       ...this.state,
       gold: this.state.gold - amount,
     };
+
+    // Issue #472: ゴールド変動イベントを発行
+    this.eventBus.emit(GameEventType.GOLD_CHANGED, {
+      previousAmount,
+      newAmount: this.state.gold,
+      delta: -amount,
+    });
 
     return true;
   }

--- a/atelier-guild-rank/src/shared/services/toast-message-formatter.ts
+++ b/atelier-guild-rank/src/shared/services/toast-message-formatter.ts
@@ -1,0 +1,27 @@
+/**
+ * toast-message-formatter.ts - Toast通知メッセージの生成（純粋関数）
+ * Issue #472: Toast通知導入
+ */
+
+/**
+ * 納品成功メッセージを生成する
+ */
+export function formatDeliverySuccessMessage(gold: number, contribution: number): string {
+  return `納品成功！ +${gold}G 貢献度+${contribution}`;
+}
+
+/**
+ * ゴールド変動メッセージを生成する
+ * @returns メッセージ文字列。delta=0の場合はnull
+ */
+export function formatGoldChangedMessage(delta: number): string | null {
+  if (delta === 0) return null;
+  return delta > 0 ? `+${delta}G` : `${delta}G`;
+}
+
+/**
+ * AP不足メッセージを生成する
+ */
+export function formatApInsufficientMessage(): string {
+  return 'APが不足しています';
+}

--- a/atelier-guild-rank/src/shared/types/events.ts
+++ b/atelier-guild-rank/src/shared/types/events.ts
@@ -82,13 +82,16 @@ export interface IPhaseChangedEvent extends IGameEvent {
 
 /**
  * 依頼完了イベント
+ * Issue #472: quest-service.ts の実際のペイロードに合わせて修正
  */
 export interface IQuestCompletedEvent extends IGameEvent {
   type: typeof GameEventType.QUEST_COMPLETED;
   /** 完了した依頼 */
   quest: IQuest;
-  /** 納品したアイテム */
-  deliveredItem: ICraftedItem;
+  /** 貢献度 */
+  contribution: number;
+  /** ゴールド報酬 */
+  gold: number;
 }
 
 // =============================================================================

--- a/atelier-guild-rank/src/shared/types/events.ts
+++ b/atelier-guild-rank/src/shared/types/events.ts
@@ -40,6 +40,9 @@ export const GameEventType = {
   // セーブ/ロード関連イベント
   GAME_SAVED: 'GAME_SAVED',
   GAME_LOADED: 'GAME_LOADED',
+  // Toast通知関連イベント (Issue #472)
+  GOLD_CHANGED: 'GOLD_CHANGED',
+  AP_INSUFFICIENT: 'AP_INSUFFICIENT',
 } as const;
 
 export type GameEventType = (typeof GameEventType)[keyof typeof GameEventType];
@@ -194,6 +197,34 @@ export interface IGameSavedEvent extends IGameEvent {
  */
 export interface IGameLoadedEvent extends IGameEvent {
   type: typeof GameEventType.GAME_LOADED;
+}
+
+// =============================================================================
+// ゴールド変動イベント (Issue #472)
+// =============================================================================
+
+/**
+ * ゴールド変動イベント
+ */
+export interface IGoldChangedEvent extends IGameEvent {
+  type: typeof GameEventType.GOLD_CHANGED;
+  /** 変動前のゴールド */
+  previousAmount: number;
+  /** 変動後のゴールド */
+  newAmount: number;
+  /** 変動量（正: 加算、負: 減算） */
+  delta: number;
+}
+
+/**
+ * AP不足イベント
+ */
+export interface IApInsufficientEvent extends IGameEvent {
+  type: typeof GameEventType.AP_INSUFFICIENT;
+  /** 要求されたAP */
+  required: number;
+  /** 現在のAP */
+  current: number;
 }
 
 // =============================================================================

--- a/atelier-guild-rank/tests/unit/application/services/state-manager.test.ts
+++ b/atelier-guild-rank/tests/unit/application/services/state-manager.test.ts
@@ -338,6 +338,73 @@ describe('StateManager', () => {
   });
 
   // =============================================================================
+  // Issue #472: Toast通知用イベント発行テスト
+  // =============================================================================
+
+  describe('Issue #472: イベント発行', () => {
+    it('addGold でGOLD_CHANGEDイベントが発行される', () => {
+      const handler = vi.fn();
+      eventBus.on(GameEventType.GOLD_CHANGED, handler);
+      const initialGold = stateManager.getState().gold;
+
+      stateManager.addGold(100);
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: { previousAmount: initialGold, newAmount: initialGold + 100, delta: 100 },
+        }),
+      );
+    });
+
+    it('spendGold でGOLD_CHANGEDイベントが発行される', () => {
+      const handler = vi.fn();
+      eventBus.on(GameEventType.GOLD_CHANGED, handler);
+      const initialGold = stateManager.getState().gold;
+
+      stateManager.spendGold(30);
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: { previousAmount: initialGold, newAmount: initialGold - 30, delta: -30 },
+        }),
+      );
+    });
+
+    it('spendGold でゴールド不足時はイベント発行されない', () => {
+      const handler = vi.fn();
+      eventBus.on(GameEventType.GOLD_CHANGED, handler);
+      const initialGold = stateManager.getState().gold;
+
+      stateManager.spendGold(initialGold + 1);
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('spendActionPoints でAP不足時にAP_INSUFFICIENTイベントが発行される', () => {
+      const handler = vi.fn();
+      eventBus.on(GameEventType.AP_INSUFFICIENT, handler);
+      const currentAp = stateManager.getState().actionPoints;
+
+      stateManager.spendActionPoints(currentAp + 1);
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: { required: currentAp + 1, current: currentAp },
+        }),
+      );
+    });
+
+    it('spendActionPoints でAP十分時はAP_INSUFFICIENTイベント発行されない', () => {
+      const handler = vi.fn();
+      eventBus.on(GameEventType.AP_INSUFFICIENT, handler);
+
+      stateManager.spendActionPoints(1);
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  // =============================================================================
   // 入力値検証（W-001/W-002修正に伴う追加テスト）
   // =============================================================================
 

--- a/atelier-guild-rank/tests/unit/scenes/main-scene-header-update.test.ts
+++ b/atelier-guild-rank/tests/unit/scenes/main-scene-header-update.test.ts
@@ -110,6 +110,12 @@ vi.mock('@presentation/ui/components/composite', () => ({
     setContent = vi.fn();
     destroy() {}
   },
+  Toast: class MockToast {
+    create() {}
+    show = vi.fn().mockReturnThis();
+    hide = vi.fn().mockReturnThis();
+    destroy() {}
+  },
 }));
 
 vi.mock('@presentation/ui/components/SidebarUI', () => ({

--- a/atelier-guild-rank/tests/unit/shared/services/toast-message-formatter.test.ts
+++ b/atelier-guild-rank/tests/unit/shared/services/toast-message-formatter.test.ts
@@ -1,0 +1,50 @@
+import {
+  formatApInsufficientMessage,
+  formatDeliverySuccessMessage,
+  formatGoldChangedMessage,
+} from '@shared/services/toast-message-formatter';
+import { describe, expect, it } from 'vitest';
+
+describe('toast-message-formatter', () => {
+  describe('formatDeliverySuccessMessage', () => {
+    describe('正常系', () => {
+      it('ゴールドと貢献度を含むメッセージを返す', () => {
+        const result = formatDeliverySuccessMessage(150, 30);
+        expect(result).toBe('納品成功！ +150G 貢献度+30');
+      });
+
+      it('ゴールド0の場合でもメッセージを返す', () => {
+        const result = formatDeliverySuccessMessage(0, 10);
+        expect(result).toBe('納品成功！ +0G 貢献度+10');
+      });
+    });
+  });
+
+  describe('formatGoldChangedMessage', () => {
+    describe('正常系', () => {
+      it('正のdeltaで加算メッセージを返す', () => {
+        const result = formatGoldChangedMessage(100);
+        expect(result).toBe('+100G');
+      });
+
+      it('負のdeltaで減算メッセージを返す', () => {
+        const result = formatGoldChangedMessage(-50);
+        expect(result).toBe('-50G');
+      });
+    });
+
+    describe('境界値', () => {
+      it('delta=0でnullを返す', () => {
+        const result = formatGoldChangedMessage(0);
+        expect(result).toBeNull();
+      });
+    });
+  });
+
+  describe('formatApInsufficientMessage', () => {
+    it('AP不足メッセージを返す', () => {
+      const result = formatApInsufficientMessage();
+      expect(result).toBe('APが不足しています');
+    });
+  });
+});

--- a/atelier-guild-rank/tests/unit/shared/types/events.test.ts
+++ b/atelier-guild-rank/tests/unit/shared/types/events.test.ts
@@ -224,21 +224,14 @@ describe('events.ts', () => {
       flavorText: 'Test',
     };
 
-    const sampleCraftedItem: ICraftedItem = {
-      itemId: toItemId('item-001'),
-      quality: Quality.A,
-      attributeValues: [],
-      effectValues: [],
-      usedMaterials: [],
-    };
-
     // TC-EVT-022
     it('IQuestCompletedEvent型がインポート可能', () => {
       const event: IQuestCompletedEvent = {
         type: GameEventType.QUEST_COMPLETED,
         timestamp: Date.now(),
         quest: sampleQuest,
-        deliveredItem: sampleCraftedItem,
+        contribution: 100,
+        gold: 50,
       };
       expect(event).toBeDefined();
     });
@@ -250,7 +243,8 @@ describe('events.ts', () => {
         type: GameEventType.QUEST_FAILED,
         timestamp: Date.now(),
         quest: sampleQuest,
-        deliveredItem: sampleCraftedItem,
+        contribution: 100,
+        gold: 50,
       };
       expect(invalid).toBeDefined();
     });
@@ -262,19 +256,21 @@ describe('events.ts', () => {
         type: GameEventType.QUEST_COMPLETED,
         timestamp: Date.now(),
         quest: 'not-a-quest',
-        deliveredItem: sampleCraftedItem,
+        contribution: 100,
+        gold: 50,
       };
       expect(invalid).toBeDefined();
     });
 
-    // TC-EVT-025
-    it('IQuestCompletedEvent.deliveredItemがICraftedItem型', () => {
+    // TC-EVT-025: Issue #472: deliveredItem → contribution/gold に変更
+    it('IQuestCompletedEvent.goldがnumber型', () => {
       // @ts-expect-error - 型違いで型エラー
       const invalid: IQuestCompletedEvent = {
         type: GameEventType.QUEST_COMPLETED,
         timestamp: Date.now(),
         quest: sampleQuest,
-        deliveredItem: 'not-an-item',
+        contribution: 100,
+        gold: 'not-a-number',
       };
       expect(invalid).toBeDefined();
     });


### PR DESCRIPTION
## Summary
- `GameEventType`に`GOLD_CHANGED`/`AP_INSUFFICIENT`イベントを追加し、StateManagerから発行
- MainSceneに既存Toastコンポーネントを配置し、EventBus経由で納品成功・ゴールド変動・AP不足を通知
- `toast-message-formatter`純粋関数でメッセージ生成をFunctional Coreに分離

## Test plan
- [x] toast-message-formatter ユニットテスト（6ケース）
- [x] StateManager GOLD_CHANGED/AP_INSUFFICIENT イベント発行テスト（5ケース）
- [x] MainScene既存テストの Toast モック対応
- [x] 全171テストファイル（2896テスト）パス
- [x] TypeScriptコンパイルパス
- [x] Biomeリントパス（既存e2eエラーのみ）

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)