### PR TITLE
fix: ContentContainer作業領域のContextPanel重なりを修正 (#490)

### DIFF
--- a/atelier-guild-rank/src/features/alchemy/components/AlchemyCraftPanel.ts
+++ b/atelier-guild-rank/src/features/alchemy/components/AlchemyCraftPanel.ts
@@ -2,7 +2,7 @@
 
 import type { RexRoundRectangle, RexUIPlugin } from '@presentation/types/rexui';
 import { THEME } from '@presentation/ui/theme';
-import { MAIN_LAYOUT } from '@shared/constants';
+import { CONTENT_WORK_WIDTH, MAIN_LAYOUT } from '@shared/constants';
 import type { Quality } from '@shared/types';
 import type Phaser from 'phaser';
 
@@ -23,11 +23,10 @@ export class AlchemyCraftPanel {
   ) {}
 
   create(): void {
-    const gameWidth = this.scene.cameras.main.width;
     const gameHeight = this.scene.cameras.main.height;
     const buttonWidth = 180;
     const buttonHeight = 44;
-    const buttonX = gameWidth - MAIN_LAYOUT.SIDEBAR_WIDTH - buttonWidth / 2 - 20;
+    const buttonX = CONTENT_WORK_WIDTH - buttonWidth / 2 - 20;
     const buttonY = gameHeight - MAIN_LAYOUT.HEADER_HEIGHT - MAIN_LAYOUT.FOOTER_HEIGHT - 30;
 
     this.craftButtonContainer = this.scene.add.container(buttonX, buttonY);

--- a/atelier-guild-rank/src/shared/constants/index.ts
+++ b/atelier-guild-rank/src/shared/constants/index.ts
@@ -36,4 +36,4 @@ export {
   KEYBINDINGS,
   type KeybindingAction,
 } from './keybindings';
-export { CONTENT_WORK_CENTER_X, MAIN_LAYOUT } from './layout';
+export { CONTENT_WORK_CENTER_X, CONTENT_WORK_WIDTH, MAIN_LAYOUT } from './layout';

--- a/atelier-guild-rank/src/shared/constants/layout.ts
+++ b/atelier-guild-rank/src/shared/constants/layout.ts
@@ -27,8 +27,14 @@ export const MAIN_LAYOUT = {
 } as const;
 
 /**
- * ContentContainer内の作業領域中央X座標（ContextPanel領域を除く）
- * 計算: (GAME_WIDTH - SIDEBAR_WIDTH - CONTEXT_PANEL_WIDTH) / 2 = (1280 - 200 - 260) / 2 = 410
+ * ContentContainer内の作業領域幅（ContextPanel領域を除く）
+ * 計算: GAME_WIDTH - SIDEBAR_WIDTH - CONTEXT_PANEL_WIDTH = 1280 - 200 - 260 = 820
  */
-export const CONTENT_WORK_CENTER_X =
-  (MAIN_LAYOUT.GAME_WIDTH - MAIN_LAYOUT.SIDEBAR_WIDTH - MAIN_LAYOUT.CONTEXT_PANEL_WIDTH) / 2;
+export const CONTENT_WORK_WIDTH =
+  MAIN_LAYOUT.GAME_WIDTH - MAIN_LAYOUT.SIDEBAR_WIDTH - MAIN_LAYOUT.CONTEXT_PANEL_WIDTH;
+
+/**
+ * ContentContainer内の作業領域中央X座標（ContextPanel領域を除く）
+ * 計算: CONTENT_WORK_WIDTH / 2 = 820 / 2 = 410
+ */
+export const CONTENT_WORK_CENTER_X = CONTENT_WORK_WIDTH / 2;

--- a/atelier-guild-rank/src/shared/presentation/ui/phases/DeliveryPhaseUI.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/phases/DeliveryPhaseUI.ts
@@ -8,6 +8,7 @@
  */
 
 import { THEME } from '@presentation/ui/theme';
+import { CONTENT_WORK_CENTER_X, CONTENT_WORK_WIDTH } from '@shared/constants';
 import type Phaser from 'phaser';
 import { BaseComponent } from '../components/BaseComponent';
 import {
@@ -35,7 +36,7 @@ const UI_LAYOUT = {
   COMPONENT_X: 0,
   COMPONENT_Y: 0,
   /** タイトルX座標（コンテンツ領域の視覚的中央） */
-  TITLE_X: 440,
+  TITLE_X: CONTENT_WORK_CENTER_X,
   /** タイトルY座標 */
   TITLE_Y: 20,
   /** サブコンポーネントの左余白 */
@@ -46,9 +47,9 @@ const UI_LAYOUT = {
   ITEM_SELECTOR_Y: 390,
   PREVIEW_Y: 300,
   // Issue #453: プレビュー領域（X=20〜480, Y=300〜380 付近）と重ならないよう右側に配置
-  BUTTON_X: 620,
+  BUTTON_X: CONTENT_WORK_WIDTH - 200,
   BUTTON_Y: 340,
-  RESULT_PANEL_X: 400,
+  RESULT_PANEL_X: CONTENT_WORK_CENTER_X,
   RESULT_PANEL_Y: 250,
 } as const;
 

--- a/atelier-guild-rank/src/shared/presentation/ui/phases/QuestAcceptPhaseUI.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/phases/QuestAcceptPhaseUI.ts
@@ -17,7 +17,7 @@
 
 import { Quest } from '@domain/entities/Quest';
 import { ScrollableContainer } from '@shared/components/ScrollableContainer';
-import { MAIN_LAYOUT } from '@shared/constants';
+import { CONTENT_WORK_CENTER_X, CONTENT_WORK_WIDTH, MAIN_LAYOUT } from '@shared/constants';
 import { getSelectionIndexFromKey, isKeyForAction } from '@shared/constants/keybindings';
 import { GameEventType } from '@shared/types/events';
 import type { IActiveQuest } from '@shared/types/quests';
@@ -248,7 +248,7 @@ export class QuestAcceptPhaseUI extends BaseComponent {
    * - 定数化されたスタイルで統一感を保つ
    */
   private createTitle(): void {
-    this.titleText = this.scene.add.text(440, 20, QuestAcceptPhaseUI.TITLE_TEXT, {
+    this.titleText = this.scene.add.text(CONTENT_WORK_CENTER_X, 20, QuestAcceptPhaseUI.TITLE_TEXT, {
       fontSize: QuestAcceptPhaseUI.TITLE_FONT_SIZE,
       color: QuestAcceptPhaseUI.TITLE_COLOR,
       fontStyle: 'bold',
@@ -844,13 +844,19 @@ export class QuestAcceptPhaseUI extends BaseComponent {
     this.destroyAcceptedSectionHeader();
 
     // 区切り線（タイトルの上に十分な余白を確保）
-    this.acceptedSectionDivider = this.scene.add.rectangle(440, sectionY, 700, 2, 0xcccccc);
+    this.acceptedSectionDivider = this.scene.add.rectangle(
+      CONTENT_WORK_CENTER_X,
+      sectionY,
+      CONTENT_WORK_WIDTH - 120,
+      2,
+      0xcccccc,
+    );
     targetContainer.add(this.acceptedSectionDivider);
 
     // セクションタイトル（区切り線の下に配置）
     // Issue #441: Phaserテキスト描画で日本語文字上部が見切れる問題をpaddingで対策
     this.acceptedSectionTitle = this.scene.add.text(
-      440,
+      CONTENT_WORK_CENTER_X,
       sectionY + 15,
       QuestAcceptPhaseUI.ACCEPTED_SECTION_TITLE,
       {
@@ -920,14 +926,13 @@ export class QuestAcceptPhaseUI extends BaseComponent {
    * 【カードスクロールエリア作成】: ScrollableContainerを使用してスクロール可能エリアを作成
    */
   private createCardScrollArea(): void {
-    const gameWidth = this.scene.cameras?.main?.width ?? 1280;
     const gameHeight = this.scene.cameras?.main?.height ?? 720;
 
     this.scrollableContainer = new ScrollableContainer(this.scene, this.container, {
       maskBounds: {
         x: MAIN_LAYOUT.SIDEBAR_WIDTH,
         y: MAIN_LAYOUT.HEADER_HEIGHT + QuestAcceptPhaseUI.CARD_AREA_OFFSET_Y,
-        width: gameWidth - MAIN_LAYOUT.SIDEBAR_WIDTH,
+        width: CONTENT_WORK_WIDTH,
         height:
           gameHeight -
           MAIN_LAYOUT.HEADER_HEIGHT -


### PR DESCRIPTION
## Summary
- `CONTENT_WORK_WIDTH`(820px)定数を追加し、ContextPanel領域を除いたContentContainer作業幅を明示的に定義
- QuestAcceptPhaseUI・AlchemyCraftPanel・DeliveryPhaseUIのハードコード座標を`CONTENT_WORK_CENTER_X`/`CONTENT_WORK_WIDTH`ベースに統一
- マスク幅やボタン配置がContextPanel領域にはみ出さないよう修正

## Test plan
- [x] 型チェック（`pnpm typecheck`）パス
- [x] リント（変更ファイルのbiome check）パス
- [x] ユニットテスト（alchemy関連120テスト）パス
- [ ] ビジュアル確認: 各フェーズ画面でUI要素がContextPanelと重ならないこと

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)