### PR TITLE
feat: RankUpSceneをモックアップ仕様に作り直し (TASK-0013)

### DIFF
--- a/atelier-guild-rank/src/scenes/components/rankup/RankUpRequirements.ts
+++ b/atelier-guild-rank/src/scenes/components/rankup/RankUpRequirements.ts
@@ -7,7 +7,7 @@
  * 課題の完了状態と期限を表示する。
  */
 
-import { Colors } from '@presentation/ui/theme';
+import { Colors, toColorStr } from '@presentation/ui/theme';
 import { UIBackgroundBuilder } from '@presentation/ui/utils';
 import type { RankTestTask } from './types';
 
@@ -23,19 +23,23 @@ const UI_TEXT = {
   TASK_PENDING: '○',
 } as const;
 
-/** スタイル定数 */
+/**
+ * スタイル定数
+ * TASK-0013: ハードコード色をデザイントークンに統一（モック08チェックリスト配色）
+ * - 完了: status.success（緑）/ 未達: text.secondary（灰）/ 見出し: text.primary
+ */
 const UI_STYLES = {
   TASK_TITLE: {
     fontSize: '18px',
-    color: '#ffffff',
+    color: toColorStr(Colors.text.primary),
   },
   TASK_ITEM: {
     fontSize: '16px',
-    color: '#cccccc',
+    color: toColorStr(Colors.text.secondary),
   },
   TASK_COMPLETED: {
     fontSize: '16px',
-    color: '#00ff00',
+    color: toColorStr(Colors.status.success),
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- 昇格条件チェックリストの**ハードコード色**（#00ff00 / #ffffff / #cccccc）を**デザイントークン**に統一
  - 完了: `status.success`（緑）/ 未達: `text.secondary`（灰）/ 見出し: `text.primary`
- モック08のチェックリスト配色方針に合わせるとともに、淡色パネル上の白文字（視認性ゼロ）の不具合も解消
- 既存の課題一覧・期限表示の挙動は維持（見た目重視・API維持方針）

## 備考
- 失敗(failed)状態の専用配色・進捗ゲージのグラデーション・結果通知パネル等のリッチ化は、試験データへの状態追加を伴う機能拡張のため本PRでは見送り

## Test plan
- [x] `pnpm test -- --run`（rankup 28件pass、本PR起因の失敗0件。残5件はmain既存）
- [x] `pnpm typecheck` / `pnpm lint`（変更ファイル警告0）

Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)