### PR TITLE
fix: FooterUI幅を1024ハードコードからMAIN_LAYOUT.GAME_WIDTH参照に修正

### DIFF
--- a/atelier-guild-rank/src/shared/components/FooterUI.ts
+++ b/atelier-guild-rank/src/shared/components/FooterUI.ts
@@ -47,8 +47,8 @@ const FOOTER_COLORS = {
  * Issue #486: 幅・高さは MAIN_LAYOUT から参照
  */
 const FOOTER_LAYOUT = {
-  /** フッター幅（画面幅 - サイドバー幅） — 注: 実際の幅は画面サイズ依存。この値はフォールバック */
-  WIDTH: 1024 - MAIN_LAYOUT.SIDEBAR_WIDTH,
+  /** フッター幅（画面幅 - サイドバー幅） */
+  WIDTH: MAIN_LAYOUT.GAME_WIDTH - MAIN_LAYOUT.SIDEBAR_WIDTH,
   /** フッター高さ */
   HEIGHT: MAIN_LAYOUT.FOOTER_HEIGHT,
   /** パディング */


### PR DESCRIPTION
## Summary
- FooterUI内の`FOOTER_LAYOUT.WIDTH`が旧画面サイズ`1024px`をハードコードしていたのを`MAIN_LAYOUT.GAME_WIDTH`参照に修正
- これにより1280px画面で右側256pxの余白が解消される

Closes #484

## Test plan
- [x] 全ユニットテスト通過（2916 passed）
- [x] 型チェック通過
- [x] リントチェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)