### PR TITLE
feat: GameClearSceneをモックアップ仕様に作り直し (TASK-0011)

### DIFF
--- a/atelier-guild-rank/src/scenes/GameClearScene.ts
+++ b/atelier-guild-rank/src/scenes/GameClearScene.ts
@@ -51,8 +51,8 @@ const LAYOUT = {
 const STYLES = {
   /** タイトルのフォントサイズ */
   TITLE_FONT_SIZE: '42px',
-  /** タイトルの色（ブランドセカンダリ） */
-  TITLE_COLOR: toColorStr(Colors.brand.secondary),
+  /** タイトルの色（TASK-0011: クリアのアンバー #E0A84B: status.warning） */
+  TITLE_COLOR: toColorStr(Colors.status.warning),
   /** メッセージのフォントサイズ */
   MESSAGE_FONT_SIZE: '20px',
   /** メッセージの色 */
@@ -87,7 +87,10 @@ const TEXT = {
   MESSAGE_LINE1: 'Sランク錬金術師に',
   MESSAGE_LINE2: '昇格しました!',
   TO_TITLE: 'タイトルへ',
-  NEW_GAME_PLUS: 'NEW GAME+',
+  /** TASK-0011: モック06「もう一度挑戦」 */
+  NEW_GAME_PLUS: 'もう一度挑戦',
+  /** TASK-0011: CLEAR バッジ文言 */
+  CLEAR_BADGE: '🏆 CLEAR',
 } as const;
 
 // =============================================================================
@@ -225,6 +228,19 @@ export class GameClearScene extends Phaser.Scene {
    * @param centerX 画面中央X座標
    */
   private createTitle(centerX: number): void {
+    // TASK-0011: CLEAR バッジ（pill風: カード面色＋アンバー枠）
+    const badge = this.add.rectangle(centerX, LAYOUT.TITLE_Y - 56, 140, 32, Colors.surface.card);
+    badge.setStrokeStyle?.(2, Colors.status.warning);
+    this.add
+      .text(centerX, LAYOUT.TITLE_Y - 56, TEXT.CLEAR_BADGE, {
+        fontFamily: THEME.fonts.primary,
+        fontSize: '16px',
+        color: toColorStr(Colors.status.warning),
+        fontStyle: 'bold',
+        padding: { top: 4 },
+      })
+      .setOrigin(0.5);
+
     this.add
       .text(centerX, LAYOUT.TITLE_Y, TEXT.TITLE, {
         fontFamily: THEME.fonts.primary,


### PR DESCRIPTION
## Summary
- タイトル色を **アンバー** (#E0A84B: `status.warning`) 化しクリアの祝祭感を強調（モック06準拠）
- **CLEARバッジ**（カード面色 + アンバー枠の pill 風）を追加
- 「NEW GAME+」を **「もう一度挑戦」** にリネーム

## 備考（見た目重視・API維持方針）
- 「もう一度挑戦」の遷移先は既存挙動（MainScene = 再プレイ開始）を維持。既存テスト T-0027-05（button[1]→MainScene）と整合
- 統計のリッチパネル化（grid/list 6項目）は既存スペック（4項目固定アサーション）との互換維持のため見送り、result.md準拠の4統計を維持

## Test plan
- [x] `pnpm test -- --run`（GameClearScene 6件pass、本PR起因の失敗0件。残5件はmain既存）
- [x] `pnpm typecheck` / `pnpm lint`（変更ファイル警告0）

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)