### PR TITLE
refactor: AlchemyPhaseUIのハードコード座標440をCONTENT_WORK_CENTER_Xに統一

### DIFF
--- a/atelier-guild-rank/src/features/alchemy/components/AlchemyPhaseUI.ts
+++ b/atelier-guild-rank/src/features/alchemy/components/AlchemyPhaseUI.ts
@@ -5,6 +5,7 @@ import type { MaterialInstance } from '@domain/entities/MaterialInstance';
 import type { IAlchemyService } from '@domain/interfaces/alchemy-service.interface';
 import { BaseComponent } from '@presentation/ui/components/BaseComponent';
 import { THEME } from '@presentation/ui/theme';
+import { CONTENT_WORK_CENTER_X } from '@shared/constants/layout';
 import type { CardId, Quality } from '@shared/types';
 
 import type Phaser from 'phaser';
@@ -70,7 +71,7 @@ export class AlchemyPhaseUI extends BaseComponent {
   private createTitle(): void {
     const titleText = this.scene.make
       .text({
-        x: 440,
+        x: CONTENT_WORK_CENTER_X,
         y: 20,
         text: '⚗️ 調合フェーズ',
         style: {


### PR DESCRIPTION
## Summary
- `AlchemyPhaseUI.ts`のタイトル座標`440`を`CONTENT_WORK_CENTER_X`定数に置換
- `HeaderUI.ts`の`440`はヘッダー内のゴールド表示位置（ContentContainer外）のため変更対象外
- `DeliveryPhaseUI.ts`、`QuestAcceptPhaseUI.ts`、`HUDBar.ts`は既に修正済み

Closes #494

## Test plan
- [x] 全ユニットテスト通過（2916 passed）
- [x] 型チェック通過
- [x] リントチェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)