### PR TITLE
refactor: レイアウト定数をlayout.tsに一元管理 (#486)

### DIFF
--- a/atelier-guild-rank/src/scenes/MainScene.ts
+++ b/atelier-guild-rank/src/scenes/MainScene.ts
@@ -59,18 +59,9 @@ import type {
 
 /**
  * レイアウト定数（共通定数から参照）
+ * Issue #486: layout.ts に一元管理
  */
 const LAYOUT = MAIN_LAYOUT;
-
-/**
- * Issue #458 Phase 4 A: 3カラムレイアウト拡張定数
- * - HUDBar: 画面上部 (y=0, height=HEADER_HEIGHT=60)
- * - PhaseRail: HUDBar直下 (y=HEADER_HEIGHT, height=PHASE_RAIL_HEIGHT)
- * - ContextPanel: 右カラム（Workspaceの右側に固定幅で配置）
- */
-const PHASE_RAIL_HEIGHT = 48;
-const CONTEXT_PANEL_WIDTH = 260;
-const CONTEXT_PANEL_PADDING = 8;
 
 // =============================================================================
 // MainSceneクラス
@@ -198,10 +189,10 @@ export class MainScene extends Phaser.Scene {
     this.data.set('deckService', realDeck ? createDeckServiceAdapter(realDeck) : null);
 
     // コンテンツコンテナを先に作成（PhaseManagerのコンストラクタで必要）
-    // Issue #458 Phase 4 A: PhaseRailを上部に昇格配置するため、contentY を HEADER_HEIGHT + PHASE_RAIL_HEIGHT に下げる
+    // PhaseRailを上部に昇格配置するため、contentY を HEADER_HEIGHT + PHASE_RAIL_HEIGHT に下げる
     this._contentContainer = this.add.container(
       LAYOUT.SIDEBAR_WIDTH,
-      LAYOUT.HEADER_HEIGHT + PHASE_RAIL_HEIGHT,
+      LAYOUT.HEADER_HEIGHT + LAYOUT.PHASE_RAIL_HEIGHT,
     );
     this._contentContainer.name = 'MainScene.contentContainer';
 
@@ -286,7 +277,7 @@ export class MainScene extends Phaser.Scene {
     // PhaseRail（HUDBar直下、サイドバー右側から開始）
     this.phaseRail = new PhaseRail(this, LAYOUT.SIDEBAR_WIDTH, LAYOUT.HEADER_HEIGHT, {
       width: workspaceWidth,
-      height: PHASE_RAIL_HEIGHT,
+      height: LAYOUT.PHASE_RAIL_HEIGHT,
       current: this.stateManager.getState().currentPhase,
       onPhaseClick: (phase) => {
         this.gameFlowManager.switchPhase({ targetPhase: phase as GamePhase }).catch(() => {
@@ -308,17 +299,21 @@ export class MainScene extends Phaser.Scene {
 
     // ContextPanel（右カラム、Workspace 右端にオーバーレイ配置）
     // 中心基準で描画されるので、右端から CONTEXT_PANEL_WIDTH/2 + padding を引いた位置に配置
-    const contextPanelCenterX = screenWidth - CONTEXT_PANEL_WIDTH / 2 - CONTEXT_PANEL_PADDING;
+    const contextPanelCenterX =
+      screenWidth - LAYOUT.CONTEXT_PANEL_WIDTH / 2 - LAYOUT.CONTEXT_PANEL_PADDING;
     const contextPanelHeight =
       this.cameras.main.height -
       LAYOUT.HEADER_HEIGHT -
-      PHASE_RAIL_HEIGHT -
+      LAYOUT.PHASE_RAIL_HEIGHT -
       LAYOUT.FOOTER_HEIGHT -
-      CONTEXT_PANEL_PADDING * 2;
+      LAYOUT.CONTEXT_PANEL_PADDING * 2;
     const contextPanelCenterY =
-      LAYOUT.HEADER_HEIGHT + PHASE_RAIL_HEIGHT + CONTEXT_PANEL_PADDING + contextPanelHeight / 2;
+      LAYOUT.HEADER_HEIGHT +
+      LAYOUT.PHASE_RAIL_HEIGHT +
+      LAYOUT.CONTEXT_PANEL_PADDING +
+      contextPanelHeight / 2;
     this.contextPanel = new ContextPanel(this, contextPanelCenterX, contextPanelCenterY, {
-      width: CONTEXT_PANEL_WIDTH,
+      width: LAYOUT.CONTEXT_PANEL_WIDTH,
       height: Math.max(120, contextPanelHeight),
     });
     this.contextPanel.create();
@@ -343,7 +338,7 @@ export class MainScene extends Phaser.Scene {
 
     // Issue #472: Toast通知（右上配置）
     const toastX = screenWidth - 160;
-    const toastY = LAYOUT.HEADER_HEIGHT + PHASE_RAIL_HEIGHT + 16;
+    const toastY = LAYOUT.HEADER_HEIGHT + LAYOUT.PHASE_RAIL_HEIGHT + 16;
     this.toast = new Toast(this, toastX, toastY);
     this.toast.create();
   }

--- a/atelier-guild-rank/src/scenes/RankUpScene.ts
+++ b/atelier-guild-rank/src/scenes/RankUpScene.ts
@@ -12,6 +12,7 @@
 import type { IRankService, PromotionResult } from '@features/rank';
 import type { RexLabel, RexUIPlugin } from '@presentation/types/rexui';
 import { THEME } from '@presentation/ui/theme';
+import { MAIN_LAYOUT } from '@shared/constants';
 import { isKeyForAction } from '@shared/constants/keybindings';
 import type { IEventBus } from '@shared/services';
 import { Container, ServiceKeys } from '@shared/services/di/container';
@@ -26,8 +27,8 @@ import Phaser from 'phaser';
  * レイアウト定数
  */
 const LAYOUT = {
-  /** ヘッダー高さ */
-  HEADER_HEIGHT: 60,
+  /** ヘッダー高さ（MAIN_LAYOUT から参照） */
+  HEADER_HEIGHT: MAIN_LAYOUT.HEADER_HEIGHT,
   /** フッター高さ */
   FOOTER_HEIGHT: 80,
   /** サイドパディング */

--- a/atelier-guild-rank/src/scenes/ShopScene.ts
+++ b/atelier-guild-rank/src/scenes/ShopScene.ts
@@ -12,6 +12,7 @@
 import type { IPurchaseResult, IShopItem, IShopService } from '@features/shop';
 import type { RexLabel, RexSizer, RexUIPlugin } from '@presentation/types/rexui';
 import { THEME } from '@presentation/ui/theme';
+import { MAIN_LAYOUT } from '@shared/constants';
 import { Container, ServiceKeys } from '@shared/services/di/container';
 import type { GuildRank } from '@shared/types';
 import Phaser from 'phaser';
@@ -24,8 +25,8 @@ import Phaser from 'phaser';
  * レイアウト定数
  */
 const LAYOUT = {
-  /** ヘッダー高さ */
-  HEADER_HEIGHT: 60,
+  /** ヘッダー高さ（MAIN_LAYOUT から参照） */
+  HEADER_HEIGHT: MAIN_LAYOUT.HEADER_HEIGHT,
   /** フッター高さ */
   FOOTER_HEIGHT: 80,
   /** サイドパディング */

--- a/atelier-guild-rank/src/shared/components/FooterUI.ts
+++ b/atelier-guild-rank/src/shared/components/FooterUI.ts
@@ -11,6 +11,7 @@
  * @信頼性レベル 🔵 REQ-006・architecture.md「FooterUI変更」より
  */
 
+import { MAIN_LAYOUT } from '@shared/constants';
 import type { IEventBus } from '@shared/services/event-bus/types';
 import type { IGameFlowManager } from '@shared/services/game-flow/game-flow-manager.interface';
 import type { GamePhase } from '@shared/types';
@@ -43,12 +44,13 @@ const FOOTER_COLORS = {
 
 /**
  * フッターレイアウト定数
+ * Issue #486: 幅・高さは MAIN_LAYOUT から参照
  */
 const FOOTER_LAYOUT = {
-  /** フッター幅（画面幅 - サイドバー幅） */
-  WIDTH: 1024 - 200,
+  /** フッター幅（画面幅 - サイドバー幅） — 注: 実際の幅は画面サイズ依存。この値はフォールバック */
+  WIDTH: 1024 - MAIN_LAYOUT.SIDEBAR_WIDTH,
   /** フッター高さ */
-  HEIGHT: 120,
+  HEIGHT: MAIN_LAYOUT.FOOTER_HEIGHT,
   /** パディング */
   PADDING: 16,
   /** PhaseTabUIのY座標オフセット */

--- a/atelier-guild-rank/src/shared/components/SidebarUI.ts
+++ b/atelier-guild-rank/src/shared/components/SidebarUI.ts
@@ -9,6 +9,7 @@
  * @信頼性レベル 🔵 requirements.md セクション2.3に基づく
  */
 
+import { MAIN_LAYOUT } from '@shared/constants';
 import type { ICraftedItem, IMaterialInstance } from '@shared/types/materials';
 import type { IActiveQuest } from '@shared/types/quests';
 import type Phaser from 'phaser';
@@ -52,12 +53,13 @@ const COLORS = {
 
 /**
  * サイドバーレイアウト定数
+ * Issue #486: 幅・ヘッダー高さは MAIN_LAYOUT から参照
  */
 const SIDEBAR_LAYOUT = {
   /** サイドバー幅 */
-  WIDTH: 200,
-  /** サイドバー高さ（画面高さ - ヘッダー高さ） */
-  HEIGHT: 768 - 60,
+  WIDTH: MAIN_LAYOUT.SIDEBAR_WIDTH,
+  /** サイドバー高さ（画面高さ - ヘッダー高さ） — 注: 実際の画面高さは実行時依存 */
+  HEIGHT: 768 - MAIN_LAYOUT.HEADER_HEIGHT,
   /** パディング */
   PADDING: 12,
   /** セクション間隔 */

--- a/atelier-guild-rank/src/shared/constants/layout.ts
+++ b/atelier-guild-rank/src/shared/constants/layout.ts
@@ -10,15 +10,15 @@
 export const MAIN_LAYOUT = {
   /** サイドバー幅 */
   SIDEBAR_WIDTH: 200,
-  /** ヘッダー（HUDBar）高さ */
+  /** ヘッダー領域の高さ（HUDBar配置スロットの高さ。位置計算に使用） */
   HEADER_HEIGHT: 60,
-  /** HUDBar 内部の高さ */
+  /** HUDBar 内部の描画高さ（背景パネル・ボーダー等の実描画サイズ） */
   HUD_HEIGHT: 56,
   /** フェーズレール高さ */
   PHASE_RAIL_HEIGHT: 48,
   /** コンテキストパネル幅 */
   CONTEXT_PANEL_WIDTH: 260,
-  /** コンテキストパネル余白 */
+  /** コンテキストパネル余白（位置計算に必要なためTHEMEではなくここで管理） */
   CONTEXT_PANEL_PADDING: 8,
   /** フッター高さ */
   FOOTER_HEIGHT: 120,

--- a/atelier-guild-rank/src/shared/constants/layout.ts
+++ b/atelier-guild-rank/src/shared/constants/layout.ts
@@ -2,14 +2,24 @@
  * レイアウト共通定数
  * メインシーンのレイアウト構成値。UIコンポーネントが画面位置を参照する際に使用。
  *
+ * Issue #486: 各コンポーネントのDEFAULT定数を一元管理に統合
+ *
  * @信頼性レベル 🔵 requirements.md セクション2.1に基づく
  */
 
 export const MAIN_LAYOUT = {
   /** サイドバー幅 */
   SIDEBAR_WIDTH: 200,
-  /** ヘッダー高さ */
+  /** ヘッダー（HUDBar）高さ */
   HEADER_HEIGHT: 60,
+  /** HUDBar 内部の高さ */
+  HUD_HEIGHT: 56,
+  /** フェーズレール高さ */
+  PHASE_RAIL_HEIGHT: 48,
+  /** コンテキストパネル幅 */
+  CONTEXT_PANEL_WIDTH: 260,
+  /** コンテキストパネル余白 */
+  CONTEXT_PANEL_PADDING: 8,
   /** フッター高さ */
   FOOTER_HEIGHT: 120,
 } as const;

--- a/atelier-guild-rank/src/shared/presentation/ui/components/composite/ContextPanel.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/components/composite/ContextPanel.ts
@@ -20,6 +20,7 @@
  */
 
 import { BaseComponent, type BaseComponentOptions } from '@shared/components';
+import { MAIN_LAYOUT } from '@shared/constants';
 import { Colors, DesignTokens } from '@shared/theme';
 import type Phaser from 'phaser';
 
@@ -43,7 +44,8 @@ export type ContextPanelChild = Phaser.GameObjects.GameObject & {
 // 定数
 // =============================================================================
 
-const DEFAULT_WIDTH = 280;
+const DEFAULT_WIDTH = MAIN_LAYOUT.CONTEXT_PANEL_WIDTH;
+/** @deprecated Issue #486: MainSceneからheightオプションで渡される。フォールバック用 */
 const DEFAULT_HEIGHT = 320;
 const PADDING = 16;
 

--- a/atelier-guild-rank/src/shared/presentation/ui/components/composite/HUDBar.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/components/composite/HUDBar.ts
@@ -22,6 +22,7 @@
  */
 
 import { BaseComponent, type BaseComponentOptions } from '@shared/components';
+import { MAIN_LAYOUT } from '@shared/constants';
 import { DesignTokens } from '@shared/theme';
 import type { GuildRank as GuildRankType } from '@shared/types/common';
 import { GuildRank } from '@shared/types/common';
@@ -88,8 +89,9 @@ const HUD_COLORS = {
   BORDER: 0x374151,
 } as const;
 
+/** @deprecated Issue #486: MainSceneからwidthオプションで渡される。フォールバック用 */
 const DEFAULT_WIDTH = 824;
-const HUD_HEIGHT = 56;
+const HUD_HEIGHT = MAIN_LAYOUT.HUD_HEIGHT;
 const PADDING = 16;
 const GAUGE_WIDTH = 100;
 const GAUGE_HEIGHT = 16;

--- a/atelier-guild-rank/src/shared/presentation/ui/components/composite/PhaseRail.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/components/composite/PhaseRail.ts
@@ -20,6 +20,7 @@
  */
 
 import { BaseComponent, type BaseComponentOptions } from '@shared/components';
+import { MAIN_LAYOUT } from '@shared/constants';
 import { DesignTokens } from '@shared/theme';
 import type { GamePhase } from '@shared/types/common';
 import { VALID_GAME_PHASES } from '@shared/types/common';
@@ -64,8 +65,9 @@ const RAIL_COLORS = {
   NOTIFICATION_TEXT: '#F87171',
 } as const;
 
+/** @deprecated Issue #486: MainSceneからwidthオプションで渡される。フォールバック用 */
 const DEFAULT_WIDTH = 640;
-const DEFAULT_HEIGHT = 48;
+const DEFAULT_HEIGHT = MAIN_LAYOUT.PHASE_RAIL_HEIGHT;
 const TAB_HEIGHT = 40;
 const TAB_SPACING = 8;
 const PADDING_X = 16;


### PR DESCRIPTION
## Summary
- `layout.ts`の`MAIN_LAYOUT`に`HUD_HEIGHT`, `PHASE_RAIL_HEIGHT`, `CONTEXT_PANEL_WIDTH`, `CONTEXT_PANEL_PADDING`を追加
- MainScene内のローカル定数(`PHASE_RAIL_HEIGHT`, `CONTEXT_PANEL_WIDTH`, `CONTEXT_PANEL_PADDING`)を`LAYOUT.*`参照に統合
- HUDBar, PhaseRail, ContextPanelのDEFAULT定数を`MAIN_LAYOUT`参照に変更
- FooterUI, SidebarUIのローカルレイアウト定数を`MAIN_LAYOUT`参照に変更

## Test plan
- [x] `pnpm typecheck` パス
- [x] `pnpm test -- --run` 全171ファイル/2896テストパス
- [x] `pnpm lint` エラーなし
- [x] grep検証で旧定数がMainSceneに残っていないことを確認

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)