### PR TITLE
fix: SidebarUI高さを768ハードコードからMAIN_LAYOUT.GAME_HEIGHT参照に修正

### DIFF
--- a/atelier-guild-rank/src/shared/components/SidebarUI.ts
+++ b/atelier-guild-rank/src/shared/components/SidebarUI.ts
@@ -58,8 +58,8 @@ const COLORS = {
 const SIDEBAR_LAYOUT = {
   /** サイドバー幅 */
   WIDTH: MAIN_LAYOUT.SIDEBAR_WIDTH,
-  /** サイドバー高さ（画面高さ - ヘッダー高さ） — 注: 実際の画面高さは実行時依存 */
-  HEIGHT: 768 - MAIN_LAYOUT.HEADER_HEIGHT,
+  /** サイドバー高さ（画面高さ - ヘッダー高さ） */
+  HEIGHT: MAIN_LAYOUT.GAME_HEIGHT - MAIN_LAYOUT.HEADER_HEIGHT,
   /** パディング */
   PADDING: 12,
   /** セクション間隔 */

--- a/atelier-guild-rank/src/shared/constants/layout.ts
+++ b/atelier-guild-rank/src/shared/constants/layout.ts
@@ -24,6 +24,8 @@ export const MAIN_LAYOUT = {
   FOOTER_HEIGHT: 120,
   /** ゲーム画面幅 */
   GAME_WIDTH: 1280,
+  /** ゲーム画面高さ */
+  GAME_HEIGHT: 720,
 } as const;
 
 /**


### PR DESCRIPTION
## Summary
- `MAIN_LAYOUT`に`GAME_HEIGHT: 720`を追加
- SidebarUI内の`SIDEBAR_LAYOUT.HEIGHT`が旧画面サイズ`768px`をハードコードしていたのを`MAIN_LAYOUT.GAME_HEIGHT`参照に修正
- これによりフッターとの168px重なりが解消される

Closes #485

## Test plan
- [x] 全ユニットテスト通過（2916 passed）
- [x] 型チェック通過
- [x] リントチェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)