### PR TITLE
design: タイトル・リザルト画面のスタイルをデザインガイドに統一 (#517)

### DIFF
--- a/atelier-guild-rank/src/main.ts
+++ b/atelier-guild-rank/src/main.ts
@@ -16,6 +16,7 @@ import {
 } from '@presentation/scenes';
 import { Container, ServiceKeys } from '@shared/services/di/container';
 import type { IStateManager } from '@shared/services/state-manager';
+import { Colors, toColorStr } from '@shared/theme';
 // debug.ts でグローバル型 (window.game, window.gameState, window.debug) が定義されている
 import { DebugTools } from '@shared/utils/debug';
 import Phaser from 'phaser';
@@ -46,8 +47,8 @@ const config: Phaser.Types.Core.GameConfig = {
   /** 親要素ID 🔵 */
   parent: 'game-container',
 
-  /** 背景色（ベージュ / 羊皮紙風） 🔵 */
-  backgroundColor: '#F5F5DC',
+  /** 背景色（プライマリ背景色） 🔵 */
+  backgroundColor: toColorStr(Colors.background.primary),
 
   /** シーン配列（起動順序） 🔵 */
   scene: [

--- a/atelier-guild-rank/src/scenes/GameClearScene.ts
+++ b/atelier-guild-rank/src/scenes/GameClearScene.ts
@@ -17,6 +17,7 @@
 
 import type { RexLabel, RexUIPlugin } from '@presentation/types/rexui';
 import { THEME } from '@presentation/ui/theme';
+import { Colors, toColorStr } from '@shared/theme';
 import type { GameEndStats } from '@shared/types';
 import Phaser from 'phaser';
 
@@ -50,16 +51,16 @@ const LAYOUT = {
 const STYLES = {
   /** タイトルのフォントサイズ */
   TITLE_FONT_SIZE: '42px',
-  /** タイトルの色（ゴールド） */
-  TITLE_COLOR: '#DAA520',
+  /** タイトルの色（ブランドセカンダリ） */
+  TITLE_COLOR: toColorStr(Colors.brand.secondary),
   /** メッセージのフォントサイズ */
   MESSAGE_FONT_SIZE: '20px',
   /** メッセージの色 */
-  MESSAGE_COLOR: '#666666',
+  MESSAGE_COLOR: toColorStr(Colors.text.secondary),
   /** 統計情報のフォントサイズ */
   STATS_FONT_SIZE: '18px',
   /** 統計情報の色 */
-  STATS_COLOR: '#333333',
+  STATS_COLOR: toColorStr(Colors.text.primary),
   /** ボタンのフォントサイズ */
   BUTTON_FONT_SIZE: '16px',
 } as const;

--- a/atelier-guild-rank/src/scenes/GameOverScene.ts
+++ b/atelier-guild-rank/src/scenes/GameOverScene.ts
@@ -17,6 +17,7 @@
 
 import type { RexLabel, RexUIPlugin } from '@presentation/types/rexui';
 import { THEME } from '@presentation/ui/theme';
+import { Colors, toColorStr } from '@shared/theme';
 import type { GameEndStats } from '@shared/types';
 import Phaser from 'phaser';
 
@@ -50,16 +51,16 @@ const LAYOUT = {
 const STYLES = {
   /** タイトルのフォントサイズ */
   TITLE_FONT_SIZE: '48px',
-  /** タイトルの色（赤） */
-  TITLE_COLOR: '#8B0000',
+  /** タイトルの色（エラー） */
+  TITLE_COLOR: toColorStr(Colors.status.error),
   /** メッセージのフォントサイズ */
   MESSAGE_FONT_SIZE: '20px',
   /** メッセージの色 */
-  MESSAGE_COLOR: '#666666',
+  MESSAGE_COLOR: toColorStr(Colors.text.secondary),
   /** 統計情報のフォントサイズ */
   STATS_FONT_SIZE: '18px',
   /** 統計情報の色 */
-  STATS_COLOR: '#333333',
+  STATS_COLOR: toColorStr(Colors.text.primary),
   /** ボタンのフォントサイズ */
   BUTTON_FONT_SIZE: '16px',
 } as const;

--- a/atelier-guild-rank/src/scenes/components/title/types.ts
+++ b/atelier-guild-rank/src/scenes/components/title/types.ts
@@ -6,6 +6,8 @@
  * TitleScene関連コンポーネントで使用する型定義、レイアウト定数、スタイル定数を定義
  */
 
+import { Colors, toColorStr } from '@shared/theme';
+
 // =============================================================================
 // コールバック型定義
 // =============================================================================
@@ -116,16 +118,16 @@ export const TITLE_LAYOUT = {
 export const TITLE_STYLES = {
   /** タイトルロゴのフォントサイズ */
   TITLE_FONT_SIZE: '48px',
-  /** タイトルロゴの色（SaddleBrown） */
-  TITLE_COLOR: '#8B4513',
+  /** タイトルロゴの色（ブランドセカンダリ） */
+  TITLE_COLOR: toColorStr(Colors.brand.secondary),
   /** サブタイトルのフォントサイズ */
   SUBTITLE_FONT_SIZE: '24px',
   /** サブタイトルの色 */
-  SUBTITLE_COLOR: '#666666',
+  SUBTITLE_COLOR: toColorStr(Colors.text.secondary),
   /** バージョン情報のフォントサイズ */
   VERSION_FONT_SIZE: '14px',
   /** バージョン情報の色 */
-  VERSION_COLOR: '#999999',
+  VERSION_COLOR: toColorStr(Colors.text.muted),
   /** ボタンのフォントサイズ */
   BUTTON_FONT_SIZE: '16px',
   /** ダイアログタイトルのフォントサイズ */

--- a/atelier-guild-rank/tests/unit/presentation/scenes/TitleScene.spec.ts
+++ b/atelier-guild-rank/tests/unit/presentation/scenes/TitleScene.spec.ts
@@ -278,7 +278,7 @@ describe('TitleScene', () => {
         'ATELIER GUILD',
         expect.objectContaining({
           fontSize: '48px',
-          color: '#8B4513',
+          color: '#d4a76a',
         }),
       ); // 🔵
     });
@@ -311,7 +311,7 @@ describe('TitleScene', () => {
         '錬金術師ギルド',
         expect.objectContaining({
           fontSize: '24px',
-          color: '#666666',
+          color: '#5a5a5a',
         }),
       ); // 🔵
     });

--- a/atelier-guild-rank/tests/unit/presentation/scenes/components/title/TitleLogo.test.ts
+++ b/atelier-guild-rank/tests/unit/presentation/scenes/components/title/TitleLogo.test.ts
@@ -145,7 +145,7 @@ describe('TitleLogo', () => {
       // 【対応要件】: 現在のTitleScene.tsのSTYLES定数
       // 🔵 信頼性レベル: 現在のTitleScene.tsの実装に基づく
 
-      it('TC-TL-005: タイトルが48px、#8B4513で表示される', async () => {
+      it('TC-TL-005: タイトルが48px、ブランドセカンダリ色で表示される', async () => {
         // Given: TitleLogoインスタンス
         const { scene: mockScene } = createMockScene();
 
@@ -163,7 +163,7 @@ describe('TitleLogo', () => {
           (call: unknown[]) =>
             call[2]?.toString().includes('ATELIER GUILD') &&
             JSON.stringify(call[3]).includes('48px') &&
-            JSON.stringify(call[3]).includes('#8B4513'),
+            JSON.stringify(call[3]).includes('#d4a76a'),
         );
         expect(hasTitleStyle).toBe(true);
       });


### PR DESCRIPTION
## Summary
- TitleScene/GameOverScene/GameClearScene/main.tsのハードコード色をDesignTokens/Colors経由に置き換え
- テストファイルの期待値も新しいカラートークンに更新

Closes #517

## Test plan
- [x] `pnpm test -- --run` パス (2896 passed)
- [x] `pnpm typecheck` パス
- [x] `pnpm lint` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)