### PR TITLE
design: Primitiveコンポーネントのハードコード色をDesignTokens参照に統一 (#518)

### DIFF
--- a/atelier-guild-rank/src/shared/presentation/ui/components/composite/ContextPanel.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/components/composite/ContextPanel.ts
@@ -21,7 +21,7 @@
 
 import { BaseComponent, type BaseComponentOptions } from '@shared/components';
 import { MAIN_LAYOUT } from '@shared/constants';
-import { Colors, DesignTokens } from '@shared/theme';
+import { Colors, DesignTokens, toColorStr } from '@shared/theme';
 import type Phaser from 'phaser';
 
 // =============================================================================
@@ -91,7 +91,7 @@ export class ContextPanel extends BaseComponent {
     const titleText = this.scene.add.text(0, -this.height / 2 + PADDING, this.title, {
       fontFamily: DesignTokens.fonts.primary,
       fontSize: `${DesignTokens.sizes.medium}px`,
-      color: '#333333',
+      color: toColorStr(Colors.text.primary),
       padding: { top: 4 },
     });
     if (titleText.setOrigin) titleText.setOrigin(0.5, 0);
@@ -103,7 +103,7 @@ export class ContextPanel extends BaseComponent {
     const bodyText = this.scene.add.text(0, 0, this.body, {
       fontFamily: DesignTokens.fonts.primary,
       fontSize: `${DesignTokens.sizes.small}px`,
-      color: '#666666',
+      color: toColorStr(Colors.text.secondary),
       padding: { top: 4 },
       wordWrap: { width: this.width - PADDING * 2 },
     });

--- a/atelier-guild-rank/src/shared/presentation/ui/components/primitive/Badge.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/components/primitive/Badge.ts
@@ -4,7 +4,7 @@
  */
 
 import { BaseComponent, type BaseComponentOptions } from '@shared/components';
-import { Colors, DesignTokens } from '@shared/theme';
+import { Colors, DesignTokens, toColorStr } from '@shared/theme';
 import type Phaser from 'phaser';
 
 export type BadgeVariant = 'default' | 'success' | 'warning' | 'danger' | 'info';
@@ -52,7 +52,7 @@ export class Badge extends BaseComponent {
     const text = this.scene.add.text(0, 0, this.label, {
       fontFamily: DesignTokens.fonts.primary,
       fontSize: `${DesignTokens.sizes.small}px`,
-      color: '#ffffff',
+      color: toColorStr(Colors.text.light),
     });
     text.setOrigin(0.5);
     this.text = text;

--- a/atelier-guild-rank/src/shared/presentation/ui/components/primitive/Icon.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/components/primitive/Icon.ts
@@ -4,7 +4,7 @@
  */
 
 import { BaseComponent, type BaseComponentOptions } from '@shared/components';
-import { DesignTokens } from '@shared/theme';
+import { Colors, DesignTokens, toColorStr } from '@shared/theme';
 import type Phaser from 'phaser';
 
 export interface IconOptions extends BaseComponentOptions {
@@ -23,7 +23,7 @@ export class Icon extends BaseComponent {
     super(scene, x, y, options);
     this.symbol = options.symbol ?? '';
     this.size = options.size ?? DesignTokens.sizes.large;
-    this.color = options.color ?? '#ffffff';
+    this.color = options.color ?? toColorStr(Colors.text.light);
   }
 
   create(): void {

--- a/atelier-guild-rank/src/shared/presentation/ui/components/primitive/Tag.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/components/primitive/Tag.ts
@@ -4,7 +4,7 @@
  */
 
 import { BaseComponent, type BaseComponentOptions } from '@shared/components';
-import { Colors, DesignTokens } from '@shared/theme';
+import { Colors, DesignTokens, toColorStr } from '@shared/theme';
 import type Phaser from 'phaser';
 
 export interface TagOptions extends BaseComponentOptions {
@@ -24,7 +24,7 @@ export class Tag extends BaseComponent {
     super(scene, x, y, options);
     this.label = options.label ?? '';
     this.color = options.color ?? Colors.cardType.default;
-    this.textColor = options.textColor ?? '#333333';
+    this.textColor = options.textColor ?? toColorStr(Colors.text.primary);
   }
 
   create(): void {


### PR DESCRIPTION
## Summary
- Badge/Icon/Tag/ContextPanelのハードコード色をDesignTokens/Colors経由に置き換え
- 機能的な変更なし（同値の置換）

Closes #518

## Test plan
- [x] `pnpm typecheck` パス
- [x] `pnpm lint` パス
- [x] ハードコード色が0件であること確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)