### PR TITLE
fix: GameClearSceneに最終ランク統計行を追加 (#530)

### DIFF
--- a/atelier-guild-rank/src/scenes/GameClearScene.ts
+++ b/atelier-guild-rank/src/scenes/GameClearScene.ts
@@ -258,6 +258,7 @@ export class GameClearScene extends Phaser.Scene {
    */
   private createStats(centerX: number): void {
     const statsLines = [
+      `最終ランク: ${this.stats.finalRank}`,
       `クリア日数: ${this.stats.totalDays}日`,
       `総納品数: ${this.stats.totalDeliveries}`,
       `獲得ゴールド: ${this.stats.totalGold.toLocaleString()}G`,

--- a/atelier-guild-rank/tests/unit/presentation/scenes/GameClearScene.spec.ts
+++ b/atelier-guild-rank/tests/unit/presentation/scenes/GameClearScene.spec.ts
@@ -87,7 +87,7 @@ describe('GameClearScene', () => {
 
       // 背景が作成される
       expect((scene as any).add.rectangle).toHaveBeenCalled();
-      // テキストが作成される（タイトル、メッセージ、統計情報3行、ボタンテキスト2つ）
+      // テキストが作成される（タイトル、メッセージ、統計情報4行、ボタンテキスト2つ）
       expect((scene as any).add.text).toHaveBeenCalled();
       // ボタンが作成される（タイトルへ、NEW GAME+）
       expect(mockRexUI.add.label).toHaveBeenCalledTimes(2);
@@ -111,6 +111,7 @@ describe('GameClearScene', () => {
       // 統計情報のテキストを確認
       const statsTexts = textCalls.slice(2); // タイトルとメッセージをスキップ
 
+      expect(statsTexts.some((call: any) => call[2].includes('最終ランク: S'))).toBe(true);
       expect(statsTexts.some((call: any) => call[2].includes('クリア日数: 25日'))).toBe(true);
       expect(statsTexts.some((call: any) => call[2].includes('総納品数: 58'))).toBe(true);
       expect(statsTexts.some((call: any) => call[2].includes('獲得ゴールド: 4,120G'))).toBe(true);


### PR DESCRIPTION
## Summary
- GameClearSceneの統計情報に「最終ランク」行を追加し、GameOverSceneと同様に4行の統計表示に統一
- テストケースも最終ランク表示の検証を追加

## 変更ファイル
- `src/scenes/GameClearScene.ts`: createStats()に最終ランク行を追加
- `tests/unit/presentation/scenes/GameClearScene.spec.ts`: 最終ランク表示のテストを追加

## Test plan
- [x] GameClearScene.spec.ts の全テストがパス（6件）
- [x] 全ユニットテストがパス（2891件、既存の5件の失敗は本修正とは無関係）
- [x] 型チェック（tsc --noEmit）パス
- [x] リントチェック（biome）パス

Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)