### PR TITLE
design: 採取フェーズUIのスタイルをデザインガイドに統一 (#514)

### DIFF
--- a/atelier-guild-rank/src/features/gathering/components/LocationSelectUI.ts
+++ b/atelier-guild-rank/src/features/gathering/components/LocationSelectUI.ts
@@ -11,7 +11,7 @@
  */
 
 import { BaseComponent } from '@shared/components';
-import { Colors, THEME } from '@shared/theme/theme';
+import { Colors, THEME, toColorStr } from '@shared/theme/theme';
 import type { CardId } from '@shared/types';
 import type {
   DropRateLabel,
@@ -360,7 +360,7 @@ export class LocationSelectUI extends BaseComponent {
       text: '採取地マップ',
       style: {
         fontSize: `${THEME.sizes.large}px`,
-        color: `#${Colors.text.primary.toString(16).padStart(6, '0')}`,
+        color: toColorStr(Colors.text.primary),
         fontStyle: 'bold',
         fontFamily: THEME.fonts.primary,
       },
@@ -401,7 +401,7 @@ export class LocationSelectUI extends BaseComponent {
       text: location.name,
       style: {
         fontSize: `${THEME.sizes.medium}px`,
-        color: `#${Colors.text.primary.toString(16).padStart(6, '0')}`,
+        color: toColorStr(Colors.text.primary),
         fontStyle: 'bold',
         fontFamily: THEME.fonts.primary,
       },
@@ -417,7 +417,7 @@ export class LocationSelectUI extends BaseComponent {
       text: `AP:${location.movementAPCost}`,
       style: {
         fontSize: `${THEME.sizes.small}px`,
-        color: '#B8860B',
+        color: toColorStr(Colors.text.accent),
         fontFamily: THEME.fonts.primary,
       },
       add: false,
@@ -433,7 +433,7 @@ export class LocationSelectUI extends BaseComponent {
       text: materialsStr,
       style: {
         fontSize: `${MAP_LAYOUT.MATERIAL_FONT_SIZE}px`,
-        color: `#${Colors.text.secondary.toString(16).padStart(6, '0')}`,
+        color: toColorStr(Colors.text.secondary),
         fontFamily: THEME.fonts.primary,
       },
       add: false,
@@ -520,7 +520,7 @@ export class LocationSelectUI extends BaseComponent {
         text: EMPTY_HAND_MESSAGE,
         style: {
           fontSize: `${THEME.sizes.medium}px`,
-          color: '#888888',
+          color: toColorStr(Colors.text.muted),
           fontFamily: THEME.fonts.primary,
         },
         add: false,

--- a/atelier-guild-rank/src/features/gathering/components/MaterialSlotUI.ts
+++ b/atelier-guild-rank/src/features/gathering/components/MaterialSlotUI.ts
@@ -16,7 +16,7 @@
 
 import { THEME } from '@presentation/ui/theme';
 import { BaseComponent } from '@shared/components';
-import { prefersReducedMotion } from '@shared/theme';
+import { Colors, prefersReducedMotion, toColorStr } from '@shared/theme';
 import type { MaterialId, Quality } from '@shared/types';
 import Phaser from 'phaser';
 
@@ -115,7 +115,7 @@ export class MaterialSlotUI extends BaseComponent {
         text: '',
         style: {
           fontSize: `${MaterialSlotUI.NAME_DEFAULT_FONT_SIZE}px`,
-          color: '#333333',
+          color: toColorStr(Colors.text.primary),
           wordWrap: { width: this.slotSize - MaterialSlotUI.NAME_TEXT_HORIZONTAL_PADDING },
           align: 'center',
         },
@@ -315,7 +315,10 @@ export class MaterialSlotUI extends BaseComponent {
         text: quality,
         style: {
           fontSize: '16px',
-          color: quality === 'D' || quality === 'S' ? '#FFFFFF' : '#000000',
+          color:
+            quality === 'D' || quality === 'S'
+              ? toColorStr(Colors.text.onPrimary)
+              : toColorStr(Colors.text.primary),
           fontStyle: 'bold',
         },
         add: false,


### PR DESCRIPTION
## Summary
- MaterialSlotUI/LocationSelectUIのハードコード色をDesignTokens/Colors経由に置き換え
- パーティクル白・S品質虹色は特殊用途として許容

Closes #514

## Test plan
- [x] `pnpm test -- --run` パス (2896 passed)
- [x] `pnpm typecheck` パス
- [x] `pnpm lint` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)