### PR TITLE
fix: フェーズ遷移時の説明テキストを削除

### DIFF
--- a/atelier-guild-rank/src/scenes/MainScene.ts
+++ b/atelier-guild-rank/src/scenes/MainScene.ts
@@ -32,7 +32,6 @@ import {
   createQuestServiceAdapter,
 } from '@shared/services/delivery-phase-adapters';
 import { Container, ServiceKeys } from '@shared/services/di/container';
-import { getPhaseConditionText } from '@shared/services/game-flow/phase-condition-text';
 import { GamePhase } from '@shared/types/common';
 import type {
   GameEndStats,
@@ -227,9 +226,6 @@ export class MainScene extends Phaser.Scene {
 
     // サイドバーの初期更新
     this.phaseManager.updateSidebar(this.sidebarUI);
-
-    // Issue #471: 到達条件テキストの初期設定
-    this.updatePhaseConditionText(initialPhase);
   }
 
   // ===========================================================================
@@ -375,8 +371,6 @@ export class MainScene extends Phaser.Scene {
         this.updateHeader();
         // Issue #458 Phase 4 A: PhaseRailのアクティブタブを更新
         this.phaseRail.setCurrent(busEvent.payload.newPhase);
-        // Issue #471: 到達条件テキストを更新
-        this.updatePhaseConditionText(busEvent.payload.newPhase);
       }),
     );
 
@@ -529,15 +523,6 @@ export class MainScene extends Phaser.Scene {
     this.gameFlowManager.switchPhase({ targetPhase: GamePhase.GATHERING }).catch(() => {
       // 遷移失敗時は何もしない（採取セッション中など）
     });
-  }
-
-  /**
-   * 到達条件テキストを更新する
-   */
-  private updatePhaseConditionText(phase: GamePhase): void {
-    const hasActiveQuests = this.questService.getActiveQuests().length > 0;
-    const conditionText = getPhaseConditionText(phase, hasActiveQuests);
-    this.phaseRail.setConditionText(conditionText);
   }
 
   // ===========================================================================

--- a/atelier-guild-rank/src/shared/services/game-flow/phase-condition-text.ts
+++ b/atelier-guild-rank/src/shared/services/game-flow/phase-condition-text.ts
@@ -1,6 +1,7 @@
 /**
  * phase-condition-text.ts
  * Issue #471: フェーズ遷移の到達条件テキストを決定する純粋関数
+ * Issue #498: 説明テキストは不要のため常に空文字を返す
  *
  * Functional Core: 副作用なし、入力のみに依存
  */
@@ -9,27 +10,15 @@ import type { GamePhase } from '@shared/types/common';
 
 /**
  * 現在のフェーズと状態から、次フェーズへの到達条件テキストを返す
+ * Issue #498: 説明テキストは不要のため常に空文字を返す
  *
- * @param currentPhase - 現在のフェーズ
- * @param hasActiveQuests - 受注中の依頼があるか
- * @returns 到達条件テキスト（条件なしの場合は空文字）
+ * @param _currentPhase - 現在のフェーズ（未使用）
+ * @param _hasActiveQuests - 受注中の依頼があるか（未使用）
+ * @returns 空文字（条件テキストは表示しない）
  */
 export function getPhaseConditionText(
-  currentPhase: GamePhase | string,
-  hasActiveQuests: boolean,
+  _currentPhase: GamePhase | string,
+  _hasActiveQuests: boolean,
 ): string {
-  switch (currentPhase) {
-    case 'QUEST_ACCEPT':
-      return hasActiveQuests
-        ? '→ 依頼を受注済み。採取に進めます'
-        : '→ 依頼を受注すると採取に進めます';
-    case 'GATHERING':
-      return '→ 素材を集めたら調合に進めます';
-    case 'ALCHEMY':
-      return '→ アイテムを調合したら納品に進めます';
-    case 'DELIVERY':
-      return '';
-    default:
-      return '';
-  }
+  return '';
 }

--- a/atelier-guild-rank/tests/unit/shared/services/game-flow/phase-condition-text.test.ts
+++ b/atelier-guild-rank/tests/unit/shared/services/game-flow/phase-condition-text.test.ts
@@ -1,42 +1,22 @@
 /**
  * phase-condition-text テスト
  * Issue #471: フェーズ到達条件テキストの純粋関数テスト
+ * Issue #498: 説明テキストは不要のため常に空文字を返す
  */
 import { getPhaseConditionText } from '@shared/services/game-flow/phase-condition-text';
 import { describe, expect, it } from 'vitest';
 
 describe('getPhaseConditionText', () => {
-  describe('正常系', () => {
-    it('QUEST_ACCEPT で受注なしの場合、受注を促すテキストを返す', () => {
-      const text = getPhaseConditionText('QUEST_ACCEPT', false);
-      expect(text).toBe('→ 依頼を受注すると採取に進めます');
-    });
-
-    it('QUEST_ACCEPT で受注済みの場合、採取に進めるテキストを返す', () => {
-      const text = getPhaseConditionText('QUEST_ACCEPT', true);
-      expect(text).toBe('→ 依頼を受注済み。採取に進めます');
-    });
-
-    it('GATHERING の場合、調合への条件テキストを返す', () => {
-      const text = getPhaseConditionText('GATHERING', false);
-      expect(text).toBe('→ 素材を集めたら調合に進めます');
-    });
-
-    it('ALCHEMY の場合、納品への条件テキストを返す', () => {
-      const text = getPhaseConditionText('ALCHEMY', false);
-      expect(text).toBe('→ アイテムを調合したら納品に進めます');
-    });
-
-    it('DELIVERY の場合、空文字を返す', () => {
-      const text = getPhaseConditionText('DELIVERY', false);
-      expect(text).toBe('');
-    });
-  });
-
-  describe('異常系', () => {
-    it('未知のフェーズの場合、空文字を返す', () => {
-      const text = getPhaseConditionText('UNKNOWN_PHASE', false);
-      expect(text).toBe('');
+  describe('Issue #498: 全フェーズで空文字を返す', () => {
+    it.each([
+      ['QUEST_ACCEPT', false],
+      ['QUEST_ACCEPT', true],
+      ['GATHERING', false],
+      ['ALCHEMY', false],
+      ['DELIVERY', false],
+      ['UNKNOWN_PHASE', false],
+    ] as const)('フェーズ %s (hasActiveQuests=%s) で空文字を返す', (phase, hasActiveQuests) => {
+      expect(getPhaseConditionText(phase, hasActiveQuests)).toBe('');
     });
   });
 });


### PR DESCRIPTION
## Summary
- MainSceneから`updatePhaseConditionText`メソッドと呼び出しを削除
- `getPhaseConditionText`関数を常に空文字返却に変更
- テストを空文字期待に更新

Closes #498

## Test plan
- [x] 全ユニットテスト通過（2916 passed）
- [x] 型チェック通過
- [x] リントチェック通過（既存e2eファイルのワーニングのみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)