### PR TITLE
design: 依頼受注フェーズUIのスタイルをデザインガイドに統一 (#513)

### DIFF
--- a/atelier-guild-rank/src/shared/presentation/ui/components/QuestCardUI.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/components/QuestCardUI.ts
@@ -12,7 +12,7 @@
 import type { Quest } from '@domain/entities/Quest';
 import { formatCondition } from '@shared/utils';
 import type Phaser from 'phaser';
-import { Colors } from '../theme';
+import { Colors, toColorStr } from '../theme';
 import { BaseComponent } from './BaseComponent';
 
 /**
@@ -127,11 +127,11 @@ export class QuestCardUI extends BaseComponent {
       0,
       QuestCardUI.CARD_WIDTH,
       QuestCardUI.CARD_HEIGHT,
-      Colors.background.parchment, // 【背景色】: 淡い黄色（Parchment風）
+      Colors.surface.card, // 【背景色】: カード背景（surface.card）
     );
     // 【型安全性】: setStrokeStyleはテストモックで定義されていないため、存在確認してから呼び出す
     if (this.background.setStrokeStyle) {
-      this.background.setStrokeStyle(2, Colors.border.quest); // 【枠線】: 濃い黄色で強調
+      this.background.setStrokeStyle(2, Colors.border.default); // 【枠線】: 標準ボーダー
     }
     this.container.add(this.background);
   }
@@ -159,7 +159,7 @@ export class QuestCardUI extends BaseComponent {
       displayName,
       {
         fontSize: '16px',
-        color: '#000000',
+        color: toColorStr(Colors.text.primary),
         fontStyle: 'bold',
       },
     );
@@ -191,7 +191,7 @@ export class QuestCardUI extends BaseComponent {
       dialogue,
       {
         fontSize: '16px',
-        color: '#333333',
+        color: toColorStr(Colors.text.primary),
         wordWrap: { width: QuestCardUI.CARD_WIDTH - QuestCardUI.PADDING * 2 },
       },
     );
@@ -219,7 +219,7 @@ export class QuestCardUI extends BaseComponent {
       conditionLabel,
       {
         fontSize: '16px',
-        color: '#1a5276',
+        color: toColorStr(Colors.status.info),
         fontStyle: 'bold',
       },
     );
@@ -252,7 +252,7 @@ export class QuestCardUI extends BaseComponent {
       rewardText,
       {
         fontSize: '16px',
-        color: '#000000',
+        color: toColorStr(Colors.text.primary),
       },
     );
     this.rewardText.setOrigin(0, 0);
@@ -283,7 +283,7 @@ export class QuestCardUI extends BaseComponent {
       deadlineText,
       {
         fontSize: '16px',
-        color: '#666666',
+        color: toColorStr(Colors.text.secondary),
       },
     );
     this.deadlineText.setOrigin(0, 0);

--- a/atelier-guild-rank/src/shared/presentation/ui/phases/QuestAcceptPhaseUI.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/phases/QuestAcceptPhaseUI.ts
@@ -26,6 +26,7 @@ import type { RexScrollablePanel } from '../../types/rexui';
 import { BaseComponent } from '../components/BaseComponent';
 import { QuestCardUI } from '../components/QuestCardUI';
 import { QuestDetailModal } from '../components/QuestDetailModal';
+import { Colors, toColorStr } from '../theme';
 
 /**
  * テスト用モックScrollablePanel型
@@ -171,7 +172,7 @@ export class QuestAcceptPhaseUI extends BaseComponent {
    * 【タイトルスタイル定数】: タイトルテキストのスタイル
    */
   private static readonly TITLE_FONT_SIZE = '24px';
-  private static readonly TITLE_COLOR = '#000000';
+  private static readonly TITLE_COLOR = toColorStr(Colors.text.primary);
   private static readonly TITLE_TEXT = '📋 本日の依頼';
 
   /**
@@ -179,7 +180,7 @@ export class QuestAcceptPhaseUI extends BaseComponent {
    */
   private static readonly ACCEPTED_SECTION_TITLE = '📌 受注済み依頼';
   private static readonly ACCEPTED_SECTION_FONT_SIZE = '20px';
-  private static readonly ACCEPTED_SECTION_COLOR = '#333333';
+  private static readonly ACCEPTED_SECTION_COLOR = toColorStr(Colors.text.primary);
   /** 受注済みカード開始X: グリッドと同じ配置 */
   private static readonly ACCEPTED_CARD_START_X = CONTENT_WORK_CENTER_X - 260;
   private static readonly ACCEPTED_CARD_SPACING_X = 260;
@@ -852,7 +853,7 @@ export class QuestAcceptPhaseUI extends BaseComponent {
       sectionY,
       CONTENT_WORK_WIDTH - 120,
       2,
-      0xcccccc,
+      Colors.border.subtle,
     );
     targetContainer.add(this.acceptedSectionDivider);
 

--- a/atelier-guild-rank/tests/unit/presentation/ui/phases/QuestAcceptPhaseUI-accepted-quests.test.ts
+++ b/atelier-guild-rank/tests/unit/presentation/ui/phases/QuestAcceptPhaseUI-accepted-quests.test.ts
@@ -40,18 +40,27 @@ vi.mock('@presentation/ui/theme', () => ({
     BORDER: 0x888888,
     ACCENT: 0xff9900,
     background: {
-      parchment: 0xf5e6c8,
+      parchment: 0xffffff,
       dark: 0x333333,
     },
+    surface: {
+      card: 0xffffff,
+    },
     border: {
-      quest: 0xc4a35a,
+      quest: 0xd9cfc2,
+      default: 0xd9cfc2,
+      subtle: 0xe8e0d6,
     },
     text: {
-      primary: '#000000',
-      secondary: '#666666',
+      primary: 0x3d3d3d,
+      secondary: 0x5a5a5a,
       light: '#ffffff',
     },
+    status: {
+      info: 0x6b9fcc,
+    },
   },
+  toColorStr: (color: number) => `#${color.toString(16).padStart(6, '0')}`,
 }));
 
 vi.mock('@presentation/ui/components/QuestCardUI', () => ({

--- a/atelier-guild-rank/tests/unit/presentation/ui/phases/QuestAcceptPhaseUI-board-visitor.test.ts
+++ b/atelier-guild-rank/tests/unit/presentation/ui/phases/QuestAcceptPhaseUI-board-visitor.test.ts
@@ -41,18 +41,27 @@ vi.mock('@presentation/ui/theme', () => ({
     BORDER: 0x888888,
     ACCENT: 0xff9900,
     background: {
-      parchment: 0xf5e6c8,
+      parchment: 0xffffff,
       dark: 0x333333,
     },
+    surface: {
+      card: 0xffffff,
+    },
     border: {
-      quest: 0xc4a35a,
+      quest: 0xd9cfc2,
+      default: 0xd9cfc2,
+      subtle: 0xe8e0d6,
     },
     text: {
-      primary: '#000000',
-      secondary: '#666666',
+      primary: 0x3d3d3d,
+      secondary: 0x5a5a5a,
       light: '#ffffff',
     },
+    status: {
+      info: 0x6b9fcc,
+    },
   },
+  toColorStr: (color: number) => `#${color.toString(16).padStart(6, '0')}`,
 }));
 
 vi.mock('@presentation/ui/components/QuestCardUI', () => ({


### PR DESCRIPTION
## Summary
- QuestAcceptPhaseUI/QuestCardUIのハードコード色を全てDesignTokens/Colors経由に置き換え
- カード背景をsurface.card、枠線をborder.defaultに統一
- テキスト色をtext.primary/text.secondary/status.infoに統一

Closes #513

## Test plan
- [x] `pnpm typecheck` パス
- [x] `pnpm lint` パス
- [x] ハードコード色が0件であること確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)