### PR TITLE
fix: GatheringPhaseUI/GatheringResultPanelのCONTENT_CENTER_Xを作業領域中央に修正

### DIFF
--- a/atelier-guild-rank/src/features/gathering/components/GatheringMaterialPool.ts
+++ b/atelier-guild-rank/src/features/gathering/components/GatheringMaterialPool.ts
@@ -6,13 +6,15 @@
  * 6スロット（2行3列）の素材プール表示・更新・選択を管理する。
  */
 
+import { CONTENT_WORK_CENTER_X } from '@shared/constants/layout';
 import type { MaterialId, Quality } from '@shared/types';
 import type Phaser from 'phaser';
 import { type MaterialDisplay, MaterialSlotUI } from './MaterialSlotUI';
 
 /** 素材プールのレイアウト定数 */
 const POOL_LAYOUT = {
-  START_X: 320,
+  /** 3列グリッドの開始X（中央列がCONTENT_WORK_CENTER_Xに揃う） */
+  START_X: CONTENT_WORK_CENTER_X - 120,
   START_Y: 150,
   SPACING_X: 120,
   SPACING_Y: 120,

--- a/atelier-guild-rank/src/features/gathering/components/GatheringPhaseUI.ts
+++ b/atelier-guild-rank/src/features/gathering/components/GatheringPhaseUI.ts
@@ -7,6 +7,7 @@ import type {
 } from '@domain/interfaces/gathering-service.interface';
 import { Colors, THEME, toColorStr } from '@presentation/ui/theme';
 import { BaseComponent } from '@shared/components';
+import { CONTENT_WORK_CENTER_X } from '@shared/constants/layout';
 import type Phaser from 'phaser';
 import { calculateExtraGatheringApCost } from '../services/extra-gathering-ap-cost';
 import type { IGatheringLocation, ILocationSelectResult } from '../types/gathering-location';
@@ -17,8 +18,6 @@ import { GatheringResultPanel } from './GatheringResultPanel';
 import { GatheringToolbar } from './GatheringToolbar';
 import { LocationSelectUI } from './LocationSelectUI';
 import type { MaterialDisplay } from './MaterialSlotUI';
-
-const CONTENT_CENTER_X = 440;
 
 export class GatheringPhaseUI extends BaseComponent {
   private materialPool!: GatheringMaterialPool;
@@ -87,7 +86,7 @@ export class GatheringPhaseUI extends BaseComponent {
   private makeText(y: number, text: string, size: number, color: number, bold = false) {
     const t = this.scene.make
       .text({
-        x: CONTENT_CENTER_X,
+        x: CONTENT_WORK_CENTER_X,
         y,
         text,
         style: {

--- a/atelier-guild-rank/src/features/gathering/components/GatheringResultPanel.ts
+++ b/atelier-guild-rank/src/features/gathering/components/GatheringResultPanel.ts
@@ -8,12 +8,13 @@
 
 import type { MaterialInstance } from '@domain/entities/MaterialInstance';
 import { THEME, toColorStr } from '@presentation/ui/theme';
+import { CONTENT_WORK_CENTER_X } from '@shared/constants/layout';
 import type Phaser from 'phaser';
 
 /** 獲得素材パネルのレイアウト定数 */
 const RESULT_LAYOUT = {
   /** コンテンツ中央X */
-  CONTENT_CENTER_X: 440,
+  CONTENT_CENTER_X: CONTENT_WORK_CENTER_X,
   /** タイトルY */
   TITLE_Y: 370,
   /** 素材表示Y */
@@ -22,8 +23,8 @@ const RESULT_LAYOUT = {
   COLUMNS: 4,
   /** 列間隔 */
   COLUMN_WIDTH: 130,
-  /** アイテム開始X（4列を中央揃え） */
-  ITEM_START_X: 180,
+  /** アイテム開始X（4列を中央揃え: CONTENT_WORK_CENTER_X - 1.5 * COLUMN_WIDTH） */
+  ITEM_START_X: CONTENT_WORK_CENTER_X - 1.5 * 130,
   /** 行高さ */
   LINE_HEIGHT: 30,
 } as const;

--- a/atelier-guild-rank/src/features/gathering/components/GatheringResultPanel.ts
+++ b/atelier-guild-rank/src/features/gathering/components/GatheringResultPanel.ts
@@ -13,8 +13,6 @@ import type Phaser from 'phaser';
 
 /** 獲得素材パネルのレイアウト定数 */
 const RESULT_LAYOUT = {
-  /** コンテンツ中央X */
-  CONTENT_CENTER_X: CONTENT_WORK_CENTER_X,
   /** タイトルY */
   TITLE_Y: 370,
   /** 素材表示Y */
@@ -52,7 +50,7 @@ export class GatheringResultPanel {
   create(): void {
     const gatheredTitle = this.scene.make
       .text({
-        x: RESULT_LAYOUT.CONTENT_CENTER_X,
+        x: CONTENT_WORK_CENTER_X,
         y: RESULT_LAYOUT.TITLE_Y,
         text: '獲得素材:',
         style: {

--- a/atelier-guild-rank/src/shared/constants/index.ts
+++ b/atelier-guild-rank/src/shared/constants/index.ts
@@ -36,4 +36,4 @@ export {
   KEYBINDINGS,
   type KeybindingAction,
 } from './keybindings';
-export { MAIN_LAYOUT } from './layout';
+export { CONTENT_WORK_CENTER_X, MAIN_LAYOUT } from './layout';

--- a/atelier-guild-rank/src/shared/constants/layout.ts
+++ b/atelier-guild-rank/src/shared/constants/layout.ts
@@ -22,4 +22,13 @@ export const MAIN_LAYOUT = {
   CONTEXT_PANEL_PADDING: 8,
   /** フッター高さ */
   FOOTER_HEIGHT: 120,
+  /** ゲーム画面幅 */
+  GAME_WIDTH: 1280,
 } as const;
+
+/**
+ * ContentContainer内の作業領域中央X座標（ContextPanel領域を除く）
+ * 計算: (GAME_WIDTH - SIDEBAR_WIDTH - CONTEXT_PANEL_WIDTH) / 2 = (1280 - 200 - 260) / 2 = 410
+ */
+export const CONTENT_WORK_CENTER_X =
+  (MAIN_LAYOUT.GAME_WIDTH - MAIN_LAYOUT.SIDEBAR_WIDTH - MAIN_LAYOUT.CONTEXT_PANEL_WIDTH) / 2;


### PR DESCRIPTION
## Summary
- `CONTENT_CENTER_X = 440` を `CONTENT_WORK_CENTER_X = 410` に修正（ContentContainer内の作業領域中央に合わせる）
- `layout.ts` に `GAME_WIDTH` と `CONTENT_WORK_CENTER_X` 定数を追加し、座標計算を一元管理
- `GatheringMaterialPool.START_X` と `GatheringResultPanel.ITEM_START_X` も作業領域中央基準で再計算

Closes #487

## Test plan
- [x] 全ユニットテスト(2896件)パス
- [x] 型チェックパス
- [x] リントチェックパス
- [ ] 採取フェーズのテキスト・素材グリッドが画面中央に対称配置されること
- [ ] 結果パネルの獲得素材表示が中央揃えになっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)