### PR TITLE
fix: 依頼受注フェーズのカード配置をCONTENT_WORK_WIDTH内に収める

### DIFF
--- a/atelier-guild-rank/src/shared/presentation/ui/phases/QuestAcceptPhaseUI.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/phases/QuestAcceptPhaseUI.ts
@@ -144,9 +144,11 @@ export class QuestAcceptPhaseUI extends BaseComponent {
    * 【設計方針】: 定数化により、将来的なデザイン変更時の保守性を向上
    */
   private static readonly GRID_COLUMNS = 3;
-  private static readonly GRID_START_X = 200;
+  /** グリッド列間隔: CONTENT_WORK_WIDTH(820) / 3 ≈ 260で3カードが収まる */
+  private static readonly GRID_SPACING_X = 260;
+  /** グリッド開始X: 中央から左に1列分オフセット = CONTENT_WORK_CENTER_X - GRID_SPACING_X */
+  private static readonly GRID_START_X = CONTENT_WORK_CENTER_X - 260;
   private static readonly GRID_START_Y = 150;
-  private static readonly GRID_SPACING_X = 300;
   private static readonly GRID_SPACING_Y = 200;
 
   /**
@@ -178,8 +180,9 @@ export class QuestAcceptPhaseUI extends BaseComponent {
   private static readonly ACCEPTED_SECTION_TITLE = '📌 受注済み依頼';
   private static readonly ACCEPTED_SECTION_FONT_SIZE = '20px';
   private static readonly ACCEPTED_SECTION_COLOR = '#333333';
-  private static readonly ACCEPTED_CARD_START_X = 200;
-  private static readonly ACCEPTED_CARD_SPACING_X = 300;
+  /** 受注済みカード開始X: グリッドと同じ配置 */
+  private static readonly ACCEPTED_CARD_START_X = CONTENT_WORK_CENTER_X - 260;
+  private static readonly ACCEPTED_CARD_SPACING_X = 260;
 
   /**
    * 【コンストラクタ】: 依頼受注フェーズUIを初期化

--- a/atelier-guild-rank/tests/integration/quest-accept-phase.spec.ts
+++ b/atelier-guild-rank/tests/integration/quest-accept-phase.spec.ts
@@ -223,10 +223,10 @@ describe('依頼受注フェーズ統合テスト', () => {
       phaseUI.create();
       phaseUI.updateQuests(dailyQuests);
 
-      expect((phaseUI as any).questCards[0].getContainer().x).toBe(200);
+      expect((phaseUI as any).questCards[0].getContainer().x).toBe(150);
       expect((phaseUI as any).questCards[0].getContainer().y).toBe(150);
-      expect((phaseUI as any).questCards[1].getContainer().x).toBe(500);
-      expect((phaseUI as any).questCards[2].getContainer().x).toBe(800);
+      expect((phaseUI as any).questCards[1].getContainer().x).toBe(410);
+      expect((phaseUI as any).questCards[2].getContainer().x).toBe(670);
     });
 
     test('各カードに依頼者名、報酬情報が表示される', () => {

--- a/atelier-guild-rank/tests/unit/presentation/ui/phases/QuestAcceptPhaseUI.spec.ts
+++ b/atelier-guild-rank/tests/unit/presentation/ui/phases/QuestAcceptPhaseUI.spec.ts
@@ -278,15 +278,15 @@ describe('QuestAcceptPhaseUI', () => {
       phaseUI.updateQuests(mockQuests);
 
       // biome-ignore lint/suspicious/noExplicitAny: テストでprivateプロパティにアクセスするために必要
-      expect((phaseUI as any).questCards[0].getContainer().x).toBe(200);
+      expect((phaseUI as any).questCards[0].getContainer().x).toBe(150);
       // biome-ignore lint/suspicious/noExplicitAny: テストでprivateプロパティにアクセスするために必要
       expect((phaseUI as any).questCards[0].getContainer().y).toBe(150);
       // biome-ignore lint/suspicious/noExplicitAny: テストでprivateプロパティにアクセスするために必要
-      expect((phaseUI as any).questCards[1].getContainer().x).toBe(500);
+      expect((phaseUI as any).questCards[1].getContainer().x).toBe(410);
       // biome-ignore lint/suspicious/noExplicitAny: テストでprivateプロパティにアクセスするために必要
       expect((phaseUI as any).questCards[1].getContainer().y).toBe(150);
       // biome-ignore lint/suspicious/noExplicitAny: テストでprivateプロパティにアクセスするために必要
-      expect((phaseUI as any).questCards[2].getContainer().x).toBe(800);
+      expect((phaseUI as any).questCards[2].getContainer().x).toBe(670);
       // biome-ignore lint/suspicious/noExplicitAny: テストでprivateプロパティにアクセスするために必要
       expect((phaseUI as any).questCards[2].getContainer().y).toBe(150);
     });
@@ -608,17 +608,17 @@ describe('QuestAcceptPhaseUI', () => {
 
       // Quest 1-3: y=150
       // biome-ignore lint/suspicious/noExplicitAny: テストでprivateプロパティにアクセスするために必要
-      expect((phaseUI as any).questCards[0].getContainer().x).toBe(200);
+      expect((phaseUI as any).questCards[0].getContainer().x).toBe(150);
       // biome-ignore lint/suspicious/noExplicitAny: テストでprivateプロパティにアクセスするために必要
       expect((phaseUI as any).questCards[0].getContainer().y).toBe(150);
       // Quest 4-6: y=350
       // biome-ignore lint/suspicious/noExplicitAny: テストでprivateプロパティにアクセスするために必要
-      expect((phaseUI as any).questCards[3].getContainer().x).toBe(200);
+      expect((phaseUI as any).questCards[3].getContainer().x).toBe(150);
       // biome-ignore lint/suspicious/noExplicitAny: テストでprivateプロパティにアクセスするために必要
       expect((phaseUI as any).questCards[3].getContainer().y).toBe(350);
       // Quest 7: y=550
       // biome-ignore lint/suspicious/noExplicitAny: テストでprivateプロパティにアクセスするために必要
-      expect((phaseUI as any).questCards[6].getContainer().x).toBe(200);
+      expect((phaseUI as any).questCards[6].getContainer().x).toBe(150);
       // biome-ignore lint/suspicious/noExplicitAny: テストでprivateプロパティにアクセスするために必要
       expect((phaseUI as any).questCards[6].getContainer().y).toBe(550);
     });


### PR DESCRIPTION
## Summary
- `GRID_SPACING_X`を300→260に縮小し、`GRID_START_X`を`CONTENT_WORK_CENTER_X`ベースの計算に変更
- 3つ目のカードがContextPanel領域と重ならないようにカード配置を修正
- 受注済みカードの配置も同様に修正

Closes #499

## Test plan
- [x] 全ユニットテスト通過（2916 passed）
- [x] 型チェック通過
- [x] 統合テストの座標期待値を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)