### PR TITLE
docs: UIデザインモックアップと実装計画を追加

### DIFF
--- a/atelier-guild-rank/src/scenes/GameClearScene.ts
+++ b/atelier-guild-rank/src/scenes/GameClearScene.ts
@@ -258,6 +258,7 @@ export class GameClearScene extends Phaser.Scene {
    */
   private createStats(centerX: number): void {
     const statsLines = [
+      `最終ランク: ${this.stats.finalRank}`,
       `クリア日数: ${this.stats.totalDays}日`,
       `総納品数: ${this.stats.totalDeliveries}`,
       `獲得ゴールド: ${this.stats.totalGold.toLocaleString()}G`,

--- a/atelier-guild-rank/tests/unit/presentation/scenes/GameClearScene.spec.ts
+++ b/atelier-guild-rank/tests/unit/presentation/scenes/GameClearScene.spec.ts
@@ -87,7 +87,7 @@ describe('GameClearScene', () => {
 
       // 背景が作成される
       expect((scene as any).add.rectangle).toHaveBeenCalled();
-      // テキストが作成される（タイトル、メッセージ、統計情報3行、ボタンテキスト2つ）
+      // テキストが作成される（タイトル、メッセージ、統計情報4行、ボタンテキスト2つ）
       expect((scene as any).add.text).toHaveBeenCalled();
       // ボタンが作成される（タイトルへ、NEW GAME+）
       expect(mockRexUI.add.label).toHaveBeenCalledTimes(2);
@@ -111,6 +111,7 @@ describe('GameClearScene', () => {
       // 統計情報のテキストを確認
       const statsTexts = textCalls.slice(2); // タイトルとメッセージをスキップ
 
+      expect(statsTexts.some((call: any) => call[2].includes('最終ランク: S'))).toBe(true);
       expect(statsTexts.some((call: any) => call[2].includes('クリア日数: 25日'))).toBe(true);
       expect(statsTexts.some((call: any) => call[2].includes('総納品数: 58'))).toBe(true);
       expect(statsTexts.some((call: any) => call[2].includes('獲得ゴールド: 4,120G'))).toBe(true);

--- a/docs/design/atelier-guild-rank/ui-design/mockup-implementation-plan.md
+++ b/docs/design/atelier-guild-rank/ui-design/mockup-implementation-plan.md
@@ -1,0 +1,300 @@
+# UIモックアップ実装計画書
+
+**作成日**: 2026-06-17  
+**対象モックアップ**: `docs/design/atelier-guild-rank/ui-design/mockups/01〜08`  
+**目的**: 8画面のHTMLモックアップをPhaser3実装に反映する
+
+---
+
+## 方針
+
+- モックアップのレイアウト・色・フォントサイズ・余白を実装の正（ソース・オブ・トゥルース）とする
+- 既存コンポーネントを**作り直し**（置き換え）する。インクリメンタルパッチではない
+- デザイントークン（`@shared/theme`）は既存のまま流用する
+- 実装順は **共通コンポーネント → フェーズUI → 独立シーン** の順とする
+- 1フェーズずつIssueを作成してPRを出す（一括マージしない）
+
+---
+
+## 事前確認事項（実装前に決定が必要）
+
+| # | 項目 | 現状 | 決定が必要な理由 |
+|---|------|------|----------------|
+| A | ゲームクリア統計項目 | result.md と06モックで相違 | モックの項目セットで仕様書を更新するか |
+| B | 「もう一度挑戦」ボタン | 06モックにあり、result.mdになし | 機能として実装するか |
+| C | 設定ボタンスタイル | 01モックで第3スタイル使用 | デザインガイドに第3スタイルを追加するかセカンダリに統一するか |
+
+---
+
+## 実装ステップ一覧
+
+### Phase 1: 共通コンポーネント（全画面で使用）
+
+#### Step 1-1: HUDBar（ヘッダー）
+**対象ファイル**: `src/shared/presentation/ui/components/composite/HUDBar.ts`
+
+モックアップ仕様（02〜05共通 `.header`）:
+- 背景: `#FDFAF5` / 下線: `1px solid #E8E0D6` / padding: `8px 16px`
+- ランクバッジ: `#D4A76A` 背景 + pill型 (radius.full) + `font-size: 12px`
+- 昇格ゲージ: `max-width: 120px` + `height: 8px` + fill色 `#D4A76A`
+- HUDアイテム: 日数・Gold・AP を `font-size: 12px font-weight: 500` で表示
+- セパレーター: `width:1px height:16px background:#E8E0D6`
+
+#### Step 1-2: SidebarUI（サイドバー）
+**対象ファイル**: `src/shared/presentation/ui/components/SidebarUI.ts`
+
+モックアップ仕様（02〜05共通 `.sidebar`）:
+- 幅: `150px` / 背景: `#F5EFE6` / 右線: `1px solid #E8E0D6` / padding: `12px 10px`
+- セクション見出し: `font-size: 11px font-weight: 500` + 下線 `#E8E0D6`
+- 受注依頼カード: `border-radius: 6px border: 1px solid #D9CFC2 padding: 5px 7px`
+  - バッジ: `#7BAE7F` pill型 (brand.primary)
+- インベントリ行: `justify-content: space-between font-size: 11px` + 下線
+- ショップボタン: `margin-top: auto` セカンダリスタイル pill型 `font-size: 11px`
+
+#### Step 1-3: FooterUI（フッター）
+**対象ファイル**: `src/shared/presentation/ui/components/FooterUI.ts`
+
+モックアップ仕様（02〜05共通 `.footer`）:
+- 背景: `#F0EBE3` / 上線: `1px solid #E8E0D6` / padding: `8px 12px`
+- フェーズタブ（PhaseRail）: 上段に配置、`margin-bottom: 8px`
+  - アクティブタブ: `#7BAE7F` / 非アクティブ: `color: #8A8A8A` / radius.full
+- 手札カード: `width: 52px height: 68px border-radius: 8px border: 1.5px solid #D9CFC2`
+  - `font-size: 9px color: #5A5A5A`
+- 右ボタン群: 休息(セカンダリ) + 日終了(デンジャー `#D46B6B`)
+
+#### Step 1-4: PhaseRail（フェーズタブ）
+**対象ファイル**: `src/shared/presentation/ui/components/composite/PhaseRail.ts`
+
+モックアップ仕様（`.phase-tabs .ptab`）:
+- pill型 `padding: 3px 12px font-size: 11px font-weight: 500`
+- アクティブ: `background: #7BAE7F color: #fff`
+- 非アクティブ: `background: transparent color: #8A8A8A`
+
+---
+
+### Phase 2: フェーズワークスペース
+
+#### Step 2-1: QuestAcceptPhaseUI（依頼受注）
+**対象ファイル**: `src/shared/presentation/ui/phases/QuestAcceptPhaseUI.ts`  
+**モックアップ**: `02-quest-accept.html`
+
+実装内容:
+- フェーズタイトル: `color: #B8A9D4` + 左バー `4px #B8A9D4`
+- 依頼元タブ: pill型 / アクティブ `#7BAE7F` / 非アクティブ `#E8E0D6`
+- 依頼カードグリッド: 3列 / gap: 12px
+  - カード: `border: 2px solid #D9CFC2 border-radius: 12px padding: 12px`
+  - 選択時: `border-color: #7BAE7F border-width: 3px` + チェックマーク (pill `#7BAE7F`)
+  - セリフ: `font-size: 11px color: #8A8A8A font-style: italic`
+  - 依頼条件: `color: #D4A76A font-size: 11px font-weight: 500`
+  - 報酬: `font-size: 11px color: #5A5A5A`
+  - 期限: `font-size: 10px color: #8A8A8A`
+- 詳細パネル: `background: #FFFDE7 border: 2px solid #D4A76A border-radius: 12px`
+- 受注数カウント: `font-size: 12px color: #5A5A5A text-align: right`
+
+#### Step 2-2: GatheringPhaseUI（採取）
+**対象ファイル**: `src/shared/presentation/ui/phases/GatheringPhaseUI.ts`  
+**モックアップ**: `03-gathering.html`
+
+実装内容:
+- フェーズタイトル: `color: #8CC084` + 左バー `4px #8CC084`
+- 採取地カード: `border: 2px solid #8CC084 border-radius: 12px`
+  - 素材プレビューリスト: `background: #F5EFE6 border-radius: 8px`
+  - レアタグ: `border-color: #E0A84B color: #795548 background: #FFFDE7`
+- ラウンドヘッダー: `background: #FDFAF5 border: 1px solid #E8E0D6 border-radius: 8px`
+  - 選択バッジ: `#8CC084` pill型
+- ドラフトカードグリッド: 3列
+  - カード: `border: 2px solid #D9CFC2 border-radius: 12px padding: 16px 10px text-align: center`
+  - 選択時: `border-color: #8CC084 border-width: 3px background: #F0FAF0`
+  - 品質バッジ C: `background: #F5F5F5 color: #888` / B: `background: #E8F5E8 color: #4A8A4A`
+
+#### Step 2-3: AlchemyPhaseUI（調合）
+**対象ファイル**: `src/shared/presentation/ui/phases/AlchemyPhaseUI.ts`  
+**モックアップ**: `04-alchemy.html`
+
+実装内容:
+- フェーズタイトル: `color: #D4A76A` + 左バー `4px #D4A76A`
+- 2カラムレイアウト (左: レシピ+素材, 右: 品質プレビュー+調合ボタン)
+- レシピカード: `border: 2px solid #D4A76A border-radius: 12px`
+  - レシピアイコン: pill型 `background: #FFF8E7 border: 2px solid #D4A76A`
+  - 素材スロット: `width: 72px border: 1.5px dashed #D9CFC2 border-radius: 8px`
+  - 素材セット済: `border: 2px solid #7BAE7F background: #F0FAF0`
+- 強化カード行: `background: #F5EFE6 border: 1.5px solid #D9CFC2 border-radius: 10px`
+  - 強化アイコン: `background: #EDE5FA border: 1.5px solid #B8A9D4`
+  - 使用ボタン: `border: 1.5px solid #B8A9D4 color: #795548`
+- 品質プレビューカード: `border: 1.5px solid #D9CFC2 border-radius: 12px`
+  - ヘッダー左バー: `3px solid #D4A76A`
+  - グレード表示: `font-size: 36px`
+
+#### Step 2-4: DeliveryPhaseUI（納品）
+**対象ファイル**: `src/shared/presentation/ui/phases/DeliveryPhaseUI.ts`  
+**モックアップ**: `05-delivery.html`
+
+実装内容:
+- フェーズタイトル: `color: #E8A87C` + 左バー `4px #E8A87C`
+- 2カラムレイアウト (左: 依頼リスト+アイテム選択, 右: 貢献度プレビュー+ボタン)
+- 依頼カード: `border: 2px solid #D9CFC2 border-radius: 12px`
+  - 選択時: `border-color: #E8A87C border-width: 3px`
+  - ヘッダー部: `background: #FFF8F0 border-bottom: 1px solid #E8E0D6`
+  - 依頼人アイコン: pill型 `background: #EDE5FA`
+  - 期限警告: `color: #D46B6B`
+- アイテムチップ: `border: 1.5px solid #D9CFC2 border-radius: 8px`
+  - 選択時: `border-color: #E8A87C background: #FFF3EB color: #7A4A2A`
+  - 空: `border-style: dashed color: #B0B0B0`
+- 報酬表示: Gold `color: #D4A76A` / 貢献度 `color: #7BAE7F`
+- セクション見出し左バー: `3px solid #E8A87C`
+- 貢献度プレビュー:
+  - ゲージ: height `12px` / fill `#D4A76A` / 追加分 `#7BAE7F`
+  - マーカー: `2px background: #E0A84B`
+- 納品ボタン: プライマリ `#7BAE7F` pill型 `padding: 12px`
+
+---
+
+### Phase 3: 独立シーン
+
+#### Step 3-1: TitleScene（タイトル）
+**対象ファイル**: `src/shared/presentation/scenes/TitleScene.ts` + `scenes/components/title/`  
+**モックアップ**: `01-title.html`
+
+実装内容:
+- 画面サイズ: `640x520`
+- 背景: `#FFF8F0 border-radius: 12px border: 1px solid #D9CFC2`
+- 装飾円: 3つ (緑 `#7BAE7F`, 琥珀 `#D4A76A`, ラベンダー `#B8A9D4`) / opacity: 0.06
+- 装飾アイコン: 3つ / opacity: 0.18
+- エンブレム: pill型二重円 + フラスコアイコン `color: #D4A76A font-size: 28px`
+- タイトルカード: `background: #fff border: 2px solid #D4A76A border-radius: 16px padding: 24px 48px`
+  - サブタイトル: `font-size: 12px color: #8A8A8A letter-spacing: 3px`
+  - メインタイトル: `font-size: 28px font-weight: 500`
+  - アクセント: `color: #D4A76A`
+  - ディバイダー: `width: 48px height: 2px background: #D4A76A`
+  - JP副題: `font-size: 14px color: #5A5A5A letter-spacing: 2px`
+- ボタンリスト: 幅 `220px` / gap `10px`
+  - 新規ゲーム: プライマリ pill型 `width: 100% padding: 12px font-size: 14px`
+  - コンティニュー: セカンダリ `border: 2px solid #D9CFC2` pill型
+  - 設定: 薄セカンダリ `border: 1.5px solid #E8E0D6 color: #8A8A8A font-size: 13px`
+- バージョン表示: `position: absolute bottom: 12px right: 16px font-size: 11px color: #B0B0B0`
+
+#### Step 3-2: GameClearScene（ゲームクリア）
+**対象ファイル**: `src/shared/presentation/scenes/GameClearScene.ts`  
+**モックアップ**: `06-game-clear.html`
+
+実装内容:
+- 装飾円: 2つ (琥珀 `#D4A76A`, 草色 `#7BAE7F`) / opacity: 0.06
+- CLEARバッジ: `background: #FFFDE7 border: 2px solid #E0A84B` pill型 / `color: #795548 letter-spacing: 2px`
+- ランク表示パネル: `border: 3px solid #E0A84B border-radius: 20px padding: 20px 40px`
+  - ランク文字: `font-size: 64px font-weight: 500 color: #E0A84B`
+  - ディバイダー: `width: 40px height: 2px background: #E0A84B`
+  - サブ説明: `font-size: 13px color: #5A5A5A`
+  - 称号: `font-size: 20px font-weight: 500`
+- 統計パネル: `border: 1.5px solid #D9CFC2 border-radius: 14px padding: 16px 20px`
+  - ヘッダー左バー: `3px solid #D4A76A`
+  - 統計グリッド（3列）: 総プレイ日数・達成依頼数・総獲得G
+    - stat-card: `background: #FFF8F0 border-radius: 10px padding: 10px text-align: center`
+    - 数値: `font-size: 22px font-weight: 500`
+  - 統計行（リスト）: 調合回数・採取素材数・S品質作成数・最終貢献度
+    - `display: flex justify-content: space-between padding: 6px 0 border-bottom: 1px solid #F0EBE3`
+- ボタン行: タイトルへ(セカンダリ) + もう一度挑戦(プライマリ) / flex gap: 10px
+
+※統計項目は事前確認事項Bを踏まえ、モックアップ仕様（上記6項目）で実装する
+
+#### Step 3-3: ShopScene（ショップ）
+**対象ファイル**: `src/shared/presentation/scenes/ShopScene.ts` + `scenes/components/shop/`  
+**モックアップ**: `07-shop.html`
+
+実装内容:
+- ヘッダー: `background: #FDFAF5 border-bottom: 1px solid #E8E0D6 padding: 10px 16px`
+  - タイトル: ショッピングバッグアイコン + `font-size: 16px`
+  - Gold表示: `color: #D4A76A font-size: 14px font-weight: 500`
+  - 閉じるボタン: セカンダリ pill型 `font-size: 12px`
+- カテゴリサイドバー: `width: 140px background: #F5EFE6 border-right: 1px solid #E8E0D6`
+  - カテゴリ行: `border-radius: 10px padding: 8px 10px font-size: 12px`
+  - アクティブ: `background: #fff border: 1px solid #D9CFC2 font-weight: 500`
+- 商品グリッド: 3列
+  - 商品カード: `border: 1.5px solid #D9CFC2 border-radius: 10px padding: 12px text-align: center`
+  - 選択時: `border: 2px solid #D4A76A background: #FFF8E7`
+  - アイコン: pill型 `width: 44px height: 44px`
+  - 価格: `color: #D4A76A font-size: 13px font-weight: 500`
+  - タグ NEW: `background: #E8F5E8 color: #4A8A4A` / 人気: `background: #FFF3EB color: #C05020`
+- 詳細バー（下固定）: `background: #FDFAF5 border-top: 1px solid #E8E0D6 padding: 12px 16px`
+  - 購入ボタン: プライマリ pill型 `padding: 10px 28px`
+  - 購入不可時: `background: #C5D9C6 cursor: not-allowed`
+
+#### Step 3-4: RankUpScene（ランク昇格試験）
+**対象ファイル**: `src/shared/presentation/scenes/RankUpScene.ts` + `scenes/components/rankup/`  
+**モックアップ**: `08-rank-up.html`
+
+実装内容:
+- 装飾円: 2つ (琥珀, 草色) / opacity: 0.06
+- ヘッダー: `background: linear-gradient(135deg, #FFF8E7, #FFF8F0)` + 下線
+  - 試験バッジ: `background: #FFFDE7 border: 2px solid #E0A84B` pill型 `color: #795548`
+  - ランク遷移表示: 現在ランク(amber) → 次ランク(green) チップ + 矢印
+- スタッフメッセージ: アバター(pill型) + 吹き出し(`border-radius: 12px border-top-left-radius: 4px`)
+- 進捗セクション: `border: 1.5px solid #D9CFC2 border-radius: 12px`
+  - ヘッダー左バー: `3px solid #D4A76A`
+  - 貢献度ゲージ: `height: 14px` gradient fill `#D4A76A → #E0A84B`
+  - チェックリスト: 完了(緑 `#F0FAF0`) / 失敗(赤 `#FFF5F5`) / 待機(灰 `#F5F5F5`)
+    - アイコン: `width: 20px height: 20px` pill型
+- 結果通知: `background: #FFFDE7 border: 1.5px solid #E0A84B border-radius: 10px`
+- ボタン行: セカンダリ + プライマリ / flex gap: 10px
+
+---
+
+## ファイル構成（変更・新規）
+
+```
+src/shared/presentation/
+├── ui/
+│   ├── components/
+│   │   ├── composite/
+│   │   │   ├── HUDBar.ts          ← 作り直し
+│   │   │   └── PhaseRail.ts       ← 作り直し
+│   │   ├── SidebarUI.ts           ← 作り直し
+│   │   └── FooterUI.ts            ← 作り直し
+│   └── phases/
+│       ├── QuestAcceptPhaseUI.ts  ← 作り直し
+│       ├── GatheringPhaseUI.ts    ← 作り直し
+│       ├── AlchemyPhaseUI.ts      ← 作り直し
+│       └── DeliveryPhaseUI.ts     ← 作り直し
+└── scenes/
+    ├── TitleScene.ts              ← 作り直し
+    ├── GameClearScene.ts          ← 作り直し
+    ├── ShopScene.ts               ← 作り直し
+    └── RankUpScene.ts             ← 作り直し
+```
+
+---
+
+## 実装優先順位
+
+| 順序 | ステップ | 理由 |
+|------|---------|------|
+| 1 | Step 1-1 HUDBar | 全フェーズ画面で必要 |
+| 2 | Step 1-2 SidebarUI | 全フェーズ画面で必要 |
+| 3 | Step 1-3/1-4 FooterUI + PhaseRail | 全フェーズ画面で必要 |
+| 4 | Step 2-1 QuestAcceptPhaseUI | ゲーム開始直後のフェーズ |
+| 5 | Step 2-2 GatheringPhaseUI | —  |
+| 6 | Step 2-3 AlchemyPhaseUI | — |
+| 7 | Step 2-4 DeliveryPhaseUI | — |
+| 8 | Step 3-1 TitleScene | 独立画面 |
+| 9 | Step 3-2 GameClearScene | 独立画面 |
+| 10 | Step 3-3 ShopScene | 独立画面 |
+| 11 | Step 3-4 RankUpScene | 独立画面 |
+
+---
+
+## 変更しないもの
+
+- `@shared/theme/` 配下のデザイントークン（既存値を流用）
+- Functional Core（`features/*/services/`）
+- ドメインエンティティ・インターフェース
+- `BootScene.ts`
+- テストコード（UIテストは別途追加を検討）
+
+---
+
+## 完了条件
+
+各ステップの完了条件：
+1. `pnpm dev` でブラウザ表示がモックアップと視覚的に一致する
+2. `pnpm typecheck` がパスする
+3. `pnpm lint` がパスする
+4. 既存のユニットテストが全てパスする（`pnpm test -- --run`）

--- a/docs/design/atelier-guild-rank/ui-design/mockups/01-title.html
+++ b/docs/design/atelier-guild-rank/ui-design/mockups/01-title.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>タイトル画面 — Atelier Guild Rank</title>
+<link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css">
+<style>
+  body { margin: 0; background: #E8E0D6; display: flex; align-items: center; justify-content: center; min-height: 100vh; font-family: 'M PLUS Rounded 1c', sans-serif; }
+  .screen {
+    width: 640px; height: 520px; background: #FFF8F0; border-radius: 12px; overflow: hidden;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    color: #3D3D3D; border: 1px solid #D9CFC2; position: relative; box-shadow: 0 4px 24px rgba(0,0,0,0.1);
+  }
+  .deco { position: absolute; border-radius: 50%; opacity: 0.06; }
+  .deco1 { width: 320px; height: 320px; background: #7BAE7F; top: -60px; left: -80px; }
+  .deco2 { width: 240px; height: 240px; background: #D4A76A; bottom: -60px; right: -40px; }
+  .deco3 { width: 160px; height: 160px; background: #B8A9D4; top: 40px; right: 30px; }
+  .herb { position: absolute; opacity: 0.18; font-size: 32px; }
+  .herb1 { top: 28px; left: 28px; transform: rotate(-15deg); }
+  .herb2 { bottom: 36px; left: 48px; transform: rotate(20deg); }
+  .herb3 { top: 48px; right: 60px; transform: rotate(10deg); }
+  .content { display: flex; flex-direction: column; align-items: center; gap: 0; z-index: 1; }
+  .emblem { width: 80px; height: 80px; border-radius: 50%; background: #FFF8F0; border: 3px solid #D4A76A; display: flex; align-items: center; justify-content: center; margin-bottom: 16px; }
+  .emblem-inner { width: 64px; height: 64px; border-radius: 50%; background: #F5EFE6; border: 2px solid #E8E0D6; display: flex; align-items: center; justify-content: center; }
+  .title-card { background: #FFFFFF; border: 2px solid #D4A76A; border-radius: 16px; padding: 24px 48px; text-align: center; margin-bottom: 36px; }
+  .title-sub { font-size: 12px; color: #8A8A8A; letter-spacing: 3px; margin-bottom: 6px; }
+  .title-main { font-size: 28px; font-weight: 500; color: #3D3D3D; line-height: 1.2; }
+  .title-main-jp { font-size: 14px; color: #5A5A5A; margin-top: 4px; letter-spacing: 2px; }
+  .title-accent { color: #D4A76A; }
+  .title-divider { width: 48px; height: 2px; background: #D4A76A; border-radius: 9999px; margin: 10px auto; }
+  .btn-list { display: flex; flex-direction: column; gap: 10px; align-items: center; width: 220px; }
+  .btn-new { width: 100%; background: #7BAE7F; color: #fff; border: none; border-radius: 9999px; padding: 12px; font-size: 14px; font-weight: 500; cursor: pointer; font-family: inherit; display: flex; align-items: center; justify-content: center; gap: 8px; }
+  .btn-continue { width: 100%; background: transparent; border: 2px solid #D9CFC2; border-radius: 9999px; padding: 11px; font-size: 14px; color: #3D3D3D; cursor: pointer; font-family: inherit; display: flex; align-items: center; justify-content: center; gap: 8px; }
+  .btn-setting { width: 100%; background: transparent; border: 1.5px solid #E8E0D6; border-radius: 9999px; padding: 9px; font-size: 13px; color: #8A8A8A; cursor: pointer; font-family: inherit; display: flex; align-items: center; justify-content: center; gap: 8px; }
+  .version { position: absolute; bottom: 12px; right: 16px; font-size: 11px; color: #B0B0B0; }
+</style>
+</head>
+<body>
+<div class="screen">
+  <div class="deco deco1"></div>
+  <div class="deco deco2"></div>
+  <div class="deco deco3"></div>
+  <div class="herb herb1"><i class="ti ti-leaf" style="color:#7BAE7F"></i></div>
+  <div class="herb herb2"><i class="ti ti-plant-2" style="color:#8CC084"></i></div>
+  <div class="herb herb3"><i class="ti ti-flask" style="color:#D4A76A"></i></div>
+  <div class="content">
+    <div class="emblem">
+      <div class="emblem-inner">
+        <i class="ti ti-flask" style="color:#D4A76A;font-size:28px"></i>
+      </div>
+    </div>
+    <div class="title-card">
+      <div class="title-sub">A L C H E M Y &nbsp; R P G</div>
+      <div class="title-main">ATELIER <span class="title-accent">GUILD</span></div>
+      <div class="title-divider"></div>
+      <div class="title-main-jp">錬金術師ギルドランク</div>
+    </div>
+    <div class="btn-list">
+      <button class="btn-new"><i class="ti ti-player-play"></i> 新規ゲーム</button>
+      <button class="btn-continue"><i class="ti ti-history"></i> コンティニュー</button>
+      <button class="btn-setting"><i class="ti ti-settings"></i> 設定</button>
+    </div>
+  </div>
+  <div class="version">Version 1.0.0</div>
+</div>
+</body>
+</html>

--- a/docs/design/atelier-guild-rank/ui-design/mockups/02-quest-accept.html
+++ b/docs/design/atelier-guild-rank/ui-design/mockups/02-quest-accept.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>依頼受注フェーズ — Atelier Guild Rank</title>
+<link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css">
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #E8E0D6; display: flex; align-items: center; justify-content: center; min-height: 100vh; font-family: 'M PLUS Rounded 1c', sans-serif; padding: 24px; }
+  .screen { width: 900px; min-height: 640px; background: #FFF8F0; border-radius: 12px; overflow: hidden; display: flex; flex-direction: column; font-size: 13px; color: #3D3D3D; border: 1px solid #D9CFC2; box-shadow: 0 4px 24px rgba(0,0,0,0.1); }
+  .header { background: #FDFAF5; border-bottom: 1px solid #E8E0D6; padding: 8px 16px; display: flex; align-items: center; gap: 16px; flex-shrink: 0; }
+  .rank-badge { background: #D4A76A; color: #3D3D3D; font-weight: 500; font-size: 12px; padding: 3px 10px; border-radius: 9999px; }
+  .gauge-wrap { display: flex; align-items: center; gap: 6px; flex: 1; }
+  .gauge-bar { flex: 1; height: 8px; background: #E8E0D6; border-radius: 9999px; overflow: hidden; max-width: 120px; }
+  .gauge-fill { height: 100%; width: 35%; background: #D4A76A; border-radius: 9999px; }
+  .hud-item { display: flex; align-items: center; gap: 4px; font-size: 12px; font-weight: 500; color: #3D3D3D; white-space: nowrap; }
+  .hud-div { width: 1px; height: 16px; background: #E8E0D6; }
+  .main-area { display: flex; flex: 1; }
+  .sidebar { width: 150px; flex-shrink: 0; background: #F5EFE6; border-right: 1px solid #E8E0D6; padding: 12px 10px; display: flex; flex-direction: column; gap: 12px; }
+  .sb-title { font-size: 11px; font-weight: 500; color: #5A5A5A; padding-bottom: 4px; border-bottom: 1px solid #E8E0D6; margin-bottom: 4px; }
+  .sb-quest { background: #fff; border: 1px solid #D9CFC2; border-radius: 6px; padding: 5px 7px; margin-bottom: 4px; }
+  .sb-badge { display: inline-block; background: #7BAE7F; color: #fff; font-size: 10px; border-radius: 9999px; padding: 1px 7px; margin-bottom: 4px; }
+  .sb-item { display: flex; align-items: center; justify-content: space-between; font-size: 11px; color: #5A5A5A; padding: 3px 0; border-bottom: 1px solid #E8E0D6; }
+  .shop-btn { margin-top: auto; background: transparent; border: 1.5px solid #D9CFC2; border-radius: 9999px; padding: 5px 10px; font-size: 11px; color: #3D3D3D; text-align: center; cursor: pointer; }
+  .workspace { flex: 1; padding: 14px 16px; display: flex; flex-direction: column; gap: 12px; }
+  .phase-title { display: flex; align-items: center; gap: 8px; }
+  .phase-bar { width: 4px; height: 20px; background: #B8A9D4; border-radius: 2px; }
+  .phase-text { font-size: 18px; font-weight: 500; color: #B8A9D4; }
+  .source-tabs { display: flex; gap: 6px; }
+  .tab { padding: 4px 14px; border-radius: 9999px; font-size: 12px; font-weight: 500; cursor: pointer; }
+  .tab.active { background: #7BAE7F; color: #fff; }
+  .tab.inactive { background: #E8E0D6; color: #5A5A5A; }
+  .quest-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+  .quest-card { background: #FFFFFF; border: 2px solid #D9CFC2; border-radius: 12px; padding: 12px; cursor: pointer; position: relative; }
+  .quest-card.selected { border-color: #7BAE7F; border-width: 3px; }
+  .qc-header { display: flex; align-items: flex-start; justify-content: space-between; margin-bottom: 6px; }
+  .qc-name { font-size: 13px; font-weight: 500; }
+  .badge { font-size: 10px; padding: 2px 6px; border-radius: 4px; }
+  .badge-b { background: #EFEBE0; color: #795548; }
+  .qc-dialogue { font-size: 11px; color: #8A8A8A; margin-bottom: 8px; font-style: italic; line-height: 1.4; }
+  .qc-divider { border: none; border-top: 1px solid #E8E0D6; margin: 6px 0; }
+  .qc-cond { font-size: 11px; color: #D4A76A; font-weight: 500; margin-bottom: 3px; }
+  .qc-reward { font-size: 11px; color: #5A5A5A; margin-bottom: 2px; }
+  .qc-dl { font-size: 10px; color: #8A8A8A; }
+  .check-mark { position: absolute; top: 8px; right: 8px; background: #7BAE7F; color: #fff; border-radius: 9999px; width: 18px; height: 18px; display: flex; align-items: center; justify-content: center; font-size: 11px; }
+  .detail-panel { background: #FFFDE7; border: 2px solid #D4A76A; border-radius: 12px; padding: 14px 16px; }
+  .dp-title { font-size: 14px; font-weight: 500; margin-bottom: 4px; }
+  .dp-dialogue { font-size: 12px; color: #5A5A5A; font-style: italic; margin-bottom: 10px; }
+  .dp-row { display: flex; gap: 6px; margin-bottom: 4px; font-size: 12px; }
+  .dp-label { color: #8A8A8A; min-width: 60px; }
+  .dp-val { font-weight: 500; }
+  .dp-actions { display: flex; gap: 8px; margin-top: 12px; justify-content: flex-end; }
+  .btn-primary { background: #7BAE7F; color: #fff; border: none; border-radius: 9999px; padding: 6px 20px; font-size: 12px; font-weight: 500; cursor: pointer; display: flex; align-items: center; gap: 6px; }
+  .btn-secondary { background: transparent; border: 1.5px solid #D9CFC2; border-radius: 9999px; padding: 6px 20px; font-size: 12px; color: #3D3D3D; cursor: pointer; }
+  .acc-count { font-size: 12px; color: #5A5A5A; text-align: right; }
+  .footer { background: #F0EBE3; border-top: 1px solid #E8E0D6; padding: 8px 12px; flex-shrink: 0; }
+  .phase-tabs { display: flex; gap: 4px; margin-bottom: 8px; }
+  .ptab { border-radius: 9999px; padding: 3px 12px; font-size: 11px; font-weight: 500; cursor: pointer; }
+  .ptab.active { background: #7BAE7F; color: #fff; }
+  .ptab.inactive { background: transparent; color: #8A8A8A; }
+  .footer-bottom { display: flex; align-items: center; gap: 8px; }
+  .hand-cards { display: flex; gap: 4px; flex: 1; }
+  .hand-card { background: #FFFFFF; border: 1.5px solid #D9CFC2; border-radius: 8px; width: 52px; height: 68px; display: flex; flex-direction: column; align-items: center; justify-content: center; font-size: 9px; color: #5A5A5A; gap: 3px; flex-shrink: 0; }
+  .footer-btns { display: flex; gap: 6px; margin-left: auto; }
+  .btn-rest { background: transparent; border: 1.5px solid #D9CFC2; border-radius: 9999px; padding: 5px 14px; font-size: 11px; color: #3D3D3D; cursor: pointer; }
+  .btn-dayend { background: #D46B6B; border: none; border-radius: 9999px; padding: 5px 14px; font-size: 11px; font-weight: 500; color: #fff; cursor: pointer; }
+</style>
+</head>
+<body>
+<div class="screen">
+  <div class="header">
+    <span class="rank-badge">ランク G</span>
+    <div class="gauge-wrap">
+      <span style="font-size:11px;color:#5A5A5A">昇格</span>
+      <div class="gauge-bar"><div class="gauge-fill"></div></div>
+      <span style="font-size:11px;color:#5A5A5A">35 / 100</span>
+    </div>
+    <div class="hud-div"></div>
+    <div class="hud-item"><i class="ti ti-calendar" style="color:#8A8A8A"></i> 残り 25日</div>
+    <div class="hud-div"></div>
+    <div class="hud-item"><i class="ti ti-coin" style="color:#D4A76A"></i> 130 G</div>
+    <div class="hud-div"></div>
+    <div class="hud-item"><i class="ti ti-bolt" style="color:#7BAE7F"></i> 3 / 3 AP</div>
+  </div>
+  <div class="main-area">
+    <div class="sidebar">
+      <div>
+        <div class="sb-title">受注依頼</div>
+        <span class="sb-badge">1 / 3</span>
+        <div class="sb-quest"><div style="font-size:11px;font-weight:500">冒険者の依頼</div><div style="font-size:10px;color:#8A8A8A">期限 5日</div></div>
+      </div>
+      <div>
+        <div class="sb-title">素材</div>
+        <div class="sb-item"><span>薬草</span><span>×3</span></div>
+        <div class="sb-item"><span>鉱石</span><span>×1</span></div>
+        <div class="sb-item"><span>魔石</span><span>×0</span></div>
+      </div>
+      <div>
+        <div class="sb-title">完成品</div>
+        <div class="sb-item"><span>回復薬</span><span>×2</span></div>
+      </div>
+      <div class="shop-btn"><i class="ti ti-shopping-cart"></i> ショップ</div>
+    </div>
+    <div class="workspace">
+      <div class="phase-title">
+        <div class="phase-bar"></div>
+        <span class="phase-text">依頼受注</span>
+      </div>
+      <div class="source-tabs">
+        <div class="tab active"><i class="ti ti-clipboard-list"></i> 掲示板</div>
+        <div class="tab inactive"><i class="ti ti-user"></i> 訪問者</div>
+      </div>
+      <div class="quest-grid">
+        <div class="quest-card selected">
+          <div class="check-mark"><i class="ti ti-check" style="font-size:10px"></i></div>
+          <div class="qc-header">
+            <div class="qc-name">冒険者</div>
+            <span class="badge badge-b">掲示板</span>
+          </div>
+          <div class="qc-dialogue">「何か薬が欲しいんだ」</div>
+          <hr class="qc-divider">
+          <div class="qc-cond">薬カテゴリ × 1個</div>
+          <div class="qc-reward"><i class="ti ti-star" style="color:#D4A76A;font-size:11px"></i> 84貢 / 48 G</div>
+          <div class="qc-dl"><i class="ti ti-clock" style="font-size:11px"></i> 期限 6日</div>
+        </div>
+        <div class="quest-card">
+          <div class="qc-header">
+            <div class="qc-name">村人</div>
+            <span class="badge badge-b">掲示板</span>
+          </div>
+          <div class="qc-dialogue">「体が弱くて…何か元気になるものを」</div>
+          <hr class="qc-divider">
+          <div class="qc-cond">回復薬 × 1個</div>
+          <div class="qc-reward"><i class="ti ti-star" style="color:#D4A76A;font-size:11px"></i> 95貢 / 57 G</div>
+          <div class="qc-dl"><i class="ti ti-clock" style="font-size:11px"></i> 期限 5日</div>
+        </div>
+        <div class="quest-card">
+          <div class="qc-header">
+            <div class="qc-name">商人</div>
+            <span class="badge badge-b">掲示板</span>
+          </div>
+          <div class="qc-dialogue">「仕入れで使う素材が足りなくてね」</div>
+          <hr class="qc-divider">
+          <div class="qc-cond">水属性アイテム × 2個</div>
+          <div class="qc-reward"><i class="ti ti-star" style="color:#D4A76A;font-size:11px"></i> 50貢 / 32 G</div>
+          <div class="qc-dl"><i class="ti ti-clock" style="font-size:11px"></i> 期限 3日</div>
+        </div>
+      </div>
+      <div class="detail-panel">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">
+          <div class="dp-title">冒険者の依頼</div>
+          <span class="badge badge-b">掲示板</span>
+        </div>
+        <div class="dp-dialogue">「何か薬が欲しいんだ、種類は何でもいい。」</div>
+        <div class="dp-row"><span class="dp-label">依頼タイプ</span><span class="dp-val">カテゴリ指定（薬）</span></div>
+        <div class="dp-row"><span class="dp-label">必要数</span><span class="dp-val">1個</span></div>
+        <div class="dp-row"><span class="dp-label">報酬</span><span class="dp-val" style="color:#D4A76A">貢献度 84 / 48 G</span></div>
+        <div class="dp-row"><span class="dp-label">期限</span><span class="dp-val">6日</span></div>
+        <div class="dp-actions">
+          <button class="btn-secondary">閉じる</button>
+          <button class="btn-primary"><i class="ti ti-check"></i> 受注する</button>
+        </div>
+      </div>
+      <div class="acc-count">受注済み: 1 / 3</div>
+    </div>
+  </div>
+  <div class="footer">
+    <div class="phase-tabs">
+      <div class="ptab active"><i class="ti ti-clipboard-list"></i> 依頼</div>
+      <div class="ptab inactive"><i class="ti ti-plant"></i> 採取</div>
+      <div class="ptab inactive"><i class="ti ti-flask"></i> 調合</div>
+      <div class="ptab inactive"><i class="ti ti-package"></i> 納品</div>
+    </div>
+    <div class="footer-bottom">
+      <span style="font-size:10px;color:#8A8A8A">手札</span>
+      <div class="hand-cards">
+        <div class="hand-card" style="border-color:#8CC084"><i class="ti ti-leaf" style="color:#8CC084;font-size:20px"></i><span>採取</span></div>
+        <div class="hand-card" style="border-color:#8CC084"><i class="ti ti-leaf" style="color:#8CC084;font-size:20px"></i><span>採取</span></div>
+        <div class="hand-card" style="border-color:#6B9FCC"><i class="ti ti-flask" style="color:#6B9FCC;font-size:20px"></i><span>レシピ</span></div>
+        <div class="hand-card" style="border-color:#B8A9D4"><i class="ti ti-sparkles" style="color:#B8A9D4;font-size:20px"></i><span>強化</span></div>
+        <div class="hand-card" style="border-color:#6B9FCC"><i class="ti ti-flask" style="color:#6B9FCC;font-size:20px"></i><span>レシピ</span></div>
+      </div>
+      <div class="footer-btns">
+        <button class="btn-rest"><i class="ti ti-coffee"></i> 休憩</button>
+        <button class="btn-dayend"><i class="ti ti-moon"></i> 日終了</button>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/design/atelier-guild-rank/ui-design/mockups/03-gathering.html
+++ b/docs/design/atelier-guild-rank/ui-design/mockups/03-gathering.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>採取フェーズ — Atelier Guild Rank</title>
+<link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css">
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #E8E0D6; display: flex; align-items: center; justify-content: center; min-height: 100vh; font-family: 'M PLUS Rounded 1c', sans-serif; padding: 24px; }
+  .screen { width: 900px; min-height: 640px; background: #FFF8F0; border-radius: 12px; overflow: hidden; display: flex; flex-direction: column; font-size: 13px; color: #3D3D3D; border: 1px solid #D9CFC2; box-shadow: 0 4px 24px rgba(0,0,0,0.1); }
+  .header { background: #FDFAF5; border-bottom: 1px solid #E8E0D6; padding: 8px 16px; display: flex; align-items: center; gap: 14px; flex-shrink: 0; }
+  .rank-badge { background: #D4A76A; color: #3D3D3D; font-weight: 500; font-size: 12px; padding: 3px 10px; border-radius: 9999px; }
+  .gauge-bar { flex: 1; height: 8px; background: #E8E0D6; border-radius: 9999px; overflow: hidden; max-width: 120px; }
+  .gauge-fill { height: 100%; width: 35%; background: #D4A76A; border-radius: 9999px; }
+  .hud-item { display: flex; align-items: center; gap: 4px; font-size: 12px; font-weight: 500; white-space: nowrap; }
+  .hud-div { width: 1px; height: 16px; background: #E8E0D6; }
+  .main-area { display: flex; flex: 1; }
+  .sidebar { width: 150px; flex-shrink: 0; background: #F5EFE6; border-right: 1px solid #E8E0D6; padding: 12px 10px; display: flex; flex-direction: column; gap: 12px; }
+  .sb-title { font-size: 11px; font-weight: 500; color: #5A5A5A; padding-bottom: 4px; border-bottom: 1px solid #E8E0D6; margin-bottom: 4px; }
+  .sb-quest { background: #fff; border: 1px solid #D9CFC2; border-radius: 6px; padding: 5px 7px; margin-bottom: 4px; }
+  .sb-item { display: flex; align-items: center; justify-content: space-between; font-size: 11px; color: #5A5A5A; padding: 3px 0; border-bottom: 1px solid #E8E0D6; }
+  .shop-btn { margin-top: auto; background: transparent; border: 1.5px solid #D9CFC2; border-radius: 9999px; padding: 5px 10px; font-size: 11px; color: #3D3D3D; text-align: center; cursor: pointer; }
+  .workspace { flex: 1; padding: 14px 16px; display: flex; flex-direction: column; gap: 14px; }
+  .phase-title { display: flex; align-items: center; gap: 8px; }
+  .phase-bar { width: 4px; height: 20px; background: #8CC084; border-radius: 2px; }
+  .phase-text { font-size: 18px; font-weight: 500; color: #8CC084; }
+  .location-info { background: #FFFFFF; border: 2px solid #8CC084; border-radius: 12px; padding: 12px 14px; display: flex; align-items: flex-start; gap: 14px; }
+  .location-detail { flex: 1; }
+  .location-name { font-size: 15px; font-weight: 500; margin-bottom: 6px; }
+  .location-stats { display: flex; gap: 14px; flex-wrap: wrap; }
+  .location-stat { font-size: 11px; color: #5A5A5A; }
+  .mat-preview { background: #F5EFE6; border-radius: 8px; padding: 8px 10px; display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin-top: 8px; }
+  .mat-tag { font-size: 11px; background: #fff; border: 1px solid #D9CFC2; border-radius: 6px; padding: 2px 8px; color: #5A5A5A; }
+  .mat-tag.rare { border-color: #E0A84B; color: #795548; background: #FFFDE7; }
+  .round-header { display: flex; align-items: center; justify-content: space-between; background: #FDFAF5; border: 1px solid #E8E0D6; border-radius: 8px; padding: 8px 12px; }
+  .selected-badge { display: inline-flex; align-items: center; gap: 4px; background: #8CC084; color: #fff; border-radius: 9999px; font-size: 11px; padding: 3px 12px; font-weight: 500; }
+  .skip-link { font-size: 11px; color: #8A8A8A; cursor: pointer; text-decoration: underline; }
+  .draft-cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+  .draft-card { background: #FFFFFF; border: 2px solid #D9CFC2; border-radius: 12px; padding: 16px 10px; text-align: center; cursor: pointer; display: flex; flex-direction: column; align-items: center; gap: 8px; }
+  .draft-card.selected { border-color: #8CC084; border-width: 3px; background: #F0FAF0; }
+  .draft-name { font-size: 13px; font-weight: 500; }
+  .q-badge { font-size: 11px; padding: 2px 8px; border-radius: 9999px; font-weight: 500; }
+  .q-c { background: #F5F5F5; color: #888; }
+  .q-b { background: #E8F5E8; color: #4A8A4A; }
+  .draft-hint { font-size: 10px; color: #8A8A8A; }
+  .action-row { display: flex; gap: 8px; justify-content: flex-end; }
+  .btn-primary { background: #7BAE7F; color: #fff; border: none; border-radius: 9999px; padding: 7px 22px; font-size: 12px; font-weight: 500; cursor: pointer; display: flex; align-items: center; gap: 6px; }
+  .btn-secondary { background: transparent; border: 1.5px solid #D9CFC2; border-radius: 9999px; padding: 7px 18px; font-size: 12px; color: #3D3D3D; cursor: pointer; }
+  .footer { background: #F0EBE3; border-top: 1px solid #E8E0D6; padding: 8px 12px; flex-shrink: 0; }
+  .phase-tabs { display: flex; gap: 4px; margin-bottom: 8px; }
+  .ptab { border-radius: 9999px; padding: 3px 12px; font-size: 11px; font-weight: 500; cursor: pointer; }
+  .ptab.active { background: #7BAE7F; color: #fff; }
+  .ptab.inactive { background: transparent; color: #8A8A8A; }
+  .footer-bottom { display: flex; align-items: center; gap: 8px; }
+  .hand-cards { display: flex; gap: 4px; flex: 1; }
+  .hand-card { background: #FFFFFF; border: 1.5px solid #D9CFC2; border-radius: 8px; width: 52px; height: 68px; display: flex; flex-direction: column; align-items: center; justify-content: center; font-size: 9px; color: #5A5A5A; gap: 3px; flex-shrink: 0; }
+  .footer-btns { display: flex; gap: 6px; margin-left: auto; }
+  .btn-rest { background: transparent; border: 1.5px solid #D9CFC2; border-radius: 9999px; padding: 5px 14px; font-size: 11px; color: #3D3D3D; cursor: pointer; }
+  .btn-dayend { background: #D46B6B; border: none; border-radius: 9999px; padding: 5px 14px; font-size: 11px; font-weight: 500; color: #fff; cursor: pointer; }
+</style>
+</head>
+<body>
+<div class="screen">
+  <div class="header">
+    <span class="rank-badge">ランク G</span>
+    <div style="display:flex;align-items:center;gap:6px;flex:1">
+      <span style="font-size:11px;color:#5A5A5A">昇格</span>
+      <div class="gauge-bar"><div class="gauge-fill"></div></div>
+      <span style="font-size:11px;color:#5A5A5A">35 / 100</span>
+    </div>
+    <div class="hud-div"></div>
+    <div class="hud-item"><i class="ti ti-calendar" style="color:#8A8A8A"></i> 残り 25日</div>
+    <div class="hud-div"></div>
+    <div class="hud-item"><i class="ti ti-coin" style="color:#D4A76A"></i> 178 G</div>
+    <div class="hud-div"></div>
+    <div class="hud-item"><i class="ti ti-bolt" style="color:#7BAE7F"></i> 2 / 3 AP</div>
+  </div>
+  <div class="main-area">
+    <div class="sidebar">
+      <div>
+        <div class="sb-title">受注依頼</div>
+        <div class="sb-quest"><div style="font-size:11px;font-weight:500">冒険者の依頼</div><div style="font-size:10px;color:#8A8A8A">期限 5日</div></div>
+        <div class="sb-quest"><div style="font-size:11px;font-weight:500">村人の依頼</div><div style="font-size:10px;color:#8A8A8A">期限 4日</div></div>
+      </div>
+      <div>
+        <div class="sb-title">素材</div>
+        <div class="sb-item"><span>薬草</span><span>×5</span></div>
+        <div class="sb-item"><span>清水</span><span>×1</span></div>
+        <div class="sb-item"><span>キノコ</span><span>×0</span></div>
+      </div>
+      <div>
+        <div class="sb-title">完成品</div>
+        <div class="sb-item" style="color:#B0B0B0"><span>（なし）</span></div>
+      </div>
+      <div class="shop-btn"><i class="ti ti-shopping-cart"></i> ショップ</div>
+    </div>
+    <div class="workspace">
+      <div class="phase-title">
+        <div class="phase-bar"></div>
+        <span class="phase-text">採取</span>
+      </div>
+      <div class="location-info">
+        <i class="ti ti-tree" style="color:#8CC084;font-size:36px;flex-shrink:0"></i>
+        <div class="location-detail">
+          <div class="location-name">近くの森</div>
+          <div class="location-stats">
+            <div class="location-stat">基本コスト <strong>0 AP</strong></div>
+            <div class="location-stat">提示回数 <strong>3回</strong></div>
+            <div class="location-stat">レア出現率 <strong>10%</strong></div>
+          </div>
+          <div class="mat-preview">
+            <span style="font-size:10px;color:#8A8A8A">出現素材:</span>
+            <span class="mat-tag"><i class="ti ti-leaf" style="color:#8CC084"></i> 薬草(C)</span>
+            <span class="mat-tag"><i class="ti ti-droplet" style="color:#6B9FCC"></i> 清水(C)</span>
+            <span class="mat-tag"><i class="ti ti-mushroom" style="color:#A08060"></i> キノコ(C)</span>
+            <span class="mat-tag rare"><i class="ti ti-sparkles" style="color:#E0A84B"></i> 光苔(C) レア</span>
+          </div>
+        </div>
+      </div>
+      <div class="round-header">
+        <div>
+          <div style="font-size:13px;font-weight:500"><i class="ti ti-cards" style="color:#8CC084"></i> 近くの森 — ラウンド 2 / 3</div>
+          <div style="font-size:11px;color:#8A8A8A">1つ選んでください</div>
+        </div>
+        <div style="display:flex;align-items:center;gap:10px">
+          <span class="selected-badge"><i class="ti ti-check"></i> 取得済み 1個</span>
+          <span class="skip-link">スキップ</span>
+        </div>
+      </div>
+      <div class="draft-cards">
+        <div class="draft-card">
+          <i class="ti ti-leaf" style="color:#8CC084;font-size:32px"></i>
+          <div class="draft-name">薬草</div>
+          <span class="q-badge q-c">C</span>
+          <div class="draft-hint">キーボード: [1]</div>
+        </div>
+        <div class="draft-card selected">
+          <i class="ti ti-droplet" style="color:#6B9FCC;font-size:32px"></i>
+          <div class="draft-name">清水</div>
+          <span class="q-badge q-c">C</span>
+          <div class="draft-hint" style="color:#7BAE7F;font-weight:500">▶ 選択中 [2]</div>
+        </div>
+        <div class="draft-card">
+          <i class="ti ti-sparkles" style="color:#E0A84B;font-size:32px"></i>
+          <div class="draft-name">光苔</div>
+          <span class="q-badge q-b">B <span style="color:#E0A84B;font-size:9px">レア</span></span>
+          <div class="draft-hint">キーボード: [3]</div>
+        </div>
+      </div>
+      <div class="action-row">
+        <button class="btn-secondary">キャンセル</button>
+        <button class="btn-primary"><i class="ti ti-check"></i> 選択して次へ</button>
+      </div>
+    </div>
+  </div>
+  <div class="footer">
+    <div class="phase-tabs">
+      <div class="ptab inactive"><i class="ti ti-clipboard-list"></i> 依頼</div>
+      <div class="ptab active"><i class="ti ti-plant"></i> 採取</div>
+      <div class="ptab inactive"><i class="ti ti-flask"></i> 調合</div>
+      <div class="ptab inactive"><i class="ti ti-package"></i> 納品</div>
+    </div>
+    <div class="footer-bottom">
+      <span style="font-size:10px;color:#8A8A8A">手札</span>
+      <div class="hand-cards">
+        <div class="hand-card" style="border-color:#8CC084;opacity:0.4"><i class="ti ti-leaf" style="color:#8CC084;font-size:20px"></i><span>採取</span></div>
+        <div class="hand-card" style="border-color:#8CC084;border-width:2px"><i class="ti ti-leaf" style="color:#8CC084;font-size:20px"></i><span>採取</span></div>
+        <div class="hand-card" style="border-color:#6B9FCC"><i class="ti ti-flask" style="color:#6B9FCC;font-size:20px"></i><span>レシピ</span></div>
+        <div class="hand-card" style="border-color:#B8A9D4"><i class="ti ti-sparkles" style="color:#B8A9D4;font-size:20px"></i><span>強化</span></div>
+        <div class="hand-card" style="border-color:#6B9FCC"><i class="ti ti-flask" style="color:#6B9FCC;font-size:20px"></i><span>レシピ</span></div>
+      </div>
+      <div class="footer-btns">
+        <button class="btn-rest"><i class="ti ti-coffee"></i> 休憩</button>
+        <button class="btn-dayend"><i class="ti ti-moon"></i> 日終了</button>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/design/atelier-guild-rank/ui-design/mockups/04-alchemy.html
+++ b/docs/design/atelier-guild-rank/ui-design/mockups/04-alchemy.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>調合フェーズ — Atelier Guild Rank</title>
+<link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css">
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #E8E0D6; display: flex; align-items: center; justify-content: center; min-height: 100vh; font-family: 'M PLUS Rounded 1c', sans-serif; padding: 24px; }
+  .screen { width: 900px; min-height: 640px; background: #FFF8F0; border-radius: 12px; overflow: hidden; display: flex; flex-direction: column; font-size: 13px; color: #3D3D3D; border: 1px solid #D9CFC2; box-shadow: 0 4px 24px rgba(0,0,0,0.1); }
+  .header { background: #FDFAF5; border-bottom: 1px solid #E8E0D6; padding: 8px 16px; display: flex; align-items: center; gap: 14px; flex-shrink: 0; }
+  .rank-badge { background: #D4A76A; color: #3D3D3D; font-weight: 500; font-size: 12px; padding: 3px 10px; border-radius: 9999px; }
+  .gauge-bar { flex: 1; height: 8px; background: #E8E0D6; border-radius: 9999px; overflow: hidden; max-width: 120px; }
+  .gauge-fill { height: 100%; width: 35%; background: #D4A76A; border-radius: 9999px; }
+  .hud-item { display: flex; align-items: center; gap: 4px; font-size: 12px; font-weight: 500; white-space: nowrap; }
+  .hud-div { width: 1px; height: 16px; background: #E8E0D6; }
+  .main-area { display: flex; flex: 1; }
+  .sidebar { width: 150px; flex-shrink: 0; background: #F5EFE6; border-right: 1px solid #E8E0D6; padding: 12px 10px; display: flex; flex-direction: column; gap: 12px; }
+  .sb-title { font-size: 11px; font-weight: 500; color: #5A5A5A; padding-bottom: 4px; border-bottom: 1px solid #E8E0D6; margin-bottom: 4px; }
+  .sb-quest { background: #fff; border: 1px solid #D9CFC2; border-radius: 6px; padding: 5px 7px; margin-bottom: 4px; }
+  .sb-item { display: flex; align-items: center; justify-content: space-between; font-size: 11px; color: #5A5A5A; padding: 3px 0; border-bottom: 1px solid #E8E0D6; }
+  .shop-btn { margin-top: auto; background: transparent; border: 1.5px solid #D9CFC2; border-radius: 9999px; padding: 5px 10px; font-size: 11px; color: #3D3D3D; text-align: center; cursor: pointer; }
+  .workspace { flex: 1; padding: 14px 16px; display: flex; flex-direction: column; gap: 14px; }
+  .phase-title { display: flex; align-items: center; gap: 8px; }
+  .phase-bar { width: 4px; height: 20px; background: #D4A76A; border-radius: 2px; }
+  .phase-text { font-size: 18px; font-weight: 500; color: #D4A76A; }
+  .alchemy-body { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; flex: 1; }
+  .left-panel { display: flex; flex-direction: column; gap: 12px; }
+  .recipe-card { background: #FFFFFF; border: 2px solid #D4A76A; border-radius: 12px; padding: 14px; }
+  .recipe-header { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
+  .recipe-icon { width: 40px; height: 40px; border-radius: 9999px; background: #FFF8E7; border: 2px solid #D4A76A; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .recipe-info { flex: 1; }
+  .recipe-name { font-size: 14px; font-weight: 500; }
+  .recipe-difficulty { font-size: 11px; color: #8A8A8A; margin-top: 2px; }
+  .recipe-req { font-size: 11px; color: #5A5A5A; background: #FFF8F0; border: 1px solid #E8E0D6; border-radius: 6px; padding: 4px 8px; }
+  .mat-slots { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px; }
+  .mat-slot { width: 72px; background: #FFF8F0; border: 1.5px dashed #D9CFC2; border-radius: 8px; padding: 8px 4px; text-align: center; display: flex; flex-direction: column; align-items: center; gap: 4px; }
+  .mat-slot.filled { border: 2px solid #7BAE7F; background: #F0FAF0; }
+  .mat-slot-icon { font-size: 22px; }
+  .mat-slot-name { font-size: 10px; color: #5A5A5A; }
+  .mat-slot-q { font-size: 10px; font-weight: 500; padding: 1px 6px; border-radius: 9999px; }
+  .q-c { background: #F5F5F5; color: #888; }
+  .q-b { background: #E8F5E8; color: #4A8A4A; }
+  .q-a { background: #FFF8E7; color: #A06000; }
+  .enhance-card { background: #F5EFE6; border: 1.5px solid #D9CFC2; border-radius: 10px; padding: 10px; display: flex; align-items: center; gap: 10px; }
+  .enhance-icon { width: 36px; height: 36px; border-radius: 8px; background: #EDE5FA; border: 1.5px solid #B8A9D4; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .enhance-info { flex: 1; }
+  .enhance-title { font-size: 12px; font-weight: 500; }
+  .enhance-desc { font-size: 10px; color: #8A8A8A; margin-top: 2px; }
+  .enhance-use { font-size: 11px; padding: 3px 10px; border: 1.5px solid #B8A9D4; border-radius: 9999px; color: #795548; cursor: pointer; background: #fff; }
+  .right-panel { display: flex; flex-direction: column; gap: 12px; }
+  .quality-preview { background: #FFFFFF; border: 1.5px solid #D9CFC2; border-radius: 12px; padding: 14px; }
+  .qp-header { font-size: 12px; font-weight: 500; color: #8A8A8A; margin-bottom: 10px; padding-left: 8px; border-left: 3px solid #D4A76A; }
+  .grade-display { display: flex; align-items: center; justify-content: center; gap: 12px; margin-bottom: 14px; }
+  .grade-box { text-align: center; }
+  .grade-label { font-size: 10px; color: #8A8A8A; margin-bottom: 2px; }
+  .grade-val { font-size: 36px; font-weight: 500; line-height: 1; }
+  .grade-arrow { font-size: 18px; color: #8A8A8A; margin-top: 10px; }
+  .quality-bar-wrap { margin-bottom: 10px; }
+  .quality-bar-label { display: flex; justify-content: space-between; font-size: 11px; color: #5A5A5A; margin-bottom: 4px; }
+  .quality-bar { height: 10px; background: #E8E0D6; border-radius: 9999px; overflow: hidden; }
+  .quality-fill { height: 100%; border-radius: 9999px; }
+  .qp-effects { background: #FFF8F0; border-radius: 8px; padding: 10px; }
+  .qp-effect-row { display: flex; justify-content: space-between; font-size: 12px; padding: 4px 0; border-bottom: 1px solid #F0EBE3; }
+  .qp-effect-row:last-child { border-bottom: none; }
+  .craft-btn { background: #7BAE7F; color: #fff; border: none; border-radius: 9999px; padding: 11px; font-size: 13px; font-weight: 500; cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 6px; }
+  .craft-btn:disabled { background: #C5D9C6; cursor: not-allowed; }
+  .info-note { font-size: 11px; color: #8A8A8A; text-align: center; }
+  .footer { background: #F0EBE3; border-top: 1px solid #E8E0D6; padding: 8px 12px; flex-shrink: 0; }
+  .phase-tabs { display: flex; gap: 4px; margin-bottom: 8px; }
+  .ptab { border-radius: 9999px; padding: 3px 12px; font-size: 11px; font-weight: 500; cursor: pointer; }
+  .ptab.active { background: #7BAE7F; color: #fff; }
+  .ptab.inactive { background: transparent; color: #8A8A8A; }
+  .footer-bottom { display: flex; align-items: center; gap: 8px; }
+  .hand-cards { display: flex; gap: 4px; flex: 1; }
+  .hand-card { background: #FFFFFF; border: 1.5px solid #D9CFC2; border-radius: 8px; width: 52px; height: 68px; display: flex; flex-direction: column; align-items: center; justify-content: center; font-size: 9px; color: #5A5A5A; gap: 3px; flex-shrink: 0; }
+  .footer-btns { display: flex; gap: 6px; margin-left: auto; }
+  .btn-rest { background: transparent; border: 1.5px solid #D9CFC2; border-radius: 9999px; padding: 5px 14px; font-size: 11px; color: #3D3D3D; cursor: pointer; }
+  .btn-dayend { background: #D46B6B; border: none; border-radius: 9999px; padding: 5px 14px; font-size: 11px; font-weight: 500; color: #fff; cursor: pointer; }
+</style>
+</head>
+<body>
+<div class="screen">
+  <div class="header">
+    <span class="rank-badge">ランク G</span>
+    <div style="display:flex;align-items:center;gap:6px;flex:1">
+      <span style="font-size:11px;color:#5A5A5A">昇格</span>
+      <div class="gauge-bar"><div class="gauge-fill"></div></div>
+      <span style="font-size:11px;color:#5A5A5A">35 / 100</span>
+    </div>
+    <div class="hud-div"></div>
+    <div class="hud-item"><i class="ti ti-calendar" style="color:#8A8A8A"></i> 残り 23日</div>
+    <div class="hud-div"></div>
+    <div class="hud-item"><i class="ti ti-coin" style="color:#D4A76A"></i> 178 G</div>
+    <div class="hud-div"></div>
+    <div class="hud-item"><i class="ti ti-bolt" style="color:#7BAE7F"></i> 1 / 3 AP</div>
+  </div>
+  <div class="main-area">
+    <div class="sidebar">
+      <div>
+        <div class="sb-title">受注依頼</div>
+        <div class="sb-quest"><div style="font-size:11px;font-weight:500">冒険者の依頼</div><div style="font-size:10px;color:#8A8A8A">期限 3日</div></div>
+        <div class="sb-quest"><div style="font-size:11px;font-weight:500">村人の依頼</div><div style="font-size:10px;color:#8A8A8A">期限 2日</div></div>
+      </div>
+      <div>
+        <div class="sb-title">素材</div>
+        <div class="sb-item"><span>薬草</span><span>×3</span></div>
+        <div class="sb-item"><span>清水</span><span>×2</span></div>
+        <div class="sb-item"><span>光苔</span><span>×1</span></div>
+      </div>
+      <div>
+        <div class="sb-title">完成品</div>
+        <div class="sb-item" style="color:#B0B0B0"><span>（なし）</span></div>
+      </div>
+      <div class="shop-btn"><i class="ti ti-shopping-cart"></i> ショップ</div>
+    </div>
+    <div class="workspace">
+      <div class="phase-title">
+        <div class="phase-bar"></div>
+        <span class="phase-text">調合</span>
+      </div>
+      <div class="alchemy-body">
+        <div class="left-panel">
+          <div class="recipe-card">
+            <div class="recipe-header">
+              <div class="recipe-icon"><i class="ti ti-flask" style="color:#D4A76A;font-size:22px"></i></div>
+              <div class="recipe-info">
+                <div class="recipe-name">回復薬</div>
+                <div class="recipe-difficulty">難易度 ★★☆☆☆</div>
+              </div>
+              <div class="recipe-req"><i class="ti ti-flask" style="color:#D4A76A"></i> 1 AP</div>
+            </div>
+            <div style="font-size:11px;color:#8A8A8A;margin-bottom:6px">素材スロット（2/2 セット済み）</div>
+            <div class="mat-slots">
+              <div class="mat-slot filled">
+                <div class="mat-slot-icon"><i class="ti ti-leaf" style="color:#8CC084"></i></div>
+                <div class="mat-slot-name">薬草</div>
+                <span class="mat-slot-q q-b">B</span>
+              </div>
+              <div class="mat-slot filled">
+                <div class="mat-slot-icon"><i class="ti ti-droplet" style="color:#6B9FCC"></i></div>
+                <div class="mat-slot-name">清水</div>
+                <span class="mat-slot-q q-c">C</span>
+              </div>
+              <div class="mat-slot" style="opacity:0.4">
+                <div style="font-size:18px;color:#C0C0C0"><i class="ti ti-plus"></i></div>
+                <div class="mat-slot-name" style="color:#B0B0B0">追加可</div>
+              </div>
+            </div>
+          </div>
+          <div class="enhance-card">
+            <div class="enhance-icon"><i class="ti ti-sparkles" style="color:#B8A9D4;font-size:18px"></i></div>
+            <div class="enhance-info">
+              <div class="enhance-title">品質強化カード</div>
+              <div class="enhance-desc">品質値 +15 / 手札に1枚</div>
+            </div>
+            <button class="enhance-use">使用する</button>
+          </div>
+          <div style="display:flex;gap:8px">
+            <button style="flex:1;background:transparent;border:1.5px solid #D9CFC2;border-radius:9999px;padding:7px;font-size:12px;color:#3D3D3D;cursor:pointer;font-family:inherit">レシピ変更</button>
+            <button class="craft-btn" style="flex:1">
+              <i class="ti ti-flask"></i> 調合する
+            </button>
+          </div>
+        </div>
+        <div class="right-panel">
+          <div class="quality-preview">
+            <div class="qp-header">品質プレビュー</div>
+            <div class="grade-display">
+              <div class="grade-box">
+                <div class="grade-label">現在</div>
+                <div class="grade-val" style="color:#4A8A4A">B</div>
+              </div>
+              <div class="grade-arrow"><i class="ti ti-arrow-right"></i></div>
+              <div class="grade-box">
+                <div class="grade-label">強化後</div>
+                <div class="grade-val" style="color:#A06000">A</div>
+              </div>
+            </div>
+            <div class="quality-bar-wrap">
+              <div class="quality-bar-label">
+                <span>品質値</span>
+                <span style="font-weight:500">65 → <span style="color:#A06000">80</span> / 100</span>
+              </div>
+              <div class="quality-bar">
+                <div class="quality-fill" style="width:65%;background:linear-gradient(90deg,#7BAE7F,#D4A76A)"></div>
+              </div>
+            </div>
+            <div style="font-size:10px;color:#8A8A8A;text-align:center;margin-bottom:10px">
+              強化カード使用で A品質 に到達！
+            </div>
+            <div class="qp-effects">
+              <div style="font-size:11px;font-weight:500;color:#5A5A5A;margin-bottom:6px">完成品の効果</div>
+              <div class="qp-effect-row">
+                <span><i class="ti ti-heart" style="color:#E07070"></i> 回復量</span>
+                <span style="font-weight:500">+30 HP（A品質ボーナス）</span>
+              </div>
+              <div class="qp-effect-row">
+                <span><i class="ti ti-star" style="color:#E0A84B"></i> 貢献度</span>
+                <span style="font-weight:500;color:#E0A84B">+12 pt</span>
+              </div>
+              <div class="qp-effect-row">
+                <span><i class="ti ti-coin" style="color:#D4A76A"></i> 売却価格</span>
+                <span style="font-weight:500">120 G</span>
+              </div>
+            </div>
+          </div>
+          <div style="background:#FFFFFF;border:1.5px solid #D9CFC2;border-radius:12px;padding:14px;">
+            <div class="qp-header">調合メモ</div>
+            <div style="font-size:11px;color:#5A5A5A;line-height:1.7">
+              <div style="display:flex;justify-content:space-between;padding:3px 0;border-bottom:1px solid #F0EBE3"><span>今日の調合回数</span><span style="font-weight:500">2 / 3回</span></div>
+              <div style="display:flex;justify-content:space-between;padding:3px 0;border-bottom:1px solid #F0EBE3"><span>連続調合ボーナス</span><span style="font-weight:500;color:#7BAE7F">+5%</span></div>
+              <div style="display:flex;justify-content:space-between;padding:3px 0"><span>今日の完成品</span><span style="font-weight:500">回復薬(C) ×1</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="footer">
+    <div class="phase-tabs">
+      <div class="ptab inactive"><i class="ti ti-clipboard-list"></i> 依頼</div>
+      <div class="ptab inactive"><i class="ti ti-plant"></i> 採取</div>
+      <div class="ptab active"><i class="ti ti-flask"></i> 調合</div>
+      <div class="ptab inactive"><i class="ti ti-package"></i> 納品</div>
+    </div>
+    <div class="footer-bottom">
+      <span style="font-size:10px;color:#8A8A8A">手札</span>
+      <div class="hand-cards">
+        <div class="hand-card" style="border-color:#D4A76A;border-width:2px"><i class="ti ti-flask" style="color:#D4A76A;font-size:20px"></i><span>レシピ</span></div>
+        <div class="hand-card" style="border-color:#8CC084"><i class="ti ti-leaf" style="color:#8CC084;font-size:20px"></i><span>採取</span></div>
+        <div class="hand-card" style="border-color:#B8A9D4;border-width:2px"><i class="ti ti-sparkles" style="color:#B8A9D4;font-size:20px"></i><span>強化</span></div>
+        <div class="hand-card" style="border-color:#D4A76A"><i class="ti ti-flask" style="color:#D4A76A;font-size:20px"></i><span>レシピ</span></div>
+        <div class="hand-card" style="border-color:#6B9FCC"><i class="ti ti-star" style="color:#6B9FCC;font-size:20px"></i><span>スキル</span></div>
+      </div>
+      <div class="footer-btns">
+        <button class="btn-rest"><i class="ti ti-coffee"></i> 休憩</button>
+        <button class="btn-dayend"><i class="ti ti-moon"></i> 日終了</button>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/design/atelier-guild-rank/ui-design/mockups/05-delivery.html
+++ b/docs/design/atelier-guild-rank/ui-design/mockups/05-delivery.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>納品フェーズ — Atelier Guild Rank</title>
+<link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css">
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #E8E0D6; display: flex; align-items: center; justify-content: center; min-height: 100vh; font-family: 'M PLUS Rounded 1c', sans-serif; padding: 24px; }
+  .screen { width: 900px; min-height: 640px; background: #FFF8F0; border-radius: 12px; overflow: hidden; display: flex; flex-direction: column; font-size: 13px; color: #3D3D3D; border: 1px solid #D9CFC2; box-shadow: 0 4px 24px rgba(0,0,0,0.1); }
+  .header { background: #FDFAF5; border-bottom: 1px solid #E8E0D6; padding: 8px 16px; display: flex; align-items: center; gap: 14px; flex-shrink: 0; }
+  .rank-badge { background: #D4A76A; color: #3D3D3D; font-weight: 500; font-size: 12px; padding: 3px 10px; border-radius: 9999px; }
+  .gauge-bar { flex: 1; height: 8px; background: #E8E0D6; border-radius: 9999px; overflow: hidden; max-width: 120px; }
+  .gauge-fill { height: 100%; width: 35%; background: #D4A76A; border-radius: 9999px; }
+  .hud-item { display: flex; align-items: center; gap: 4px; font-size: 12px; font-weight: 500; white-space: nowrap; }
+  .hud-div { width: 1px; height: 16px; background: #E8E0D6; }
+  .main-area { display: flex; flex: 1; }
+  .sidebar { width: 150px; flex-shrink: 0; background: #F5EFE6; border-right: 1px solid #E8E0D6; padding: 12px 10px; display: flex; flex-direction: column; gap: 12px; }
+  .sb-title { font-size: 11px; font-weight: 500; color: #5A5A5A; padding-bottom: 4px; border-bottom: 1px solid #E8E0D6; margin-bottom: 4px; }
+  .sb-quest { background: #fff; border: 1px solid #D9CFC2; border-radius: 6px; padding: 5px 7px; margin-bottom: 4px; }
+  .sb-item { display: flex; align-items: center; justify-content: space-between; font-size: 11px; color: #5A5A5A; padding: 3px 0; border-bottom: 1px solid #E8E0D6; }
+  .shop-btn { margin-top: auto; background: transparent; border: 1.5px solid #D9CFC2; border-radius: 9999px; padding: 5px 10px; font-size: 11px; color: #3D3D3D; text-align: center; cursor: pointer; }
+  .workspace { flex: 1; padding: 14px 16px; display: flex; flex-direction: column; gap: 14px; }
+  .phase-title { display: flex; align-items: center; gap: 8px; }
+  .phase-bar { width: 4px; height: 20px; background: #E8A87C; border-radius: 2px; }
+  .phase-text { font-size: 18px; font-weight: 500; color: #E8A87C; }
+  .delivery-body { display: grid; grid-template-columns: 1fr 280px; gap: 14px; flex: 1; }
+  .left-panel { display: flex; flex-direction: column; gap: 10px; overflow-y: auto; }
+  .section-label { font-size: 11px; font-weight: 500; color: #5A5A5A; padding-left: 8px; border-left: 3px solid #E8A87C; }
+  .quest-delivery-card { background: #FFFFFF; border: 2px solid #D9CFC2; border-radius: 12px; overflow: hidden; }
+  .quest-delivery-card.selected { border-color: #E8A87C; border-width: 3px; }
+  .qdc-header { background: #FFF8F0; border-bottom: 1px solid #E8E0D6; padding: 8px 12px; display: flex; align-items: center; gap: 8px; }
+  .qdc-client-icon { width: 28px; height: 28px; border-radius: 9999px; background: #EDE5FA; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .qdc-name { font-size: 13px; font-weight: 500; flex: 1; }
+  .qdc-deadline { font-size: 11px; color: #D46B6B; }
+  .qdc-body { padding: 10px 12px; display: flex; gap: 10px; align-items: center; }
+  .qdc-require { flex: 1; }
+  .qdc-req-label { font-size: 10px; color: #8A8A8A; margin-bottom: 4px; }
+  .qdc-req-item { display: flex; align-items: center; gap: 6px; font-size: 12px; }
+  .qdc-req-icon { width: 24px; height: 24px; border-radius: 6px; background: #F5EFE6; display: flex; align-items: center; justify-content: center; }
+  .item-selector { flex: 1; }
+  .item-selector-label { font-size: 10px; color: #8A8A8A; margin-bottom: 4px; }
+  .item-chips { display: flex; gap: 4px; flex-wrap: wrap; }
+  .item-chip { border: 1.5px solid #D9CFC2; border-radius: 8px; padding: 3px 8px; font-size: 11px; cursor: pointer; display: flex; align-items: center; gap: 4px; background: #fff; }
+  .item-chip.selected { border-color: #E8A87C; background: #FFF3EB; color: #7A4A2A; font-weight: 500; }
+  .item-chip.empty { border-style: dashed; color: #B0B0B0; cursor: default; }
+  .qdc-reward { text-align: right; }
+  .reward-gold { font-size: 13px; font-weight: 500; color: #D4A76A; }
+  .reward-contrib { font-size: 11px; color: #7BAE7F; margin-top: 2px; }
+  .right-panel { display: flex; flex-direction: column; gap: 10px; }
+  .preview-card { background: #FFFFFF; border: 1.5px solid #D9CFC2; border-radius: 12px; padding: 14px; }
+  .preview-title { font-size: 12px; font-weight: 500; color: #8A8A8A; margin-bottom: 12px; padding-left: 8px; border-left: 3px solid #E8A87C; }
+  .preview-row { display: flex; justify-content: space-between; align-items: center; padding: 6px 0; border-bottom: 1px solid #F0EBE3; font-size: 12px; }
+  .preview-row:last-child { border-bottom: none; }
+  .contrib-gauge-wrap { margin: 12px 0; }
+  .contrib-label { display: flex; justify-content: space-between; font-size: 11px; color: #5A5A5A; margin-bottom: 4px; }
+  .contrib-bar { height: 12px; background: #E8E0D6; border-radius: 9999px; overflow: visible; position: relative; }
+  .contrib-fill { height: 100%; width: 58%; background: #D4A76A; border-radius: 9999px; }
+  .contrib-fill-add { height: 100%; width: 16%; background: #7BAE7F; border-radius: 9999px; margin-left: 0; position: absolute; left: 58%; top: 0; }
+  .contrib-marker { position: absolute; right: 0; top: -2px; height: 16px; width: 2px; background: #E0A84B; }
+  .submit-btn { background: #7BAE7F; color: #fff; border: none; border-radius: 9999px; padding: 12px; font-size: 13px; font-weight: 500; cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 6px; }
+  .skip-btn { background: transparent; border: 1.5px solid #D9CFC2; border-radius: 9999px; padding: 8px; font-size: 12px; color: #8A8A8A; cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 4px; }
+  .footer { background: #F0EBE3; border-top: 1px solid #E8E0D6; padding: 8px 12px; flex-shrink: 0; }
+  .phase-tabs { display: flex; gap: 4px; margin-bottom: 8px; }
+  .ptab { border-radius: 9999px; padding: 3px 12px; font-size: 11px; font-weight: 500; cursor: pointer; }
+  .ptab.active { background: #7BAE7F; color: #fff; }
+  .ptab.inactive { background: transparent; color: #8A8A8A; }
+  .footer-bottom { display: flex; align-items: center; gap: 8px; }
+  .hand-cards { display: flex; gap: 4px; flex: 1; }
+  .hand-card { background: #FFFFFF; border: 1.5px solid #D9CFC2; border-radius: 8px; width: 52px; height: 68px; display: flex; flex-direction: column; align-items: center; justify-content: center; font-size: 9px; color: #5A5A5A; gap: 3px; flex-shrink: 0; }
+  .footer-btns { display: flex; gap: 6px; margin-left: auto; }
+  .btn-rest { background: transparent; border: 1.5px solid #D9CFC2; border-radius: 9999px; padding: 5px 14px; font-size: 11px; color: #3D3D3D; cursor: pointer; }
+  .btn-dayend { background: #D46B6B; border: none; border-radius: 9999px; padding: 5px 14px; font-size: 11px; font-weight: 500; color: #fff; cursor: pointer; }
+</style>
+</head>
+<body>
+<div class="screen">
+  <div class="header">
+    <span class="rank-badge">ランク G</span>
+    <div style="display:flex;align-items:center;gap:6px;flex:1">
+      <span style="font-size:11px;color:#5A5A5A">昇格</span>
+      <div class="gauge-bar"><div class="gauge-fill"></div></div>
+      <span style="font-size:11px;color:#5A5A5A">35 / 100</span>
+    </div>
+    <div class="hud-div"></div>
+    <div class="hud-item"><i class="ti ti-calendar" style="color:#8A8A8A"></i> 残り 22日</div>
+    <div class="hud-div"></div>
+    <div class="hud-item"><i class="ti ti-coin" style="color:#D4A76A"></i> 178 G</div>
+    <div class="hud-div"></div>
+    <div class="hud-item"><i class="ti ti-bolt" style="color:#7BAE7F"></i> 0 / 3 AP</div>
+  </div>
+  <div class="main-area">
+    <div class="sidebar">
+      <div>
+        <div class="sb-title">受注依頼</div>
+        <div class="sb-quest"><div style="font-size:11px;font-weight:500">冒険者の依頼</div><div style="font-size:10px;color:#8A8A8A">期限 2日</div></div>
+        <div class="sb-quest"><div style="font-size:11px;font-weight:500">村人の依頼</div><div style="font-size:10px;color:#D46B6B">期限 1日</div></div>
+      </div>
+      <div>
+        <div class="sb-title">素材</div>
+        <div class="sb-item" style="color:#B0B0B0"><span>（なし）</span></div>
+      </div>
+      <div>
+        <div class="sb-title">完成品</div>
+        <div class="sb-item"><span>回復薬(A)</span><span>×1</span></div>
+        <div class="sb-item"><span>回復薬(C)</span><span>×1</span></div>
+      </div>
+      <div class="shop-btn"><i class="ti ti-shopping-cart"></i> ショップ</div>
+    </div>
+    <div class="workspace">
+      <div class="phase-title">
+        <div class="phase-bar"></div>
+        <span class="phase-text">納品</span>
+      </div>
+      <div class="delivery-body">
+        <div class="left-panel">
+          <div class="section-label">依頼と納品品を選択してください</div>
+          <!-- Quest 1: selected -->
+          <div class="quest-delivery-card selected">
+            <div class="qdc-header">
+              <div class="qdc-client-icon"><i class="ti ti-sword" style="color:#795548;font-size:14px"></i></div>
+              <div class="qdc-name">冒険者の依頼</div>
+              <span style="font-size:11px;background:#FFFDE7;color:#795548;padding:2px 8px;border-radius:9999px">E難易度</span>
+              <div class="qdc-deadline">期限 2日</div>
+            </div>
+            <div class="qdc-body">
+              <div class="qdc-require">
+                <div class="qdc-req-label">納品要求</div>
+                <div class="qdc-req-item">
+                  <div class="qdc-req-icon"><i class="ti ti-flask" style="color:#D4A76A;font-size:14px"></i></div>
+                  <span>回復薬 × 1</span>
+                  <span style="font-size:10px;background:#E8F5E8;color:#4A8A4A;padding:1px 6px;border-radius:9999px">B品質以上</span>
+                </div>
+              </div>
+              <div class="item-selector">
+                <div class="item-selector-label">納品品を選択</div>
+                <div class="item-chips">
+                  <div class="item-chip selected"><i class="ti ti-flask" style="color:#D4A76A"></i> 回復薬(A)</div>
+                  <div class="item-chip"><i class="ti ti-flask" style="color:#8A8A8A"></i> 回復薬(C)</div>
+                </div>
+              </div>
+              <div class="qdc-reward">
+                <div class="reward-gold"><i class="ti ti-coin"></i> 120 G</div>
+                <div class="reward-contrib"><i class="ti ti-star"></i> +16 pt</div>
+              </div>
+            </div>
+          </div>
+          <!-- Quest 2: not selected -->
+          <div class="quest-delivery-card">
+            <div class="qdc-header">
+              <div class="qdc-client-icon" style="background:#F5EFE6"><i class="ti ti-user" style="color:#795548;font-size:14px"></i></div>
+              <div class="qdc-name">村人の依頼</div>
+              <span style="font-size:11px;background:#FFFDE7;color:#795548;padding:2px 8px;border-radius:9999px">E難易度</span>
+              <div class="qdc-deadline">期限 1日</div>
+            </div>
+            <div class="qdc-body">
+              <div class="qdc-require">
+                <div class="qdc-req-label">納品要求</div>
+                <div class="qdc-req-item">
+                  <div class="qdc-req-icon"><i class="ti ti-flask" style="color:#D4A76A;font-size:14px"></i></div>
+                  <span>回復薬 × 1</span>
+                  <span style="font-size:10px;background:#F5F5F5;color:#888;padding:1px 6px;border-radius:9999px">品質不問</span>
+                </div>
+              </div>
+              <div class="item-selector">
+                <div class="item-selector-label">納品品を選択</div>
+                <div class="item-chips">
+                  <div class="item-chip empty">（未選択）</div>
+                </div>
+              </div>
+              <div class="qdc-reward">
+                <div class="reward-gold"><i class="ti ti-coin"></i> 80 G</div>
+                <div class="reward-contrib"><i class="ti ti-star"></i> +8 pt</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="right-panel">
+          <div class="preview-card">
+            <div class="preview-title">納品プレビュー</div>
+            <div class="preview-row">
+              <span style="color:#5A5A5A">対象依頼</span>
+              <span style="font-weight:500">冒険者の依頼</span>
+            </div>
+            <div class="preview-row">
+              <span style="color:#5A5A5A">納品品</span>
+              <span style="font-weight:500">回復薬(A品質)</span>
+            </div>
+            <div class="preview-row">
+              <span style="color:#5A5A5A">品質ボーナス</span>
+              <span style="font-weight:500;color:#7BAE7F">+4 pt</span>
+            </div>
+            <div class="preview-row">
+              <span style="color:#5A5A5A">獲得G</span>
+              <span style="font-weight:500;color:#D4A76A">120 G</span>
+            </div>
+            <div class="preview-row" style="border-bottom:none">
+              <span style="color:#5A5A5A">貢献度</span>
+              <span style="font-weight:500;color:#E0A84B">+16 pt</span>
+            </div>
+            <div class="contrib-gauge-wrap">
+              <div class="contrib-label">
+                <span>ランク昇格ゲージ</span>
+                <span style="font-weight:500">35 → <span style="color:#7BAE7F">58</span> / 100</span>
+              </div>
+              <div class="contrib-bar">
+                <div class="contrib-fill"></div>
+                <div class="contrib-fill-add"></div>
+              </div>
+              <div style="font-size:10px;color:#7BAE7F;text-align:right;margin-top:4px">+23 pt 予定</div>
+            </div>
+          </div>
+          <button class="submit-btn">
+            <i class="ti ti-package"></i> 納品する
+          </button>
+          <button class="skip-btn">
+            <i class="ti ti-skip-forward"></i> スキップ（納品しない）
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="footer">
+    <div class="phase-tabs">
+      <div class="ptab inactive"><i class="ti ti-clipboard-list"></i> 依頼</div>
+      <div class="ptab inactive"><i class="ti ti-plant"></i> 採取</div>
+      <div class="ptab inactive"><i class="ti ti-flask"></i> 調合</div>
+      <div class="ptab active"><i class="ti ti-package"></i> 納品</div>
+    </div>
+    <div class="footer-bottom">
+      <span style="font-size:10px;color:#8A8A8A">手札</span>
+      <div class="hand-cards">
+        <div class="hand-card" style="border-color:#E8A87C;border-width:2px"><i class="ti ti-package" style="color:#E8A87C;font-size:20px"></i><span>納品</span></div>
+        <div class="hand-card" style="border-color:#D4A76A"><i class="ti ti-flask" style="color:#D4A76A;font-size:20px"></i><span>レシピ</span></div>
+        <div class="hand-card" style="border-color:#B8A9D4"><i class="ti ti-sparkles" style="color:#B8A9D4;font-size:20px"></i><span>強化</span></div>
+        <div class="hand-card"><i class="ti ti-leaf" style="color:#8CC084;font-size:20px"></i><span>採取</span></div>
+        <div class="hand-card" style="border-color:#6B9FCC"><i class="ti ti-star" style="color:#6B9FCC;font-size:20px"></i><span>スキル</span></div>
+      </div>
+      <div class="footer-btns">
+        <button class="btn-rest"><i class="ti ti-coffee"></i> 休憩</button>
+        <button class="btn-dayend"><i class="ti ti-moon"></i> 日終了</button>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/design/atelier-guild-rank/ui-design/mockups/06-game-clear.html
+++ b/docs/design/atelier-guild-rank/ui-design/mockups/06-game-clear.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ゲームクリア — Atelier Guild Rank</title>
+<link href="https://fonts.googleapis.com/css2?family=M PLUS Rounded 1c:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css">
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #E8E0D6; display: flex; align-items: center; justify-content: center; min-height: 100vh; font-family: 'M PLUS Rounded 1c', sans-serif; padding: 24px; }
+  .screen { width: 560px; min-height: 560px; background: #FFF8F0; border-radius: 12px; overflow: hidden; display: flex; flex-direction: column; align-items: center; padding: 28px 24px; gap: 20px; font-size: 13px; color: #3D3D3D; border: 1px solid #D9CFC2; position: relative; box-shadow: 0 4px 24px rgba(0,0,0,0.1); }
+  .deco { position: absolute; border-radius: 50%; opacity: 0.06; }
+  .deco1 { width: 280px; height: 280px; background: #D4A76A; top: -60px; left: -60px; }
+  .deco2 { width: 200px; height: 200px; background: #7BAE7F; bottom: -40px; right: -40px; }
+  .clear-badge { background: #FFFDE7; border: 2px solid #E0A84B; border-radius: 9999px; padding: 5px 20px; font-size: 12px; font-weight: 500; color: #795548; letter-spacing: 2px; z-index: 1; }
+  .rank-display { background: #FFFFFF; border: 3px solid #E0A84B; border-radius: 20px; padding: 20px 40px; text-align: center; z-index: 1; display: flex; flex-direction: column; align-items: center; gap: 6px; width: 100%; }
+  .rank-s { font-size: 64px; font-weight: 500; color: #E0A84B; line-height: 1; }
+  .rank-title { font-size: 20px; font-weight: 500; }
+  .rank-divider { width: 40px; height: 2px; background: #E0A84B; border-radius: 9999px; }
+  .stats-panel { width: 100%; background: #FFFFFF; border: 1.5px solid #D9CFC2; border-radius: 14px; padding: 16px 20px; z-index: 1; }
+  .stats-title { font-size: 12px; font-weight: 500; color: #8A8A8A; margin-bottom: 12px; padding-left: 8px; border-left: 3px solid #D4A76A; }
+  .stats-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-bottom: 12px; }
+  .stat-card { background: #FFF8F0; border-radius: 10px; padding: 10px; text-align: center; }
+  .stat-num { font-size: 22px; font-weight: 500; }
+  .stat-label { font-size: 10px; color: #8A8A8A; }
+  .stats-row { display: flex; justify-content: space-between; padding: 6px 0; border-bottom: 1px solid #F0EBE3; font-size: 12px; }
+  .stats-row:last-child { border-bottom: none; }
+  .btn-row { display: flex; gap: 10px; z-index: 1; width: 100%; }
+  .btn-title { flex: 1; background: transparent; border: 2px solid #D9CFC2; border-radius: 9999px; padding: 10px 20px; font-size: 13px; color: #3D3D3D; cursor: pointer; font-family: inherit; display: flex; align-items: center; justify-content: center; gap: 6px; }
+  .btn-retry { flex: 1; background: #7BAE7F; color: #fff; border: none; border-radius: 9999px; padding: 10px 20px; font-size: 13px; font-weight: 500; cursor: pointer; font-family: inherit; display: flex; align-items: center; justify-content: center; gap: 6px; }
+</style>
+</head>
+<body>
+<div class="screen">
+  <div class="deco deco1"></div>
+  <div class="deco deco2"></div>
+  <div class="clear-badge"><i class="ti ti-trophy" style="color:#E0A84B"></i> &nbsp;GAME CLEAR&nbsp; <i class="ti ti-trophy" style="color:#E0A84B"></i></div>
+  <div class="rank-display">
+    <div class="rank-s">S</div>
+    <div class="rank-divider"></div>
+    <div style="font-size:13px;color:#5A5A5A">最高ランク到達</div>
+    <div class="rank-title">伝説の錬金術師</div>
+  </div>
+  <div class="stats-panel">
+    <div class="stats-title">プレイ統計</div>
+    <div class="stats-grid">
+      <div class="stat-card"><div class="stat-num">87</div><div class="stat-label">総プレイ日数</div></div>
+      <div class="stat-card"><div class="stat-num" style="color:#7BAE7F">156</div><div class="stat-label">達成依頼数</div></div>
+      <div class="stat-card"><div class="stat-num" style="color:#D4A76A">4,820</div><div class="stat-label">総獲得G</div></div>
+    </div>
+    <div class="stats-row"><span style="color:#5A5A5A"><i class="ti ti-flask" style="color:#D4A76A"></i> 調合回数</span><span style="font-weight:500">312 回</span></div>
+    <div class="stats-row"><span style="color:#5A5A5A"><i class="ti ti-leaf" style="color:#8CC084"></i> 採取素材数</span><span style="font-weight:500">847 個</span></div>
+    <div class="stats-row"><span style="color:#5A5A5A"><i class="ti ti-sparkles" style="color:#B8A9D4"></i> S品質作成数</span><span style="font-weight:500">28 個</span></div>
+    <div class="stats-row"><span style="color:#5A5A5A"><i class="ti ti-star" style="color:#E0A84B"></i> 最終貢献度</span><span style="font-weight:500;color:#E0A84B">9,450 pt</span></div>
+  </div>
+  <div class="btn-row">
+    <button class="btn-title"><i class="ti ti-home"></i> タイトルへ</button>
+    <button class="btn-retry"><i class="ti ti-refresh"></i> もう一度挑戦</button>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/design/atelier-guild-rank/ui-design/mockups/07-shop.html
+++ b/docs/design/atelier-guild-rank/ui-design/mockups/07-shop.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ショップ — Atelier Guild Rank</title>
+<link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css">
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #E8E0D6; display: flex; align-items: center; justify-content: center; min-height: 100vh; font-family: 'M PLUS Rounded 1c', sans-serif; padding: 24px; }
+  .screen { width: 900px; min-height: 640px; background: #FFF8F0; border-radius: 12px; overflow: hidden; display: flex; flex-direction: column; font-size: 13px; color: #3D3D3D; border: 1px solid #D9CFC2; box-shadow: 0 4px 24px rgba(0,0,0,0.1); }
+  .shop-header { background: #FDFAF5; border-bottom: 1px solid #E8E0D6; padding: 10px 16px; display: flex; align-items: center; gap: 12px; flex-shrink: 0; }
+  .shop-title { font-size: 16px; font-weight: 500; display: flex; align-items: center; gap: 6px; }
+  .gold-display { display: flex; align-items: center; gap: 4px; font-size: 14px; font-weight: 500; color: #D4A76A; margin-left: auto; }
+  .close-btn { background: transparent; border: 1.5px solid #D9CFC2; border-radius: 9999px; padding: 5px 14px; font-size: 12px; color: #3D3D3D; cursor: pointer; }
+  .shop-body { display: flex; flex: 1; }
+  .cat-sidebar { width: 140px; flex-shrink: 0; background: #F5EFE6; border-right: 1px solid #E8E0D6; padding: 12px 8px; display: flex; flex-direction: column; gap: 4px; }
+  .cat-item { display: flex; align-items: center; gap: 8px; padding: 8px 10px; border-radius: 10px; font-size: 12px; cursor: pointer; color: #5A5A5A; }
+  .cat-item.active { background: #FFFFFF; color: #3D3D3D; font-weight: 500; border: 1px solid #D9CFC2; }
+  .cat-item:hover { background: rgba(255,255,255,0.5); }
+  .cat-icon { width: 24px; text-align: center; }
+  .product-area { flex: 1; padding: 14px; display: flex; flex-direction: column; gap: 12px; overflow-y: auto; }
+  .cat-title { font-size: 12px; font-weight: 500; color: #5A5A5A; padding-left: 8px; border-left: 3px solid #D4A76A; }
+  .product-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+  .product-card { background: #FFFFFF; border: 1.5px solid #D9CFC2; border-radius: 10px; padding: 12px; display: flex; flex-direction: column; align-items: center; gap: 8px; cursor: pointer; text-align: center; }
+  .product-card:hover { border-color: #D4A76A; box-shadow: 0 2px 8px rgba(0,0,0,0.06); }
+  .product-card.selected { border: 2px solid #D4A76A; background: #FFF8E7; }
+  .product-icon { width: 44px; height: 44px; border-radius: 9999px; display: flex; align-items: center; justify-content: center; }
+  .product-name { font-size: 12px; font-weight: 500; }
+  .product-desc { font-size: 10px; color: #8A8A8A; line-height: 1.4; }
+  .product-price { font-size: 13px; font-weight: 500; color: #D4A76A; display: flex; align-items: center; gap: 3px; }
+  .product-tag { font-size: 10px; padding: 2px 6px; border-radius: 9999px; }
+  .tag-new { background: #E8F5E8; color: #4A8A4A; }
+  .tag-popular { background: #FFF3EB; color: #C05020; }
+  .detail-bar { background: #FDFAF5; border-top: 1px solid #E8E0D6; padding: 12px 16px; display: flex; align-items: center; gap: 14px; flex-shrink: 0; }
+  .detail-item-icon { width: 40px; height: 40px; border-radius: 9999px; background: #FFF8E7; border: 2px solid #D4A76A; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .detail-info { flex: 1; }
+  .detail-name { font-size: 14px; font-weight: 500; }
+  .detail-desc { font-size: 11px; color: #5A5A5A; margin-top: 2px; }
+  .detail-price { font-size: 16px; font-weight: 500; color: #D4A76A; display: flex; align-items: center; gap: 4px; }
+  .buy-btn { background: #7BAE7F; color: #fff; border: none; border-radius: 9999px; padding: 10px 28px; font-size: 13px; font-weight: 500; cursor: pointer; display: flex; align-items: center; gap: 6px; white-space: nowrap; }
+  .buy-btn:disabled { background: #C5D9C6; cursor: not-allowed; }
+  .cant-afford { font-size: 11px; color: #D46B6B; margin-top: 2px; }
+</style>
+</head>
+<body>
+<div class="screen">
+  <div class="shop-header">
+    <div class="shop-title"><i class="ti ti-shopping-bag" style="color:#D4A76A;font-size:20px"></i> ギルドショップ</div>
+    <span style="font-size:11px;color:#8A8A8A">素材・レシピ・強化カードを購入できるのだ</span>
+    <div class="gold-display"><i class="ti ti-coin"></i> 178 G</div>
+    <button class="close-btn"><i class="ti ti-x"></i> 閉じる</button>
+  </div>
+  <div class="shop-body">
+    <div class="cat-sidebar">
+      <div style="font-size:10px;color:#8A8A8A;padding:4px 6px;margin-bottom:4px">カテゴリ</div>
+      <div class="cat-item active"><span class="cat-icon"><i class="ti ti-leaf" style="color:#8CC084"></i></span> 素材</div>
+      <div class="cat-item"><span class="cat-icon"><i class="ti ti-flask" style="color:#D4A76A"></i></span> レシピ</div>
+      <div class="cat-item"><span class="cat-icon"><i class="ti ti-sparkles" style="color:#B8A9D4"></i></span> 強化カード</div>
+      <div class="cat-item"><span class="cat-icon"><i class="ti ti-bolt" style="color:#7BAE7F"></i></span> 行動力</div>
+      <div class="cat-item"><span class="cat-icon"><i class="ti ti-star" style="color:#E0A84B"></i></span> 特殊</div>
+    </div>
+    <div class="product-area">
+      <div class="cat-title">素材</div>
+      <div class="product-grid">
+        <div class="product-card">
+          <div class="product-icon" style="background:#F0FAF0;border:2px solid #8CC084"><i class="ti ti-leaf" style="color:#8CC084;font-size:22px"></i></div>
+          <div class="product-name">薬草</div>
+          <div class="product-desc">基本的な回復素材。どの依頼にも使える。</div>
+          <div class="product-price"><i class="ti ti-coin"></i> 20 G</div>
+        </div>
+        <div class="product-card">
+          <div class="product-icon" style="background:#EBF4FF;border:2px solid #6B9FCC"><i class="ti ti-droplet" style="color:#6B9FCC;font-size:22px"></i></div>
+          <div class="product-name">清水</div>
+          <div class="product-desc">薬効成分を引き出す清らかな水。</div>
+          <div class="product-price"><i class="ti ti-coin"></i> 15 G</div>
+        </div>
+        <div class="product-card selected">
+          <div class="product-icon" style="background:#FFF8E7;border:2px solid #E0A84B;position:relative">
+            <i class="ti ti-sparkles" style="color:#E0A84B;font-size:22px"></i>
+          </div>
+          <div style="display:flex;align-items:center;gap:4px"><div class="product-name">光苔</div><span class="product-tag tag-popular">人気</span></div>
+          <div class="product-desc">希少な発光性素材。高品質調合に必須。</div>
+          <div class="product-price"><i class="ti ti-coin"></i> 80 G</div>
+        </div>
+        <div class="product-card">
+          <div class="product-icon" style="background:#F5EFE6;border:2px solid #A08060"><i class="ti ti-mushroom" style="color:#A08060;font-size:22px"></i></div>
+          <div class="product-name">キノコ</div>
+          <div class="product-desc">独特の香りを持つ森の恵み。</div>
+          <div class="product-price"><i class="ti ti-coin"></i> 25 G</div>
+        </div>
+        <div class="product-card">
+          <div class="product-icon" style="background:#FFF0F5;border:2px solid #D49090"><i class="ti ti-flower" style="color:#D49090;font-size:22px"></i></div>
+          <div style="display:flex;align-items:center;gap:4px"><div class="product-name">薬花</div><span class="product-tag tag-new">新入荷</span></div>
+          <div class="product-desc">甘い香りの花びら。調合補助効果あり。</div>
+          <div class="product-price"><i class="ti ti-coin"></i> 45 G</div>
+        </div>
+        <div class="product-card" style="opacity:0.5;cursor:not-allowed">
+          <div class="product-icon" style="background:#F5F5F5;border:2px solid #C0C0C0"><i class="ti ti-gem" style="color:#C0C0C0;font-size:22px"></i></div>
+          <div class="product-name" style="color:#8A8A8A">宝石の欠片</div>
+          <div class="product-desc" style="color:#B0B0B0">ランクF以上で解放</div>
+          <div class="product-price" style="color:#B0B0B0"><i class="ti ti-lock" style="font-size:12px"></i> 未解放</div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="detail-bar">
+    <div class="detail-item-icon"><i class="ti ti-sparkles" style="color:#E0A84B;font-size:20px"></i></div>
+    <div class="detail-info">
+      <div class="detail-name">光苔</div>
+      <div class="detail-desc">希少な発光性素材。品質値 +10 ボーナスを持ち、S品質調合に欠かせない素材なのだ。</div>
+      <div class="cant-afford"><i class="ti ti-alert-circle"></i> 所持G不足（80G必要 / 178G所持）</div>
+    </div>
+    <div style="text-align:right">
+      <div class="detail-price"><i class="ti ti-coin"></i> 80 G</div>
+      <div style="font-size:10px;color:#8A8A8A;margin-top:2px;margin-bottom:8px">在庫 3個</div>
+      <button class="buy-btn"><i class="ti ti-shopping-cart"></i> 購入する</button>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/design/atelier-guild-rank/ui-design/mockups/08-rank-up.html
+++ b/docs/design/atelier-guild-rank/ui-design/mockups/08-rank-up.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ランク昇格試験 — Atelier Guild Rank</title>
+<link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css">
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #E8E0D6; display: flex; align-items: center; justify-content: center; min-height: 100vh; font-family: 'M PLUS Rounded 1c', sans-serif; padding: 24px; }
+  .screen { width: 600px; background: #FFF8F0; border-radius: 12px; overflow: hidden; display: flex; flex-direction: column; font-size: 13px; color: #3D3D3D; border: 1px solid #D9CFC2; box-shadow: 0 4px 24px rgba(0,0,0,0.1); position: relative; }
+  .deco { position: absolute; border-radius: 50%; opacity: 0.06; pointer-events: none; }
+  .deco1 { width: 260px; height: 260px; background: #D4A76A; top: -60px; right: -60px; }
+  .deco2 { width: 180px; height: 180px; background: #7BAE7F; bottom: 40px; left: -40px; }
+  .exam-header { background: linear-gradient(135deg, #FFF8E7, #FFF8F0); border-bottom: 1px solid #E8E0D6; padding: 16px 20px; display: flex; align-items: center; gap: 12px; z-index: 1; }
+  .exam-badge { background: #FFFDE7; border: 2px solid #E0A84B; border-radius: 9999px; padding: 4px 14px; font-size: 12px; font-weight: 500; color: #795548; letter-spacing: 1px; }
+  .exam-title { font-size: 15px; font-weight: 500; flex: 1; }
+  .rank-transition { display: flex; align-items: center; gap: 8px; }
+  .rank-chip { background: #FFFDE7; border: 2px solid #E0A84B; border-radius: 8px; padding: 4px 12px; font-size: 18px; font-weight: 500; color: #E0A84B; }
+  .rank-arrow { font-size: 16px; color: #8A8A8A; }
+  .rank-chip.next { background: #F0FAF0; border-color: #7BAE7F; color: #4A8A4A; }
+  .exam-body { padding: 18px 20px; display: flex; flex-direction: column; gap: 14px; z-index: 1; }
+  .staff-bubble { display: flex; gap: 12px; align-items: flex-start; }
+  .staff-avatar { width: 44px; height: 44px; border-radius: 9999px; background: #F5EFE6; border: 2px solid #D4A76A; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .bubble { background: #FFFFFF; border: 1.5px solid #D9CFC2; border-radius: 12px; border-top-left-radius: 4px; padding: 10px 14px; flex: 1; font-size: 12px; line-height: 1.7; color: #5A5A5A; }
+  .bubble b { color: #3D3D3D; }
+  .progress-section { background: #FFFFFF; border: 1.5px solid #D9CFC2; border-radius: 12px; padding: 14px 16px; }
+  .progress-title { font-size: 12px; font-weight: 500; color: #8A8A8A; margin-bottom: 10px; padding-left: 8px; border-left: 3px solid #D4A76A; }
+  .contrib-bar-wrap { margin-bottom: 6px; }
+  .contrib-bar-label { display: flex; justify-content: space-between; font-size: 12px; margin-bottom: 6px; }
+  .contrib-bar-label strong { color: #E0A84B; }
+  .contrib-bar { height: 14px; background: #E8E0D6; border-radius: 9999px; overflow: hidden; }
+  .contrib-fill { height: 100%; width: 100%; background: linear-gradient(90deg, #D4A76A, #E0A84B); border-radius: 9999px; }
+  .contrib-note { font-size: 11px; color: #7BAE7F; text-align: right; margin-top: 4px; }
+  .checklist { display: flex; flex-direction: column; gap: 6px; margin-top: 10px; }
+  .check-item { display: flex; align-items: center; gap: 8px; font-size: 12px; padding: 6px 8px; border-radius: 8px; }
+  .check-item.done { background: #F0FAF0; color: #4A8A4A; }
+  .check-item.fail { background: #FFF5F5; color: #D46B6B; }
+  .check-item.pending { background: #F5F5F5; color: #8A8A8A; }
+  .check-icon { width: 20px; height: 20px; border-radius: 9999px; display: flex; align-items: center; justify-content: center; font-size: 12px; flex-shrink: 0; }
+  .check-icon.done { background: #7BAE7F; color: #fff; }
+  .check-icon.fail { background: #D46B6B; color: #fff; }
+  .check-icon.pending { background: #C0C0C0; color: #fff; }
+  .check-label { flex: 1; }
+  .check-val { font-size: 11px; font-weight: 500; }
+  .result-notice { background: #FFFDE7; border: 1.5px solid #E0A84B; border-radius: 10px; padding: 10px 14px; display: flex; gap: 10px; align-items: flex-start; }
+  .btn-row { display: flex; gap: 10px; }
+  .btn-primary { flex: 1; background: #7BAE7F; color: #fff; border: none; border-radius: 9999px; padding: 11px; font-size: 13px; font-weight: 500; cursor: pointer; font-family: inherit; display: flex; align-items: center; justify-content: center; gap: 6px; }
+  .btn-secondary { flex: 1; background: transparent; border: 2px solid #D9CFC2; border-radius: 9999px; padding: 10px; font-size: 13px; color: #3D3D3D; cursor: pointer; font-family: inherit; display: flex; align-items: center; justify-content: center; gap: 6px; }
+</style>
+</head>
+<body>
+<div class="screen">
+  <div class="deco deco1"></div>
+  <div class="deco deco2"></div>
+  <div class="exam-header">
+    <div class="exam-badge"><i class="ti ti-certificate" style="color:#E0A84B"></i> 昇格試験</div>
+    <div class="exam-title">ランク昇格のお知らせ</div>
+    <div class="rank-transition">
+      <div class="rank-chip">G</div>
+      <div class="rank-arrow"><i class="ti ti-arrow-right"></i></div>
+      <div class="rank-chip next">F</div>
+    </div>
+  </div>
+  <div class="exam-body">
+    <div class="staff-bubble">
+      <div class="staff-avatar"><i class="ti ti-user" style="color:#D4A76A;font-size:22px"></i></div>
+      <div class="bubble">
+        おめでとうございます、錬金術師さん！<br>
+        <b>ランク G から F への昇格条件</b>を達成しました。<br>
+        これまでのギルドへの貢献に感謝します。<br>
+        新たなランクでも、引き続きよろしくお願いします！
+      </div>
+    </div>
+
+    <div class="progress-section">
+      <div class="progress-title">昇格条件の達成状況</div>
+      <div class="contrib-bar-wrap">
+        <div class="contrib-bar-label">
+          <span>総貢献度</span>
+          <span><strong>100 pt</strong> / 100 pt</span>
+        </div>
+        <div class="contrib-bar"><div class="contrib-fill"></div></div>
+        <div class="contrib-note"><i class="ti ti-check"></i> 貢献度条件クリア！</div>
+      </div>
+      <div class="checklist">
+        <div class="check-item done">
+          <div class="check-icon done"><i class="ti ti-check"></i></div>
+          <div class="check-label">依頼を達成する</div>
+          <div class="check-val">12 件 ✓</div>
+        </div>
+        <div class="check-item done">
+          <div class="check-icon done"><i class="ti ti-check"></i></div>
+          <div class="check-label">調合品を納品する</div>
+          <div class="check-val">8 個 ✓</div>
+        </div>
+        <div class="check-item done">
+          <div class="check-icon done"><i class="ti ti-check"></i></div>
+          <div class="check-label">期限内に完了した依頼</div>
+          <div class="check-val">12 / 12 件 ✓</div>
+        </div>
+        <div class="check-item done">
+          <div class="check-icon done"><i class="ti ti-check"></i></div>
+          <div class="check-label">貢献度を達成する</div>
+          <div class="check-val">100 pt ✓</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="result-notice">
+      <i class="ti ti-star-filled" style="color:#E0A84B;font-size:20px;flex-shrink:0;margin-top:2px"></i>
+      <div>
+        <div style="font-size:12px;font-weight:500;margin-bottom:4px">ランクF解放コンテンツ</div>
+        <div style="font-size:11px;color:#5A5A5A;line-height:1.6">
+          ・新しい採取エリア「古代遺跡の丘」が解放されるのだ<br>
+          ・レシピ「中級回復薬」が購入可能になるのだ<br>
+          ・ランクF専用依頼が追加されるのだ
+        </div>
+      </div>
+    </div>
+
+    <div class="btn-row">
+      <button class="btn-secondary"><i class="ti ti-arrow-left"></i> 後で確認</button>
+      <button class="btn-primary"><i class="ti ti-trophy"></i> 昇格を受け入れる</button>
+    </div>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- 全8画面のUIモックアップHTMLファイルを追加（タイトル・依頼受注・採取・調合・納品・ゲームクリア・ショップ・ランクアップ）
- モックアップ実装計画ドキュメントを追加

## Test plan
- [ ] 各モックアップHTMLをブラウザで開いて表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)