### PR TITLE
design: PhaseRail/PhaseTabUIの色をデザインガイドに統一 (#512)

### DIFF
--- a/atelier-guild-rank/src/shared/components/PhaseTabUI.ts
+++ b/atelier-guild-rank/src/shared/components/PhaseTabUI.ts
@@ -12,6 +12,7 @@
 
 import type { IEventBus } from '@shared/services/event-bus/types';
 import type { IGameFlowManager } from '@shared/services/game-flow/game-flow-manager.interface';
+import { Colors, toColorStr } from '@shared/theme';
 import type { GamePhase, IPhaseChangedEvent, IPhaseSwitchRequest } from '@shared/types';
 import { VALID_GAME_PHASES } from '@shared/types/common';
 import { GameEventType } from '@shared/types/events';
@@ -28,26 +29,26 @@ import { BaseComponent } from './BaseComponent';
  * 🔵 信頼性レベル: REQ-006-02・既存PHASE_COLORSより
  */
 const TAB_COLORS = {
-  /** アクティブタブ背景 */
-  ACTIVE: 0x6366f1,
-  /** 非アクティブタブ背景 */
-  INACTIVE: 0x374151,
+  /** アクティブタブ背景（草色） */
+  ACTIVE: Colors.brand.primary,
+  /** 非アクティブタブ背景（サイドバー色） */
+  INACTIVE: Colors.surface.sidebar,
   /** 無効化タブ背景（Issue #434） */
-  DISABLED: 0x1f2937,
+  DISABLED: Colors.ui.button.disabled,
   /** アクティブタブテキスト */
-  ACTIVE_TEXT: '#FFFFFF',
+  ACTIVE_TEXT: toColorStr(Colors.text.onPrimary),
   /** 非アクティブタブテキスト */
-  INACTIVE_TEXT: '#9CA3AF',
+  INACTIVE_TEXT: toColorStr(Colors.text.secondary),
   /** 無効化タブテキスト（Issue #434） */
-  DISABLED_TEXT: '#4B5563',
-  /** 日終了ボタン背景 */
-  END_DAY_BUTTON: 0xef4444,
+  DISABLED_TEXT: toColorStr(Colors.text.disabled),
+  /** 日終了ボタン背景（デンジャー） */
+  END_DAY_BUTTON: Colors.status.error,
   /** 日終了ボタンホバー */
-  END_DAY_BUTTON_HOVER: 0xf87171,
-  /** 休憩ボタン背景 */
-  REST_BUTTON: 0x3b82f6,
+  END_DAY_BUTTON_HOVER: Colors.status.warning,
+  /** 休憩ボタン背景（情報） */
+  REST_BUTTON: Colors.status.info,
   /** 休憩ボタンホバー */
-  REST_BUTTON_HOVER: 0x60a5fa,
+  REST_BUTTON_HOVER: Colors.brand.primary,
 } as const;
 
 /**
@@ -278,7 +279,11 @@ export class PhaseTabUI extends BaseComponent {
       x: endDayX - TAB_LAYOUT.END_DAY_TEXT_OFFSET_X,
       y: TAB_LAYOUT.TAB_Y - TAB_LAYOUT.TEXT_OFFSET_Y,
       text: '日終了',
-      style: { fontSize: '16px', color: '#FFFFFF', fontStyle: 'bold' },
+      style: {
+        fontSize: '16px',
+        color: toColorStr(Colors.text.light),
+        fontStyle: 'bold',
+      },
       add: false,
     });
     this._endDayText.setName('PhaseTabUI.endDayText');
@@ -310,7 +315,11 @@ export class PhaseTabUI extends BaseComponent {
       x: restX - TAB_LAYOUT.REST_TEXT_OFFSET_X,
       y: TAB_LAYOUT.TAB_Y - TAB_LAYOUT.TEXT_OFFSET_Y,
       text: '休憩',
-      style: { fontSize: '16px', color: '#FFFFFF', fontStyle: 'bold' },
+      style: {
+        fontSize: '16px',
+        color: toColorStr(Colors.text.light),
+        fontStyle: 'bold',
+      },
       add: false,
     });
     this._restText.setName('PhaseTabUI.restText');
@@ -562,7 +571,7 @@ export class PhaseTabUI extends BaseComponent {
       text: message,
       style: {
         fontSize: '16px',
-        color: '#F87171',
+        color: toColorStr(Colors.status.error),
         fontStyle: 'bold',
       },
       add: false,

--- a/atelier-guild-rank/src/shared/presentation/ui/components/composite/PhaseRail.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/components/composite/PhaseRail.ts
@@ -21,7 +21,7 @@
 
 import { BaseComponent, type BaseComponentOptions } from '@shared/components';
 import { MAIN_LAYOUT } from '@shared/constants';
-import { DesignTokens } from '@shared/theme';
+import { Colors, DesignTokens, toColorStr } from '@shared/theme';
 import type { GamePhase } from '@shared/types/common';
 import { VALID_GAME_PHASES } from '@shared/types/common';
 import type Phaser from 'phaser';
@@ -52,17 +52,17 @@ export interface PhaseRailOptions extends BaseComponentOptions {
 // 定数
 // =============================================================================
 
-/** タブ用カラー定数（PhaseTabUI と同じ値） */
+/** タブ用カラー定数（DesignTokens/Colors経由） */
 const RAIL_COLORS = {
-  ACTIVE: 0x6366f1,
-  INACTIVE: 0x374151,
-  DISABLED: 0x1f2937,
-  BACKGROUND: 0x111827,
-  BORDER: 0x374151,
-  ACTIVE_TEXT: '#FFFFFF',
-  INACTIVE_TEXT: '#9CA3AF',
-  DISABLED_TEXT: '#4B5563',
-  NOTIFICATION_TEXT: '#F87171',
+  ACTIVE: Colors.brand.primary,
+  INACTIVE: Colors.surface.sidebar,
+  DISABLED: Colors.ui.button.disabled,
+  BACKGROUND: Colors.surface.header,
+  BORDER: Colors.border.subtle,
+  ACTIVE_TEXT: toColorStr(Colors.text.onPrimary),
+  INACTIVE_TEXT: toColorStr(Colors.text.secondary),
+  DISABLED_TEXT: toColorStr(Colors.text.disabled),
+  NOTIFICATION_TEXT: toColorStr(Colors.status.error),
 } as const;
 
 /** @deprecated Issue #486: MainSceneからwidthオプションで渡される。フォールバック用 */
@@ -215,7 +215,7 @@ export class PhaseRail extends BaseComponent {
       text: this._conditionText,
       style: {
         fontSize: '16px',
-        color: '#9CA3AF',
+        color: toColorStr(Colors.text.muted),
         fontStyle: 'normal',
       },
       add: false,


### PR DESCRIPTION
## Summary
- PhaseRail/PhaseTabUIのハードコード色を全てDesignTokens/Colors経由に置き換え
- アクティブタブを草色(brand.primary)、背景をクリーム系(surface.header)に変更

Closes #512

## Test plan
- [x] `pnpm test -- --run` パス (2896 passed)
- [x] `pnpm typecheck` パス
- [x] `pnpm lint` パス (変更ファイルのみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)