### PR TITLE
feat: FooterUIをモックアップ仕様に作り直し (TASK-0004)

### DIFF
--- a/atelier-guild-rank/src/shared/components/FooterUI.ts
+++ b/atelier-guild-rank/src/shared/components/FooterUI.ts
@@ -58,13 +58,15 @@ const FOOTER_LAYOUT = {
   /** PhaseTabUIのY座標オフセット */
   PHASE_TAB_Y: 0,
   /** 手札表示Y座標（タブ行と重ならないよう下部に配置） */
-  HAND_Y: 85,
+  HAND_Y: 80,
   /** 手札表示開始X座標 */
   HAND_START_X: 320,
-  /** カード幅 */
-  CARD_WIDTH: 50,
-  /** カード高さ */
-  CARD_HEIGHT: 60,
+  /** カード幅（TASK-0004: モック 52px） */
+  CARD_WIDTH: 52,
+  /** カード高さ（TASK-0004: モック 68px） */
+  CARD_HEIGHT: 68,
+  /** カード枠線幅（TASK-0004: モック 1.5px） */
+  CARD_BORDER_WIDTH: 1.5,
   /** カード間のスペース */
   CARD_SPACING: 60,
 } as const;
@@ -158,13 +160,13 @@ export class FooterUI extends BaseComponent {
     ).setName('FooterUI.backgroundPanel');
     this.container.add(this._backgroundPanel);
 
-    // 上部ボーダーライン
+    // 上部ボーダーライン（TASK-0004: モック 1px）
     const borderLine = new Phaser.GameObjects.Rectangle(
       this.scene,
       FOOTER_LAYOUT.WIDTH / 2,
       1,
       FOOTER_LAYOUT.WIDTH,
-      2,
+      1,
       FOOTER_COLORS.BORDER,
       1,
     ).setName('FooterUI.borderLine');
@@ -197,7 +199,10 @@ export class FooterUI extends BaseComponent {
         FOOTER_COLORS.CARD_PLACEHOLDER,
         0.5,
       ).setName(`FooterUI.cardPlaceholder${i}`);
-      placeholder.setStrokeStyle(2, FOOTER_COLORS.CARD_PLACEHOLDER_BORDER);
+      placeholder.setStrokeStyle(
+        FOOTER_LAYOUT.CARD_BORDER_WIDTH,
+        FOOTER_COLORS.CARD_PLACEHOLDER_BORDER,
+      );
       this.container.add(placeholder);
       this._handDisplayArea.push(placeholder);
     }

--- a/atelier-guild-rank/tests/unit/presentation/ui/components/footer-ui-visual.test.ts
+++ b/atelier-guild-rank/tests/unit/presentation/ui/components/footer-ui-visual.test.ts
@@ -153,7 +153,6 @@ const createMockEventBus = (): MockEventBus => ({
 describe('FooterUI（TASK-0112）', () => {
   let scene: MockScene;
   let mockContainer: MockContainer;
-  let mockRectangles: MockRectangle[];
   let mockGameFlowManager: MockGameFlowManager;
   let mockEventBus: MockEventBus;
   let footerUI: FooterUI;
@@ -162,7 +161,6 @@ describe('FooterUI（TASK-0112）', () => {
     const mocks = createMockScene();
     scene = mocks.scene;
     mockContainer = mocks.mockContainer;
-    mockRectangles = mocks.mockRectangles;
     mockGameFlowManager = createMockGameFlowManager();
     mockEventBus = createMockEventBus();
 
@@ -293,6 +291,15 @@ describe('FooterUI（TASK-0112）', () => {
 
       expect(footerUI.getHandDisplayAreaCapacity()).toBe(5);
       expect(footerUI.getHandDisplayArea()).toHaveLength(5);
+    });
+
+    it('TASK-0004: 手札カードがモック仕様 52x68px で生成される', () => {
+      footerUI.create();
+
+      // Phaser.GameObjects.Rectangle の呼び出しに width=52, height=68 が含まれる
+      const rectCalls = vi.mocked(Phaser.GameObjects.Rectangle).mock.calls;
+      const handCardCalls = rectCalls.filter((call) => call[3] === 52 && call[4] === 68);
+      expect(handCardCalls).toHaveLength(5);
     });
   });
 


### PR DESCRIPTION
## Summary
- 上部ボーダーを **1px** に変更（モック `.footer` 準拠）
- 手札カードを **52x68px**・枠線 **1.5px**（`border.default` #D9CFC2）に変更
- 背景 `surface.footer` (#F0EBE3) と PhaseTabUI（休息/日終了ボタン）統合は維持
- 日終了ボタンは既に `status.error` (#D46B6B) デンジャースタイルのため変更不要であることを確認

## 備考
- 休息/日終了ボタンは PhaseTabUI に既存（TASK-0005 PhaseRail で更にスタイル調整予定）
- 既存公開API（`getPhaseTabUI` / `getHandDisplayArea` / `getHandDisplayAreaCapacity`）は維持
- 手札カード寸法を検証するテストを追加、未使用変数 `mockRectangles` を除去

## Test plan
- [x] `pnpm test -- --run tests/unit/presentation/ui/components/footer-ui-visual.test.ts`（11件pass）
- [x] `pnpm typecheck`
- [x] `pnpm lint`（変更ファイル警告0）

Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)