### PR TITLE
design: 調合フェーズUIのスタイルをデザインガイドに統一 (#515)

### DIFF
--- a/atelier-guild-rank/src/features/alchemy/components/AlchemyCraftPanel.ts
+++ b/atelier-guild-rank/src/features/alchemy/components/AlchemyCraftPanel.ts
@@ -3,6 +3,7 @@
 import type { RexRoundRectangle, RexUIPlugin } from '@presentation/types/rexui';
 import { THEME } from '@presentation/ui/theme';
 import { CONTENT_WORK_WIDTH, MAIN_LAYOUT } from '@shared/constants';
+import { Colors, toColorStr } from '@shared/theme';
 import type { Quality } from '@shared/types';
 import type Phaser from 'phaser';
 
@@ -44,7 +45,7 @@ export class AlchemyCraftPanel {
       text: '調合実行',
       style: {
         fontSize: `${THEME.sizes.large}px`,
-        color: '#ffffff',
+        color: toColorStr(Colors.text.onPrimary),
         fontFamily: THEME.fonts.primary,
         fontStyle: 'bold',
       },
@@ -60,7 +61,7 @@ export class AlchemyCraftPanel {
       text: '',
       style: {
         fontSize: `${THEME.sizes.medium}px`,
-        color: `#${THEME.colors.text.toString(16).padStart(6, '0')}`,
+        color: toColorStr(Colors.text.primary),
         fontFamily: THEME.fonts.primary,
       },
       add: false,

--- a/atelier-guild-rank/src/features/alchemy/components/AlchemyRecipeGrid.ts
+++ b/atelier-guild-rank/src/features/alchemy/components/AlchemyRecipeGrid.ts
@@ -7,6 +7,7 @@ import { THEME } from '@presentation/ui/theme';
 import { ScrollableContainer } from '@shared/components/ScrollableContainer';
 import { MAIN_LAYOUT } from '@shared/constants';
 import { getSelectionIndexFromKey, isKeyForAction } from '@shared/constants/keybindings';
+import { Colors, toColorStr } from '@shared/theme';
 import type { CardId } from '@shared/types';
 import type { IRecipeCardMaster } from '@shared/types/master-data';
 import type Phaser from 'phaser';
@@ -84,7 +85,7 @@ export class AlchemyRecipeGrid {
 
   clearSelection(): void {
     for (const item of this.recipeLabels) {
-      const color = item.craftable ? THEME.colors.secondary : 0x3a3a3a;
+      const color = item.craftable ? THEME.colors.secondary : Colors.ui.button.disabled;
       item.background.setFillStyle(color);
     }
   }
@@ -155,14 +156,14 @@ export class AlchemyRecipeGrid {
       LAYOUT.ITEM_HEIGHT + matCount * LAYOUT.MATERIAL_LINE_HEIGHT + LAYOUT.PADDING_VERTICAL;
     const cardContainer = this.scene.add.container(x, y);
 
-    const bgColor = craftable ? THEME.colors.secondary : 0x3a3a3a;
+    const bgColor = craftable ? THEME.colors.secondary : Colors.ui.button.disabled;
     const background = this.rexUI.add
       .roundRectangle({ width: LAYOUT.ITEM_WIDTH, height: cardH, radius: LAYOUT.BORDER_RADIUS })
       .setFillStyle(bgColor);
     background.setPosition(LAYOUT.ITEM_WIDTH / 2, cardH / 2);
     cardContainer.add(background);
 
-    const textColor = craftable ? THEME.colors.textOnSecondary : '#cccccc';
+    const textColor = craftable ? THEME.colors.textOnSecondary : toColorStr(Colors.text.disabled);
     const nameText = this.scene.make.text({
       x: LAYOUT.PADDING_HORIZONTAL,
       y: LAYOUT.PADDING_VERTICAL,
@@ -181,7 +182,11 @@ export class AlchemyRecipeGrid {
     let matY = LAYOUT.ITEM_HEIGHT;
     for (const req of recipe.requiredMaterials) {
       const isMissing = missingMap.has(req.materialId);
-      const matColor = isMissing ? '#ff4444' : craftable ? '#e0d0b0' : '#aaaaaa';
+      const matColor = isMissing
+        ? toColorStr(Colors.text.error)
+        : craftable
+          ? toColorStr(Colors.text.accent)
+          : toColorStr(Colors.text.muted);
       const matText = this.scene.make.text({
         x: LAYOUT.MATERIAL_INDENT,
         y: matY,


### PR DESCRIPTION
## Summary
- AlchemyRecipeGrid/AlchemyCraftPanelのハードコード色をDesignTokens/Colors経由に置き換え
- RecipeListUIは既にTHEME経由のため変更不要

Closes #515

## Test plan
- [x] `pnpm test -- --run` パス (2896 passed)
- [x] `pnpm typecheck` パス
- [x] `pnpm lint` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)