### PR TITLE
feat: 採取フェーズUIをモックアップ仕様に作り直し (TASK-0007)

### DIFF
--- a/atelier-guild-rank/src/features/gathering/components/GatheringPhaseUI.ts
+++ b/atelier-guild-rank/src/features/gathering/components/GatheringPhaseUI.ts
@@ -102,14 +102,27 @@ export class GatheringPhaseUI extends BaseComponent {
     return t;
   }
 
+  /** TASK-0007: フェーズタイトル左に 4px のリーフグリーンアクセントバーを配置 */
+  private addTitleAccentBar(titleY: number): void {
+    const titleWidth = this.titleText.width || 0;
+    const barHeight = 28;
+    const barX = CONTENT_WORK_CENTER_X - titleWidth / 2 - 12;
+    const bar = this.scene.add.rectangle(barX, titleY, 4, barHeight, Colors.phase.gathering);
+    if (bar.setOrigin) bar.setOrigin(0.5, 0.5);
+    if (bar.setName) bar.setName('GatheringPhaseUI.titleAccentBar');
+    this.container.add(bar);
+  }
+
   private createHeaderUI(): void {
+    // TASK-0007: タイトルをリーフグリーンアクセント (#8CC084) 化
     this.titleText = this.makeText(
       20,
       '🌿 採取フェーズ',
       THEME.sizes.xlarge,
-      THEME.colors.text,
+      Colors.phase.gathering,
       true,
     );
+    this.addTitleAccentBar(20);
     this.remainingText = this.makeText(
       60,
       '残り選択回数: 0/0',


### PR DESCRIPTION
## Summary
- 採取フェーズタイトルを **リーフグリーンアクセント** (#8CC084: `phase.gathering`) 化し、左に **4px アクセントバー**を追加（モック03準拠）
- 既存のラウンド制ドラフト採取フロー・公開APIは維持（見た目重視・API維持方針）

## 備考
- ドラフトカードの選択枠(3px)・品質バッジ(C/B)配色はサブコンポーネント(MaterialPool/カード)側の領域のため本PRではタイトルアクセントに限定

## Test plan
- [x] `pnpm test -- --run`（gathering 199件pass、本PR起因の失敗0件。残5件はmain既存）
- [x] `pnpm typecheck` / `pnpm lint`（変更ファイル警告0）

Closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)