### PR TITLE
feat: 依頼受注フェーズUIをモックアップ仕様に作り直し (TASK-0006)

### DIFF
--- a/atelier-guild-rank/src/shared/presentation/ui/components/QuestCardUI.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/components/QuestCardUI.ts
@@ -191,7 +191,9 @@ export class QuestCardUI extends BaseComponent {
       dialogue,
       {
         fontSize: '16px',
-        color: toColorStr(Colors.text.primary),
+        // TASK-0006: セリフは italic + ミューテッド (#8A8A8A)
+        color: toColorStr(Colors.text.muted),
+        fontStyle: 'italic',
         wordWrap: { width: QuestCardUI.CARD_WIDTH - QuestCardUI.PADDING * 2 },
       },
     );
@@ -219,7 +221,8 @@ export class QuestCardUI extends BaseComponent {
       conditionLabel,
       {
         fontSize: '16px',
-        color: toColorStr(Colors.status.info),
+        // TASK-0006: 条件はアンバー (#D4A76A: text.accent)
+        color: toColorStr(Colors.text.accent),
         fontStyle: 'bold',
       },
     );
@@ -252,7 +255,8 @@ export class QuestCardUI extends BaseComponent {
       rewardText,
       {
         fontSize: '16px',
-        color: toColorStr(Colors.text.primary),
+        // TASK-0006: 報酬は本文グレー (#5A5A5A: text.secondary)
+        color: toColorStr(Colors.text.secondary),
       },
     );
     this.rewardText.setOrigin(0, 0);
@@ -283,7 +287,8 @@ export class QuestCardUI extends BaseComponent {
       deadlineText,
       {
         fontSize: '16px',
-        color: toColorStr(Colors.text.secondary),
+        // TASK-0006: 期限はミューテッド (#8A8A8A: text.muted)
+        color: toColorStr(Colors.text.muted),
       },
     );
     this.deadlineText.setOrigin(0, 0);

--- a/atelier-guild-rank/src/shared/presentation/ui/phases/QuestAcceptPhaseUI.ts
+++ b/atelier-guild-rank/src/shared/presentation/ui/phases/QuestAcceptPhaseUI.ts
@@ -172,8 +172,11 @@ export class QuestAcceptPhaseUI extends BaseComponent {
    * 【タイトルスタイル定数】: タイトルテキストのスタイル
    */
   private static readonly TITLE_FONT_SIZE = '24px';
-  private static readonly TITLE_COLOR = toColorStr(Colors.text.primary);
+  // TASK-0006: フェーズタイトルはラベンダーアクセント (#B8A9D4)
+  private static readonly TITLE_COLOR = toColorStr(Colors.phase.questAccept);
   private static readonly TITLE_TEXT = '📋 本日の依頼';
+  /** タイトル左アクセントバー幅（モック: 4px） */
+  private static readonly TITLE_BAR_WIDTH = 4;
 
   /**
    * 【受注済みセクション定数】: 受注済み依頼の表示レイアウト（Issue #431）
@@ -259,6 +262,21 @@ export class QuestAcceptPhaseUI extends BaseComponent {
     });
     this.titleText.setOrigin(0.5, 0);
     this.container.add(this.titleText);
+
+    // TASK-0006: タイトル左に 4px のラベンダーアクセントバーを配置
+    const titleWidth = this.titleText.width || 0;
+    const barHeight = 28;
+    const barX = CONTENT_WORK_CENTER_X - titleWidth / 2 - 12;
+    const accentBar = this.scene.add.rectangle(
+      barX,
+      20 + barHeight / 2,
+      QuestAcceptPhaseUI.TITLE_BAR_WIDTH,
+      barHeight,
+      Colors.phase.questAccept,
+    );
+    accentBar.setOrigin(0.5, 0.5);
+    if (accentBar.setName) accentBar.setName('QuestAcceptPhaseUI.titleAccentBar');
+    this.container.add(accentBar);
   }
 
   /**

--- a/atelier-guild-rank/tests/unit/presentation/ui/phases/QuestAcceptPhaseUI-accepted-quests.test.ts
+++ b/atelier-guild-rank/tests/unit/presentation/ui/phases/QuestAcceptPhaseUI-accepted-quests.test.ts
@@ -59,6 +59,12 @@ vi.mock('@presentation/ui/theme', () => ({
     status: {
       info: 0x6b9fcc,
     },
+    phase: {
+      questAccept: 0xb8a9d4,
+      gathering: 0x8cc084,
+      alchemy: 0xd4a76a,
+      delivery: 0xe8a87c,
+    },
   },
   toColorStr: (color: number) => `#${color.toString(16).padStart(6, '0')}`,
 }));

--- a/atelier-guild-rank/tests/unit/presentation/ui/phases/QuestAcceptPhaseUI-board-visitor.test.ts
+++ b/atelier-guild-rank/tests/unit/presentation/ui/phases/QuestAcceptPhaseUI-board-visitor.test.ts
@@ -60,6 +60,12 @@ vi.mock('@presentation/ui/theme', () => ({
     status: {
       info: 0x6b9fcc,
     },
+    phase: {
+      questAccept: 0xb8a9d4,
+      gathering: 0x8cc084,
+      alchemy: 0xd4a76a,
+      delivery: 0xe8a87c,
+    },
   },
   toColorStr: (color: number) => `#${color.toString(16).padStart(6, '0')}`,
 }));


### PR DESCRIPTION
## Summary
- フェーズタイトルを **ラベンダーアクセント** (#B8A9D4: `phase.questAccept`) 化し、左に **4px アクセントバー**を追加（モック02準拠）
- 依頼カードのテキスト色をモックに統一:
  - セリフ: italic + `text.muted` (#8A8A8A)
  - 条件: `text.accent` (#D4A76A)
  - 報酬: `text.secondary` (#5A5A5A)
  - 期限: `text.muted` (#8A8A8A)
- 3列グリッド・カード枠（border.default 2px / radius）・モーダル受注フロー・公開APIは維持（見た目重視・API維持方針）

## 備考
- カード選択(3px枠+チェック)/インライン詳細パネルはモーダルベースの現行フローを維持するため見送り（API維持方針）
- 既存テストの `@presentation/ui/theme` Colorsモックに `phase` トークンを追加

## Test plan
- [x] `pnpm test -- --run`（本PR起因の失敗0件。残5件はmain既存）
- [x] `pnpm typecheck` / `pnpm lint`（変更ファイル警告0）

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)